### PR TITLE
Fix enum handling for Avro 1.8

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.Encoder;
 
@@ -18,6 +19,8 @@ import org.apache.avro.io.Encoder;
 public class NonBSGenericDatumWriter<D>
 	extends GenericDatumWriter<D>
 {
+	private static final GenericData GENERIC_DATA = GenericData.get();
+
 	public NonBSGenericDatumWriter(Schema root) {
 		super(root);
 	}
@@ -58,6 +61,8 @@ public class NonBSGenericDatumWriter<D>
 	protected void write(Schema schema, Object datum, Encoder out) throws IOException {
 	    if ((schema.getType() == Type.DOUBLE) && datum instanceof BigDecimal) {
 	        out.writeDouble(((BigDecimal)datum).doubleValue());
+	    } else if (schema.getType() == Type.ENUM) {
+	        super.write(schema, GENERIC_DATA.createEnum(datum.toString(), schema), out);
 	    } else {
 	        super.write(schema, datum, out);
 	    }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/EnumTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/EnumTest.java
@@ -17,6 +17,10 @@ public class EnumTest extends AvroTestBase
         public Gender gender;
     }
 
+    protected static class EmployeeStr {
+        public String gender;
+    }
+
     private final AvroMapper MAPPER = new AvroMapper();
     
     public void testSimple() throws Exception
@@ -24,6 +28,23 @@ public class EnumTest extends AvroTestBase
         AvroSchema schema = MAPPER.schemaFrom(ENUM_SCHEMA_JSON);
         Employee input = new Employee();
         input.gender = Gender.F;
+
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(input);
+        assertNotNull(bytes);
+        assertEquals(1, bytes.length); // measured to be current exp size
+
+        // and then back
+        Employee output = MAPPER.readerFor(Employee.class).with(schema)
+                .readValue(bytes);
+        assertNotNull(output);
+        assertEquals(Gender.F, output.gender);
+    }
+
+    public void testEnumValueAsString() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFrom(ENUM_SCHEMA_JSON);
+        EmployeeStr input = new EmployeeStr();
+        input.gender = "F";
 
         byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(input);
         assertNotNull(bytes);


### PR DESCRIPTION
The GenericDatumWriter in Avro 1.8 became more strict about enums. It
no longer accepts raw enum values, those must be wrapped in a
GenericEnumSymbol (cf AVRO-1810 and AVRO-1870).

Although we still depend on Avro 1.7.7, this change is needed for
projects that use Avro 1.8.