### PR TITLE
Fixed long deserialization problem for longs of ~13digit length

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -2326,7 +2326,8 @@ public class ProtobufParser extends ParserMinimalBase
         v |= ((ch & 0x7F) << 14);
         ch = buf[_inputPtr++];
         if (ch >= 0) {
-            return v | (ch << 21);
+            long l2 = (v | (ch << 21));
+            return (l2 << 28) | l;
         }
         v |= ((ch & 0x7F) << 21);
 

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/BigNumPair.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/BigNumPair.java
@@ -1,0 +1,12 @@
+package com.fasterxml.jackson.dataformat.protobuf;
+
+public class BigNumPair {
+    public static final String protobuf_str =
+            "message BigNumPair {\n"
+                    + " required int64 long1 = 1;\n"
+                    + " required int64 long2 = 2;\n"
+                    + "}\n";
+
+    public long long1;
+    public long long2;
+}

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/SerDeserLongTest.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/SerDeserLongTest.java
@@ -1,0 +1,30 @@
+package com.fasterxml.jackson.dataformat.protobuf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
+import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchemaLoader;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Created by miz on 8/10/16.
+ */
+public class SerDeserLongTest {
+    @Test
+    public void testWeirdLongSerDeser() throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new ProtobufFactory());
+        ProtobufSchema schema = ProtobufSchemaLoader.std.parse(BigNumPair.protobuf_str);
+
+        BigNumPair bnp = new BigNumPair();
+        bnp.long1 = 72057594037927935L;
+        bnp.long2 = 0;
+
+        byte[] encoded = mapper.writer(schema).writeValueAsBytes(bnp);
+
+        BigNumPair parsed = mapper.readerFor(BigNumPair.class).with(schema).readValue(encoded);
+
+        assert parsed.long1 == bnp.long1;
+        assert parsed.long2 == bnp.long2;
+    }
+}


### PR DESCRIPTION
The decoding for variable length long should use the previously calculated part into account otherwise it throws away some of the long during deserialization. Included is a test that reproduces the error given the previous code.