### PR TITLE
Add Avro file output and test

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
@@ -49,7 +49,13 @@ public class AvroGenerator extends GeneratorBase
          *
          * @since 2.7
          */
-        AVRO_BUFFERING(true)
+        AVRO_BUFFERING(true),
+
+        /**
+         * Feature that tells Avro to write data in file format (i.e. including the schema with the data)
+         * rather than the RPC format
+         */
+        AVRO_FILE_OUTPUT(false)
         ;
 
         protected final boolean _defaultState;
@@ -600,8 +606,12 @@ public class AvroGenerator extends GeneratorBase
         // do not want to hide the original problem...
         // First one sanity check, for a (relatively?) common case
         if (_rootContext != null) {
-            _rootContext.complete();
-            _encoder.flush();
+            if (isEnabled(Feature.AVRO_FILE_OUTPUT)) {
+                _rootContext.complete(_output);
+            } else {
+                _rootContext.complete();
+                _encoder.flush();
+            }
         }
     }
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/AvroWriteContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/AvroWriteContext.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.dataformat.avro.ser;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
@@ -94,6 +95,10 @@ public abstract class AvroWriteContext
     public abstract Object rawValue();
 
     public void complete() throws IOException {
+        throw new IllegalStateException("Can not be called on "+getClass().getName());
+    }
+
+    public void complete(OutputStream outputStream) throws IOException {
         throw new IllegalStateException("Can not be called on "+getClass().getName());
     }
 

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/RootContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/RootContext.java
@@ -1,13 +1,16 @@
 package com.fasterxml.jackson.dataformat.avro.ser;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.*;
 import org.apache.avro.io.BinaryEncoder;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.dataformat.avro.AvroGenerator;
+import org.apache.avro.io.DatumWriter;
 
 class RootContext
     extends AvroWriteContext
@@ -103,6 +106,16 @@ class RootContext
             _writer().write(_rootValue, _encoder);
         }
         _rootValue = null;
+    }
+
+    @Override
+    public void complete(OutputStream outputStream) throws IOException {
+        DatumWriter<Object> datumWriter = new NonBSGenericDatumWriter<>(_schema);
+        DataFileWriter<Object> dataFileWriter = new DataFileWriter<>(datumWriter);
+
+        dataFileWriter.create(_schema, outputStream);
+        dataFileWriter.append(_rootValue);
+        dataFileWriter.close();
     }
 
     @Override


### PR DESCRIPTION
Hi,

After my team and I wondering (for a while) why we couldn't use avro-tools to open the output of this project, we stumbled upon this issue: https://github.com/FasterXML/jackson-dataformats-binary/issues/15

This PR addresses it by creating a flag to output in the Avro file format.

I'm new to the internals of this project so I may not have done it in the most optimal way.

Thanks for a decade of building and supporting such a great project.