### PR TITLE
Avro Array/Character/char[] fixes and Test Suite

### DIFF
--- a/avro/pom.xml
+++ b/avro/pom.xml
@@ -45,6 +45,20 @@ abstractions.
       <version>1.1.3</version>
       <scope>test</scope>
     </dependency>
+    <!-- A bit of help to reduce boiler-plate in dummy test classes -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.16.12</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- For validating more complex comparisons -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.6.2</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
@@ -1,0 +1,19 @@
+package com.fasterxml.jackson.dataformat.avro;
+
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import org.apache.avro.reflect.AvroIgnore;
+
+/**
+ * Adds support for the following annotations from the Apache Avro implementation:
+ * <ul>
+ * <li>{@link AvroIgnore @AvroIgnore} - Alias for {@code @JsonIgnore(true)}</li>
+ * </ul>
+ */
+public class AvroAnnotationIntrospector extends JacksonAnnotationIntrospector {
+
+    @Override
+    protected boolean _isIgnorable(Annotated a) {
+        return a.getAnnotation(AvroIgnore.class) != null || super._isIgnorable(a);
+    }
+}

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
@@ -1,13 +1,18 @@
 package com.fasterxml.jackson.dataformat.avro;
 
+import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import org.apache.avro.reflect.AvroIgnore;
+import org.apache.avro.reflect.AvroName;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * Adds support for the following annotations from the Apache Avro implementation:
  * <ul>
- * <li>{@link AvroIgnore @AvroIgnore} - Alias for {@code @JsonIgnore(true)}</li>
+ * <li>{@link AvroIgnore @AvroIgnore} - Alias for {@link JsonIgnore @JsonIgnore(true)}</li>
+ * <li>{@link AvroName @AvroName("custom Name")} - Alias for {@link JsonProperty @JsonProperty("custom name")}</li>
  * </ul>
  */
 public class AvroAnnotationIntrospector extends JacksonAnnotationIntrospector {
@@ -15,5 +20,21 @@ public class AvroAnnotationIntrospector extends JacksonAnnotationIntrospector {
     @Override
     protected boolean _isIgnorable(Annotated a) {
         return a.getAnnotation(AvroIgnore.class) != null || super._isIgnorable(a);
+    }
+
+    @Override
+    public PropertyName findNameForSerialization(Annotated a) {
+        if (a.hasAnnotation(AvroName.class)) {
+            return PropertyName.construct(a.getAnnotation(AvroName.class).value());
+        }
+        return super.findNameForSerialization(a);
+    }
+
+    @Override
+    public PropertyName findNameForDeserialization(Annotated a) {
+        if (a.hasAnnotation(AvroName.class)) {
+            return PropertyName.construct(a.getAnnotation(AvroName.class).value());
+        }
+        return super.findNameForDeserialization(a);
     }
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroModule.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroModule.java
@@ -4,9 +4,8 @@ import java.io.IOException;
 
 import org.apache.avro.Schema;
 
-import com.fasterxml.jackson.core.*;
-
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
@@ -33,6 +32,12 @@ public class AvroModule extends SimpleModule
      */
     @Deprecated // 08-Mar-2016, tatu: How on earth did this end up here?!?
     public Schema schema;
+
+    @Override
+    public void setupModule(SetupContext context) {
+        super.setupModule(context);
+        context.insertAnnotationIntrospector(new AvroAnnotationIntrospector());
+    }
 
     /*
     /**********************************************************

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
@@ -5,6 +5,7 @@ import java.util.*;
 import org.apache.avro.Schema;
 
 import com.fasterxml.jackson.dataformat.avro.deser.ScalarDecoder.*;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 
 /**
  * Helper class used for constructing a hierarchic reader for given
@@ -20,6 +21,7 @@ public abstract class AvroReaderFactory
     protected final static ScalarDecoder READER_LONG = new LongReader();
     protected final static ScalarDecoder READER_NULL = new NullReader();
     protected final static ScalarDecoder READER_STRING = new StringReader();
+    protected final static ScalarDecoder READER_CHAR = new CharReader();
 
     /**
      * To resolve cyclic types, need to keep track of resolved named
@@ -65,6 +67,9 @@ public abstract class AvroReaderFactory
         case FLOAT: 
             return READER_FLOAT;
         case INT:
+            if (Character.class.getName().equals(type.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS))) {
+                return READER_CHAR;
+            }
             return READER_INT;
         case LONG: 
             return READER_LONG;

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
@@ -214,6 +214,42 @@ public abstract class ScalarDecoder
             }
         }
     }
+
+    protected final static class CharReader extends ScalarDecoder {
+        @Override
+        public JsonToken decodeValue(AvroParserImpl parser, Decoder decoder) throws IOException {
+            return parser.setString(Character.toString((char)decoder.readInt()));
+        }
+
+        @Override
+        protected void skipValue(Decoder decoder) throws IOException {
+            // ints use variable-length zigzagging; alas, no native skipping
+            decoder.readInt();
+        }
+
+        @Override
+        public AvroFieldReader asFieldReader(String name, boolean skipper) {
+            return new FR(name, skipper);
+        }
+
+        private final static class FR extends AvroFieldReader {
+            public FR(String name, boolean skipper) {
+                super(name, skipper);
+            }
+
+            @Override
+            public JsonToken readValue(
+                AvroReadContext parent, AvroParserImpl parser, BinaryDecoder decoder
+            ) throws IOException {
+                return parser.setString(Character.toString((char) decoder.readInt()));
+            }
+
+            @Override
+            public void skipValue(BinaryDecoder decoder) throws IOException {
+                decoder.readInt();
+            }
+        }
+    }
     
     protected final static class LongReader extends ScalarDecoder
     {

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.dataformat.avro.schema;
 
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/StringVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/StringVisitor.java
@@ -1,12 +1,15 @@
 package com.fasterxml.jackson.dataformat.avro.schema;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Set;
 
 import org.apache.avro.Schema;
 
+import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 public class StringVisitor extends JsonStringFormatVisitor.Base
     implements SchemaBuilder
@@ -33,6 +36,10 @@ public class StringVisitor extends JsonStringFormatVisitor.Base
 
     @Override
     public Schema builtAvroSchema() {
+        // Unlike Jackson, Avro treats characters as an int with the java.lang.Character class type.
+        if (_type.hasRawClass(char.class) || _type.hasRawClass(Character.class)) {
+            return AvroSchemaHelper.numericAvroSchema(NumberType.INT, TypeFactory.defaultInstance().constructType(Character.class));
+        }
         if (_enums == null) {
             return Schema.create(Schema.Type.STRING);
         }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
@@ -2,12 +2,15 @@ package com.fasterxml.jackson.dataformat.avro.ser;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.Encoder;
+
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 
 /**
  * Need to sub-class to prevent encoder from crapping on writing an optional
@@ -28,25 +31,33 @@ public class NonBSGenericDatumWriter<D>
 		if (datum == null) {
 			return union.getIndexNamed(Type.NULL.getName());
 		}
-		if (datum instanceof String) { // String or Enum
-			List<Schema> schemas = union.getTypes();
-			for (int i = 0, len = schemas.size(); i < len; ++i) {
-				Schema s = schemas.get(i);
-				switch (s.getType()) {
-				case STRING:
-				case ENUM:
-					return i;
-				default:
-				}
+		List<Schema> schemas = union.getTypes();
+		for (int i = 0, len = schemas.size(); i < len; i++) {
+			Schema s = schemas.get(i);
+			if (datum instanceof BigDecimal && s.getType() == Type.DOUBLE) {
+				return i;
 			}
-		} else if( datum instanceof BigDecimal) {
-			List<Schema> schemas = union.getTypes();
-			for (int i = 0, len = schemas.size(); i < len; ++i) {
-				Schema s = schemas.get(i);
+			if (datum instanceof String) { // String or Enum or Character or char[]
 				switch (s.getType()) {
-				case DOUBLE:
-					return i;
-				default:
+					case STRING:
+					case ENUM:
+						return i;
+					case INT:
+						// Avro distinguishes between String and Character, whereas Jackson doesn't
+						// Check if the schema is expecting a Character and handle appropriately
+						if (Character.class.getName().equals(s.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS))) {
+							return i;
+						}
+						break;
+					case ARRAY:
+						// Avro distinguishes between String and char[], whereas Jackson doesn't
+						// Check if the schema is expecting a char[] and handle appropriately
+						if (s.getElementType().getType() == Type.INT && Character.class
+							.getName().equals(s.getElementType().getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS))) {
+							return i;
+						}
+						break;
+					default:
 				}
 			}
 		}
@@ -58,7 +69,16 @@ public class NonBSGenericDatumWriter<D>
 	protected void write(Schema schema, Object datum, Encoder out) throws IOException {
 	    if ((schema.getType() == Type.DOUBLE) && datum instanceof BigDecimal) {
 	        out.writeDouble(((BigDecimal)datum).doubleValue());
-	    } else {
+		} else if (datum instanceof String && schema.getType() == Type.ARRAY && schema.getElementType().getType() == Type.INT) {
+			ArrayList<Integer> chars = new ArrayList<>(((String) datum).length());
+			char[]             src   = ((String) datum).toCharArray();
+			for (int i = 0; i < src.length; i++) {
+				chars.add((int) src[i]);
+			}
+			super.write(schema, chars, out);
+		} else if (datum instanceof String && ((String) datum).length() == 1 && schema.getType() == Type.INT) {
+			super.write(schema, (int) ((String) datum).charAt(0), out);
+		} else {
 	        super.write(schema, datum, out);
 	    }
 	}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/ApacheAvroInteropUtil.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/ApacheAvroInteropUtil.java
@@ -1,0 +1,282 @@
+package com.fasterxml.jackson.dataformat.avro.interop;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.dataformat.avro.AvroMapper;
+import com.fasterxml.jackson.dataformat.avro.AvroSchema;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.reflect.ReflectData;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utilities and helper functions to aid compatibility testing between Jackson and Apache Avro implementations
+ */
+public class ApacheAvroInteropUtil {
+    /**
+     * Functor of {@link #jacksonSerialize(Schema, Object)}
+     */
+    public static final  BiFunction<Schema, Object, byte[]> jacksonSerializer         = new BiFunction<Schema, Object, byte[]>() {
+        @Override
+        public byte[] apply(Schema schema, Object originalObject) {
+            return jacksonSerialize(schema, originalObject);
+        }
+    };
+    /**
+     * Functor of {@link #getJacksonSchema(Type)}
+     */
+    public static final  Function<Type, Schema>             getJacksonSchema          = new Function<Type, Schema>() {
+        @Override
+        public Schema apply(Type input) {
+            return getJacksonSchema(input);
+        }
+    };
+    /**
+     * Functor of {@link #jacksonDeserialize(Schema, Type, byte[])} which uses {@link Object} as the target type,
+     * requiring the use of native type IDs
+     */
+    public static final  BiFunction<Schema, byte[], Object> jacksonDeserializer       = new BiFunction<Schema, byte[], Object>() {
+        @Override
+        public Object apply(Schema schema, byte[] originalObject) {
+            return jacksonDeserialize(schema, Object.class, originalObject);
+        }
+    };
+    /**
+     * Functor of {@link #getApacheSchema(Type)}
+     */
+    public static final  Function<Type, Schema>             getApacheSchema           = new Function<Type, Schema>() {
+        @Override
+        public Schema apply(Type input) {
+            return getApacheSchema(input);
+        }
+    };
+    /**
+     * Functor of {@link #apacheDeserialize(Schema, byte[])}
+     */
+    public static final  BiFunction<Schema, byte[], Object> apacheDeserializer        = new BiFunction<Schema, byte[], Object>() {
+        @Override
+        public Object apply(Schema first, byte[] second) {
+            return apacheDeserialize(first, second);
+        }
+    };
+    /**
+     * Functor of {@link #apacheSerialize(Schema, Object)}
+     */
+    public static final  BiFunction<Schema, Object, byte[]> apacheSerializer          = new BiFunction<Schema, Object, byte[]>() {
+        @Override
+        public byte[] apply(Schema schema, Object originalObject) {
+            return apacheSerialize(schema, originalObject);
+        }
+    };
+    private static final AvroMapper                         MAPPER                    = new AvroMapper();
+    /*
+     * Special subclass of ReflectData that knows how to resolve and bind generic types. This saves us much pain of
+     * having to build these schemas by hand. Also, workarounds for several bugs in the Apache implementation are
+     * implemented here.
+     */
+    private static final ReflectData                        PATCHED_AVRO_REFLECT_DATA = new ReflectData() {
+        @SuppressWarnings({"unchecked", "SuspiciousMethodCalls"})
+        @Override
+        protected Schema createSchema(Type type, Map<String, Schema> names) {
+        /*
+         * Note, we abuse the fact that we can stick whatever we want into "names" and it won't interfere as long as we don't use String
+         * keys. To persist and look up type variable information, we watch for ParameterizedTypes, TypeVariables, and Classes with
+         * generic superclasses to extract type variable information and store it in the map. This allows full type variable resolution
+         * when building a schema from reflection data.
+         */
+            if (type instanceof ParameterizedType) {
+                TypeVariable[] genericParameters = ((Class) ((ParameterizedType) type).getRawType()).getTypeParameters();
+                if (genericParameters.length > 0) {
+                    Type[] boundParameters = ((ParameterizedType) type).getActualTypeArguments();
+                    for (int i = 0; i < boundParameters.length; i++) {
+                        ((Map) names).put(genericParameters[i], createSchema(boundParameters[i], new HashMap<>(names)));
+                    }
+                }
+            }
+            if (type instanceof Class && ((Class) type).getSuperclass() != null) {
+                // Raw class may extend a generic superclass
+                // extract all the type bindings and add them to the map so they can be returned by the next block
+                // Interfaces shouldn't matter here because interfaces can't have fields and avro only looks at fields.
+                TypeVariable[] genericParameters = ((Class) type).getSuperclass().getTypeParameters();
+                if (genericParameters.length > 0) {
+                    Type[] boundParameters = ((ParameterizedType) ((Class) type).getGenericSuperclass()).getActualTypeArguments();
+                    for (int i = 0; i < boundParameters.length; i++) {
+                        ((Map) names).put(genericParameters[i], createSchema(boundParameters[i], new HashMap<>(names)));
+                    }
+                }
+            }
+            if (type instanceof TypeVariable) {
+                // Should only get here by recursion normally; names should be populated with the schema for this type variable by a
+                // previous stack frame
+                if (names.containsKey(type)) {
+                    return names.get(type);
+                }
+                // someone fed us an unbound type variable, just fall through to the default behavior
+            }
+            return super.createSchema(type, names);
+        }
+
+        /*
+         * Fix bug where avro can't deserialize from its own schema because it decodes byte[] as an array of ints even though it should be
+         */
+        @Override
+        protected String getSchemaName(Object datum) {
+            if (datum instanceof byte[]) {
+                return Schema.Type.BYTES.getName();
+            }
+            return super.getSchemaName(datum);
+        }
+    };
+
+    public interface BiFunction<T, U, V> {
+        V apply(T first, U second);
+    }
+
+    public interface Function<T, U> {
+        U apply(T input);
+    }
+
+    /**
+     * Deserialize an avro-encoded payload using the given {@code schema} and Apache implementation
+     *
+     * @param schema
+     *     {@link Schema} to use when deserializing the payload
+     * @param data
+     *     Payload to deserialize
+     * @param <T>
+     *     Expected type of the deserialized payload
+     *
+     * @return Deserialized payload
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T apacheDeserialize(Schema schema, byte[] data) {
+        try {
+            Decoder encoder = DecoderFactory.get().binaryDecoder(data, null);
+            return (T) PATCHED_AVRO_REFLECT_DATA.createDatumReader(schema).read(null, encoder);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed Apache Deserialization", e);
+        }
+    }
+
+    /**
+     * Serializes the {@code object} using the given {@code schema} and the Apache implementation
+     *
+     * @param schema
+     *     {@link Schema} to use when serializing the {@code object}
+     * @param object
+     *     Object to serialize
+     *
+     * @return Payload containing the Avro-serialized form of {@code object}
+     */
+    @SuppressWarnings("unchecked")
+    public static byte[] apacheSerialize(Schema schema, Object object) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            Encoder encoder = EncoderFactory.get().binaryEncoder(baos, null);
+            PATCHED_AVRO_REFLECT_DATA.createDatumWriter(schema).write(object, encoder);
+            encoder.flush();
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed Apache Serialization", e);
+        }
+    }
+
+    /**
+     * Generates a {@link Schema} for {@code type} using the Apache implementation of Avro
+     *
+     * @param type
+     *     Type for which schema should be generated
+     *
+     * @return Schema for {@code type}
+     */
+    public static Schema getApacheSchema(Type type) {
+        return PATCHED_AVRO_REFLECT_DATA.getSchema(type);
+    }
+
+    /**
+     * Generates a {@link Schema} for {@code type} using the Jackson implementation of Avro
+     *
+     * @param type
+     *     Type for which schema should be generated
+     *
+     * @return Schema for {@code type}
+     */
+    public static Schema getJacksonSchema(Type type) {
+        try {
+            return MAPPER.schemaFor(MAPPER.constructType(type)).getAvroSchema();
+        } catch (JsonMappingException e) {
+            throw new RuntimeException("Could not generate schema for " + type, e);
+        }
+    }
+
+    /**
+     * Deserialize an avro-encoded payload using the given {@code schema} and Jackson implementation, using the given target {@code type}
+     *
+     * @param schema
+     *     {@link Schema} to use when deserializing the payload
+     * @param type
+     *     Target type into which Jackson will deserialize the payload
+     * @param data
+     *     Payload to deserialize
+     * @param <T>
+     *     Expected type of the deserialized payload
+     *
+     * @return Deserialized payload
+     */
+    public static <T> T jacksonDeserialize(Schema schema, JavaType type, byte[] data) {
+        AvroMapper mapper = new AvroMapper();
+        try {
+            return mapper.readerFor(type).with(new AvroSchema(schema)).readValue(data, 0, data.length);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to Deserialize", e);
+        }
+    }
+
+    /**
+     * Deserialize an avro-encoded payload using the given {@code schema} and Jackson implementation, using the given target {@code type}
+     *
+     * @param schema
+     *     {@link Schema} to use when deserializing the payload
+     * @param type
+     *     Target type into which Jackson will deserialize the payload
+     * @param data
+     *     Payload to deserialize
+     * @param <T>
+     *     Expected type of the deserialized payload
+     *
+     * @return Deserialized payload
+     */
+    public static <T> T jacksonDeserialize(Schema schema, Type type, byte[] data) {
+        return jacksonDeserialize(schema, MAPPER.constructType(type), data);
+    }
+
+    /**
+     * Serializes the {@code object} using the given {@code schema} and the Jackson implementation
+     *
+     * @param schema
+     *     {@link Schema} to use when serializing the {@code object}
+     * @param object
+     *     Object to serialize
+     *
+     * @return Payload containing the Avro-serialized form of {@code object}
+     */
+    public static byte[] jacksonSerialize(Schema schema, Object object) {
+        AvroMapper mapper = new AvroMapper();
+        try {
+            return mapper.writer().with(new AvroSchema(schema)).writeValueAsBytes(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed Serialization", e);
+        }
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
@@ -1,0 +1,148 @@
+package com.fasterxml.jackson.dataformat.avro.interop;
+
+import org.apache.avro.Schema;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.*;
+
+/**
+ * Parameterized base class for tests that populates {@link #schemaFunctor}, {@link #serializeFunctor}, and
+ * {@link #deserializeFunctor} with permutations of Apache and Jackson implementations to test all aspects of
+ * interoperability between the implementations.
+ */
+@RunWith(Parameterized.class)
+public abstract class InteropTestBase {
+    /**
+     * Helper method for building a {@link ParameterizedType} for use with {@link #roundTrip(Type, Object)}
+     *
+     * @param baseClass
+     *     A generic {@link Class} with type variables
+     * @param parameters
+     *     Bindings for the variables in {@code baseClass}
+     *
+     * @return A type representing the bound {@code baseClass}
+     */
+    protected static ParameterizedType type(Class<?> baseClass, Type... parameters) {
+        if (baseClass.getTypeParameters().length != parameters.length) {
+            throw new IllegalArgumentException("Incorrect number of type parameters, expected "
+                                               + baseClass.getTypeParameters().length
+                                               + ", got "
+                                               + parameters.length);
+        }
+        for (Type type : parameters) {
+            if (!(type instanceof Class) && !(type instanceof ParameterizedType)) {
+                throw new IllegalArgumentException("Only Class and ParameterizedType bindings are supported");
+            }
+        }
+        return new ParameterizedTypeImpl(baseClass, parameters);
+    }
+
+    private static class ParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> rawType;
+        private final Type[]   typeBindings;
+
+        private ParameterizedTypeImpl(Class<?> rawType, Type[] typeBindings) {
+            this.rawType = rawType;
+            this.typeBindings = typeBindings;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return typeBindings;
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return rawType.getEnclosingClass();
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder(rawType.getName());
+            if (typeBindings.length != 0) {
+                builder.append('<');
+                for (Type type : typeBindings) {
+                    if (type instanceof Class) {
+                        builder.append(((Class) type).getName());
+                    } else {
+                        builder.append(type.toString());
+                    }
+                }
+                builder.append('>');
+            }
+            return builder.toString();
+        }
+    }
+
+    @Parameterized.Parameter
+    public Function<Type, Schema>             schemaFunctor;
+    @Parameterized.Parameter(1)
+    public BiFunction<Schema, Object, byte[]> serializeFunctor;
+    @Parameterized.Parameter(2)
+    public BiFunction<Schema, byte[], Object> deserializeFunctor;
+    @Parameterized.Parameter(3)
+    public String                             combinationName;
+
+    @Parameterized.Parameters(name = "{3}")
+    public static Object[][] getParameters() {
+        return new Object[][]{
+                {getApacheSchema, apacheSerializer, jacksonDeserializer, "Apache to Jackson with Apache schema"},
+                {getJacksonSchema, apacheSerializer, jacksonDeserializer, "Apache to Jackson with Jackson schema"},
+                {getApacheSchema, jacksonSerializer, jacksonDeserializer, "Jackson to Jackson with Apache schema"},
+                {getJacksonSchema, jacksonSerializer, jacksonDeserializer, "Jackson to Jackson with Jackson schema"},
+                {getApacheSchema, jacksonSerializer, apacheDeserializer, "Jackson to Apache with Apache schema"},
+                {getJacksonSchema, jacksonSerializer, apacheDeserializer, "Jackson to Apache with Jackson schema"},
+                {getJacksonSchema, apacheSerializer, apacheDeserializer, "Apache to Apache with Jackson schema"},
+                {getApacheSchema, apacheSerializer, apacheDeserializer, "Apache to Apache with Apache schema"}
+        };
+    }
+
+    /**
+     * Serializes and deserializes the {@code object} using the current combination of schema generator, serializer, and
+     * deserializer implementations
+     *
+     * @param object
+     *     The object to serialize and deserialize. The schema used for serialization and deserialization will be generated based on {@code
+     *     object.getClass()}.
+     * @param <T>
+     *     Type of object being serialized and deserialized
+     *
+     * @return A recreated version of the original object
+     */
+    protected <T> T roundTrip(T object) {
+        return roundTrip(object.getClass(), object);
+    }
+
+    /**
+     * Serializes and deserializes the {@code object} using the current combination of schema generator, serializer, and
+     * deserializer implementations
+     *
+     * @param schemaType
+     *     Type to use for generating the schema when {@code object} has
+     * @param object
+     *     The object to serialize and deserialize. The schema used for serialization and deserialization will be generated based on {@code
+     *     object.getClass()}.
+     * @param <T>
+     *     Type of object being serialized and deserialized
+     *
+     * @return A recreated version of the original object
+     */
+    @SuppressWarnings("unchecked")
+    protected <T> T roundTrip(Type schemaType, T object) {
+        Schema schema = schemaFunctor.apply(schemaType);
+        // Temporary hack until jackson supports native type Ids and we don't need to give it a target type
+        if (deserializeFunctor == jacksonDeserializer) {
+            return jacksonDeserialize(schema, schemaType, serializeFunctor.apply(schema, object));
+        }
+        return (T) deserializeFunctor.apply(schema, serializeFunctor.apply(schema, object));
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroIgnoreTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroIgnoreTest.java
@@ -1,0 +1,40 @@
+package com.fasterxml.jackson.dataformat.avro.interop.annotations;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+import org.apache.avro.reflect.AvroIgnore;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class AvroIgnoreTest extends InteropTestBase {
+
+
+    @Test
+    public void testFieldIgnored() {
+
+        RecordWithIgnoredField r = new RecordWithIgnoredField();
+        r.ignoredField = "fail";
+        r.notIgnoredField = "success";
+
+        RecordWithIgnoredField processedR = roundTrip(r);
+
+        assertThat(processedR, is(not(nullValue())));
+
+        assertThat(processedR.ignoredField, is(nullValue()));
+
+        assertThat(processedR.notIgnoredField, is(equalTo("success")));
+
+
+    }
+
+    public static class RecordWithIgnoredField {
+        public RecordWithIgnoredField() {}
+
+        @AvroIgnore
+        public String ignoredField;
+        public String notIgnoredField;
+
+    }
+
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroNameTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroNameTest.java
@@ -1,0 +1,45 @@
+package com.fasterxml.jackson.dataformat.avro.interop.annotations;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+import lombok.Data;
+import org.apache.avro.reflect.AvroName;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the {@link AvroName @AvroName} annotation
+ */
+public class AvroNameTest extends InteropTestBase {
+
+    @Data
+    public static class RecordWithRenamed {
+        @AvroName("newName")
+        private String someField;
+    }
+
+    @Data
+    public static class RecordWithNameCollision {
+        @AvroName("otherField")
+        private String firstField;
+
+        private String otherField;
+    }
+
+    @Test
+    public void testRecordWithRenamedField() {
+        RecordWithRenamed original = new RecordWithRenamed();
+        original.setSomeField("blah");
+        //
+        RecordWithRenamed result = roundTrip(original);
+        //
+        assertThat(result).isEqualTo(result);
+    }
+
+    @Test(expected = Exception.class)
+    public void testRecordWithNameCollision() {
+        schemaFunctor.apply(RecordWithNameCollision.class);
+        // Should throw because of name collision
+    }
+
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapSubtypeTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapSubtypeTest.java
@@ -1,0 +1,71 @@
+package com.fasterxml.jackson.dataformat.avro.interop.maps;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.apacheDeserializer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests map subtypes such as {@link TreeMap}, {@link ConcurrentHashMap}, and {@link ConcurrentSkipListMap}. The Apache Avro implementation
+ * has a bug that will cause these to fail with ClassCastExceptions since it assumes all maps are {@link HashMap HashMaps}.
+ */
+public class MapSubtypeTest extends InteropTestBase {
+    @Before
+    public void ignoreApacheMapSubtypeBug() {
+        // The Apache Avro implementation has a bug that causes all of these tests to fail. Conditionally ignore these tests when running
+        // with Apache deserializer implementation
+        Assume.assumeTrue(deserializeFunctor != apacheDeserializer);
+    }
+
+    @Test
+    public void testHashMap() {
+        HashMap<String, Integer> original = new HashMap<>();
+        original.put("test", 1234);
+        original.put("Second", 98768234);
+        //
+        HashMap<String, Integer> result = roundTrip(type(HashMap.class, String.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testConcurrentHashMap() {
+        ConcurrentHashMap<String, Integer> original = new ConcurrentHashMap<>();
+        original.put("test", 1234);
+        original.put("Second", 98768234);
+        //
+        ConcurrentHashMap<String, Integer> result = roundTrip(type(ConcurrentHashMap.class, String.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testConcurrentSkipListMap() {
+        ConcurrentSkipListMap<String, Integer> original = new ConcurrentSkipListMap<>();
+        original.put("test", 1234);
+        original.put("Second", 98768234);
+        //
+        ConcurrentSkipListMap<String, Integer> result = roundTrip(type(ConcurrentSkipListMap.class, String.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testTreeMap() {
+        TreeMap<String, Integer> original = new TreeMap<>();
+        original.put("test", 1234);
+        original.put("Second", 98768234);
+        //
+        TreeMap<String, Integer> result = roundTrip(type(TreeMap.class, String.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveArrayTest.java
@@ -1,0 +1,115 @@
+package com.fasterxml.jackson.dataformat.avro.interop.maps;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that maps behave as expected when primitive arrays (byte[], short[], char[], int[], long[], float[], double[]) are used as the
+ * value
+ * type
+ */
+public class MapWithPrimitiveArrayTest extends InteropTestBase {
+    @Test
+    public void testMapWithBytes() {
+        Map<String, byte[]> original = new HashMap<>();
+        original.put("one", new byte[]{(byte)1 });
+        original.put("zero", new byte[0]);
+        original.put("negative one", new byte[]{(byte) -1});
+        original.put("min", new byte[]{Byte.MIN_VALUE});
+        original.put("max", new byte[]{Byte.MAX_VALUE});
+        //
+        Map<String, byte[]> result = roundTrip(type(Map.class, String.class, byte[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    //@Ignore // Jackson doesn't support deserializing char[] properly yet
+    public void testMapWithCharacters() {
+        Map<String, char[]> original = new HashMap<>();
+        original.put("one", new char[]{(char) 1});
+        original.put("zero", new char[0]);
+        original.put("negative one", new char[]{(char) -1});
+        original.put("min", new char[]{Character.MIN_VALUE});
+        original.put("max", new char[]{Character.MAX_VALUE});
+        //
+        Map<String, char[]> result = roundTrip(type(Map.class, String.class, char[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithDoubles() {
+        Map<String, double[]> original = new HashMap<>();
+        original.put("one", new double[]{(double) 1});
+        original.put("zero", new double[0]);
+        original.put("negative one", new double[]{(double) -1});
+        original.put("min", new double[]{Double.MIN_VALUE});
+        original.put("max", new double[]{Double.MAX_VALUE});
+        //
+        Map<String, double[]> result = roundTrip(type(Map.class, String.class, double[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithFloats() {
+        Map<String, float[]> original = new HashMap<>();
+        original.put("one", new float[]{(float) 1});
+        original.put("zero", new float[0]);
+        original.put("negative one", new float[]{(float) -1});
+        original.put("min", new float[]{Float.MIN_VALUE});
+        original.put("max", new float[]{Float.MAX_VALUE});
+        //
+        Map<String, float[]> result = roundTrip(type(Map.class, String.class, float[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithIntegers() {
+        Map<String, int[]> original = new HashMap<>();
+        original.put("one", new int[]{(int) 1});
+        original.put("zero", new int[0]);
+        original.put("negative one", new int[]{(int) -1});
+        original.put("min", new int[]{Integer.MIN_VALUE});
+        original.put("max", new int[]{Integer.MAX_VALUE});
+        //
+        Map<String, int[]> result = roundTrip(type(Map.class, String.class, int[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithLongs() {
+        Map<String, long[]> original = new HashMap<>();
+        original.put("one", new long[]{(long) 1});
+        original.put("zero", new long[0]);
+        original.put("negative one", new long[]{(long) -1});
+        original.put("min", new long[]{Long.MIN_VALUE});
+        original.put("max", new long[]{Long.MAX_VALUE});
+        //
+        Map<String, long[]> result = roundTrip(type(Map.class, String.class, long[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithShorts() {
+        Map<String, short[]> original = new HashMap<>();
+        original.put("one", new short[]{(short) 1});
+        original.put("zero", new short[0]);
+        original.put("negative one", new short[]{(short) -1});
+        original.put("min", new short[]{Short.MIN_VALUE});
+        original.put("max", new short[]{Short.MAX_VALUE});
+        //
+        Map<String, short[]> result = roundTrip(type(Map.class, String.class, short[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperArrayTest.java
@@ -1,0 +1,127 @@
+package com.fasterxml.jackson.dataformat.avro.interop.maps;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that maps behave as expected when primitive wrapper arrays (Byte[], Short[], Character[], Integer[], Long[], Float[], Double[])
+ * are used as the value type
+ */
+public class MapWithPrimitiveWrapperArrayTest extends InteropTestBase {
+    @Test
+    public void testMapWithBytes() {
+        Map<String, Byte[]> original = new HashMap<>();
+        original.put("one", new Byte[]{(byte) 1});
+        original.put("zero", new Byte[0]);
+        original.put("negative one", new Byte[]{(byte) -1});
+        original.put("min", new Byte[]{Byte.MIN_VALUE});
+        original.put("max", new Byte[]{Byte.MAX_VALUE});
+        //
+        Map<String, Byte[]> result = roundTrip(type(Map.class, String.class, Byte[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithCharacters() {
+        Map<String, Character[]> original = new HashMap<>();
+        original.put("one", new Character[]{(char) 1});
+        original.put("zero", new Character[0]);
+        original.put("negative one", new Character[]{(char) -1});
+        original.put("min", new Character[]{Character.MIN_VALUE});
+        original.put("max", new Character[]{Character.MAX_VALUE});
+        //
+        Map<String, Character[]> result = roundTrip(type(Map.class, String.class, Character[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithDoubles() {
+        Map<String, Double[]> original = new HashMap<>();
+        original.put("one", new Double[]{(double) 1});
+        original.put("zero", new Double[0]);
+        original.put("negative one", new Double[]{(double) -1});
+        original.put("min", new Double[]{Double.MIN_VALUE});
+        original.put("max", new Double[]{Double.MAX_VALUE});
+        //
+        Map<String, Double[]> result = roundTrip(type(Map.class, String.class, Double[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithFloats() {
+        Map<String, Float[]> original = new HashMap<>();
+        original.put("one", new Float[]{(float) 1});
+        original.put("zero", new Float[0]);
+        original.put("negative one", new Float[]{(float) -1});
+        original.put("min", new Float[]{Float.MIN_VALUE});
+        original.put("max", new Float[]{Float.MAX_VALUE});
+        //
+        Map<String, Float[]> result = roundTrip(type(Map.class, String.class, Float[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithIntegers() {
+        Map<String, Integer[]> original = new HashMap<>();
+        original.put("one", new Integer[]{(int) 1});
+        original.put("zero", new Integer[0]);
+        original.put("negative one", new Integer[]{(int) -1});
+        original.put("min", new Integer[]{Integer.MIN_VALUE});
+        original.put("max", new Integer[]{Integer.MAX_VALUE});
+        //
+        Map<String, Integer[]> result = roundTrip(type(Map.class, String.class, Integer[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithLongs() {
+        Map<String, Long[]> original = new HashMap<>();
+        original.put("one", new Long[]{(long) 1});
+        original.put("zero", new Long[0]);
+        original.put("negative one", new Long[]{(long) -1});
+        original.put("min", new Long[]{Long.MIN_VALUE});
+        original.put("max", new Long[]{Long.MAX_VALUE});
+        //
+        Map<String, Long[]> result = roundTrip(type(Map.class, String.class, Long[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithShorts() {
+        Map<String, Short[]> original = new HashMap<>();
+        original.put("one", new Short[]{(short) 1});
+        original.put("zero", new Short[0]);
+        original.put("negative one", new Short[]{(short) -1});
+        original.put("min", new Short[]{Short.MIN_VALUE});
+        original.put("max", new Short[]{Short.MAX_VALUE});
+        //
+        Map<String, Short[]> result = roundTrip(type(Map.class, String.class, Short[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+
+    @Test
+    public void testMapWithStrings() {
+        Map<String, String[]> original = new HashMap<>();
+        original.put("one", new String[]{"1"});
+        original.put("zero", new String[0]);
+        original.put("empty", new String[]{""});
+        original.put("single", new String[]{"a really long string for testing"});
+        original.put("multi", new String[]{"multiple", "string", "values", "here"});
+        //
+        Map<String, String[]> result = roundTrip(type(Map.class, String.class, String[].class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperTest.java
@@ -1,0 +1,125 @@
+package com.fasterxml.jackson.dataformat.avro.interop.maps;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that maps behave as expected when primitive wrappers (Byte, Short, Character, Integer, Long, Float, Double) are used as the value
+ * type
+ */
+public class MapWithPrimitiveWrapperTest extends InteropTestBase {
+    @Test
+    public void testMapWithBytes() {
+        Map<String, Byte> original = new HashMap<>();
+        original.put("one", (byte) 1);
+        original.put("zero", (byte) 0);
+        original.put("negative one", (byte) -1);
+        original.put("min", Byte.MIN_VALUE);
+        original.put("max", Byte.MAX_VALUE);
+        //
+        Map<String, Byte> result = roundTrip(type(Map.class, String.class, Byte.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithCharacters() {
+        Map<String, Character> original = new HashMap<>();
+        original.put("one", (char) 1);
+        original.put("zero", (char) 0);
+        original.put("negative one", (char) -1);
+        original.put("min", Character.MIN_VALUE);
+        original.put("max", Character.MAX_VALUE);
+        //
+        Map<String, Character> result = roundTrip(type(Map.class, String.class, Character.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithDoubles() {
+        Map<String, Double> original = new HashMap<>();
+        original.put("one", 1D);
+        original.put("zero", 0D);
+        original.put("negative one", -1D);
+        original.put("min", Double.MIN_VALUE);
+        original.put("max", Double.MAX_VALUE);
+        //
+        Map<String, Double> result = roundTrip(type(Map.class, String.class, Double.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithFloats() {
+        Map<String, Float> original = new HashMap<>();
+        original.put("one", 1F);
+        original.put("zero", 0F);
+        original.put("negative one", -1F);
+        original.put("min", Float.MIN_VALUE);
+        original.put("max", Float.MAX_VALUE);
+        //
+        Map<String, Float> result = roundTrip(type(Map.class, String.class, Float.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithIntegers() {
+        Map<String, Integer> original = new HashMap<>();
+        original.put("one", 1);
+        original.put("zero", 0);
+        original.put("negative one", -1);
+        original.put("min", Integer.MIN_VALUE);
+        original.put("max", Integer.MAX_VALUE);
+        //
+        Map<String, Integer> result = roundTrip(type(Map.class, String.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithLongs() {
+        Map<String, Long> original = new HashMap<>();
+        original.put("one", 1L);
+        original.put("zero", 0L);
+        original.put("negative one", -1L);
+        original.put("min", Long.MIN_VALUE);
+        original.put("max", Long.MAX_VALUE);
+        //
+        Map<String, Long> result = roundTrip(type(Map.class, String.class, Long.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithShorts() {
+        Map<String, Short> original = new HashMap<>();
+        original.put("one", (short) 1);
+        original.put("zero", (short) 0);
+        original.put("negative one", (short) -1);
+        original.put("min", Short.MIN_VALUE);
+        original.put("max", Short.MAX_VALUE);
+        //
+        Map<String, Short> result = roundTrip(type(Map.class, String.class, Short.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithStrings() {
+        Map<String, String> original = new HashMap<>();
+        original.put("one", "1");
+        original.put("empty", "");
+        original.put("single", "a really long string for testing");
+        //
+        Map<String, String> result = roundTrip(type(Map.class, String.class, String.class), original);
+        //
+        assertThat(result).containsAllEntriesOf(original);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveArrayTest.java
@@ -1,0 +1,94 @@
+package com.fasterxml.jackson.dataformat.avro.interop.records;
+
+import lombok.Data;
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests serializing primitive array fields on records
+ */
+public class RecordWithPrimitiveArrayTest extends InteropTestBase {
+    @Data
+    public static class TestRecord {
+        private byte[]   byteArrayField      = new byte[0];
+        private short[]  shortArrayField     = new short[0];
+        private char[]   characterArrayField = new char[0];
+        private int[]    integerArrayField   = new int[0];
+        private long[]   longArrayField      = new long[0];
+        private float[]  floatArrayField     = new float[0];
+        private double[] doubleArrayField    = new double[0];
+    }
+
+    @Test
+    public void testByteField() {
+        TestRecord record = new TestRecord();
+        record.byteArrayField = new byte[]{1, 0, -1, Byte.MIN_VALUE, Byte.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.byteArrayField).isEqualTo(record.byteArrayField);
+    }
+
+    @Test
+    public void testCharacterField() {
+        TestRecord record = new TestRecord();
+        record.characterArrayField = new char[]{1, 0, Character.MIN_VALUE, Character.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.characterArrayField).isEqualTo(record.characterArrayField);
+    }
+
+    @Test
+    public void testDoubleField() {
+        TestRecord record = new TestRecord();
+        record.doubleArrayField = new double[]{1, 0, -1, Double.MIN_VALUE, Double.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.doubleArrayField).isEqualTo(record.doubleArrayField);
+    }
+
+    @Test
+    public void testFloatField() {
+        TestRecord record = new TestRecord();
+        record.floatArrayField = new float[]{1, 0, -1, Float.MIN_VALUE, Float.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.floatArrayField).isEqualTo(record.floatArrayField);
+    }
+
+    @Test
+    public void testInteger() {
+        TestRecord record = new TestRecord();
+        record.integerArrayField = new int[]{1, 0, -1, Integer.MIN_VALUE, Integer.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.integerArrayField).isEqualTo(record.integerArrayField);
+    }
+
+    @Test
+    public void testLongField() {
+        TestRecord record = new TestRecord();
+        record.longArrayField = new long[]{1, 0, -1, Long.MIN_VALUE, Long.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.longArrayField).isEqualTo(record.longArrayField);
+    }
+
+    @Test
+    public void testShortField() {
+        TestRecord record = new TestRecord();
+        record.shortArrayField = new short[]{1, 0, -1, Short.MIN_VALUE, Short.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.shortArrayField).isEqualTo(record.shortArrayField);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveTest.java
@@ -1,0 +1,94 @@
+package com.fasterxml.jackson.dataformat.avro.interop.records;
+
+import lombok.Data;
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests serializing primitive fields on records
+ */
+public class RecordWithPrimitiveTest extends InteropTestBase {
+    @Data
+    public static class TestRecord {
+        private byte   byteField;
+        private short  shortField;
+        private char   characterField;
+        private int    integerField;
+        private long   longField;
+        private float  floatField;
+        private double doubleField;
+    }
+
+    @Test
+    public void testByteField() {
+        TestRecord record = new TestRecord();
+        record.byteField = Byte.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.byteField).isEqualTo(record.byteField);
+    }
+
+    @Test
+    public void testCharacterField() {
+        TestRecord record = new TestRecord();
+        record.characterField = Character.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.characterField).isEqualTo(record.characterField);
+    }
+
+    @Test
+    public void testDoubleField() {
+        TestRecord record = new TestRecord();
+        record.doubleField = Double.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.doubleField).isEqualTo(record.doubleField);
+    }
+
+    @Test
+    public void testFloatField() {
+        TestRecord record = new TestRecord();
+        record.floatField = Float.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.floatField).isEqualTo(record.floatField);
+    }
+
+    @Test
+    public void testInteger() {
+        TestRecord record = new TestRecord();
+        record.integerField = Integer.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.integerField).isEqualTo(record.integerField);
+    }
+
+    @Test
+    public void testLongField() {
+        TestRecord record = new TestRecord();
+        record.longField = Long.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.longField).isEqualTo(record.longField);
+    }
+
+    @Test
+    public void testShortField() {
+        TestRecord record = new TestRecord();
+        record.shortField = Short.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.shortField).isEqualTo(record.shortField);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveWrapperArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveWrapperArrayTest.java
@@ -1,0 +1,105 @@
+package com.fasterxml.jackson.dataformat.avro.interop.records;
+
+import lombok.Data;
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests serializing primitive array fields on records
+ */
+public class RecordWithPrimitiveWrapperArrayTest extends InteropTestBase {
+    @Data
+    public static class TestRecord {
+        private Byte[]      byteArrayField      = new Byte[0];
+        private Short[]     shortArrayField     = new Short[0];
+        private Character[] characterArrayField = new Character[0];
+        private Integer[]   integerArrayField   = new Integer[0];
+        private Long[]      longArrayField      = new Long[0];
+        private Float[]     floatArrayField     = new Float[0];
+        private Double[]    doubleArrayField    = new Double[0];
+        private String[]    stringArrayField    = new String[0];
+    }
+
+    @Test
+    public void testByteField() {
+        TestRecord record = new TestRecord();
+        record.byteArrayField = new Byte[]{1, 0, -1, Byte.MIN_VALUE, Byte.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.byteArrayField).isEqualTo(record.byteArrayField);
+    }
+
+    @Test
+    public void testCharacterField() {
+        TestRecord record = new TestRecord();
+        record.characterArrayField = new Character[]{1, 0, Character.MIN_VALUE, Character.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.characterArrayField).isEqualTo(record.characterArrayField);
+    }
+
+    @Test
+    public void testDoubleField() {
+        TestRecord record = new TestRecord();
+        record.doubleArrayField = new Double[]{1D, 0D, -1D, Double.MIN_VALUE, Double.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.doubleArrayField).isEqualTo(record.doubleArrayField);
+    }
+
+    @Test
+    public void testFloatField() {
+        TestRecord record = new TestRecord();
+        record.floatArrayField = new Float[]{1F, 0F, -1F, Float.MIN_VALUE, Float.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.floatArrayField).isEqualTo(record.floatArrayField);
+    }
+
+    @Test
+    public void testInteger() {
+        TestRecord record = new TestRecord();
+        record.integerArrayField = new Integer[]{1, 0, -1, Integer.MIN_VALUE, Integer.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.integerArrayField).isEqualTo(record.integerArrayField);
+    }
+
+    @Test
+    public void testLongField() {
+        TestRecord record = new TestRecord();
+        record.longArrayField = new Long[]{1L, 0L, -1L, Long.MIN_VALUE, Long.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.longArrayField).isEqualTo(record.longArrayField);
+    }
+
+    @Test
+    public void testShortField() {
+        TestRecord record = new TestRecord();
+        record.shortArrayField = new Short[]{1, 0, -1, Short.MIN_VALUE, Short.MAX_VALUE};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.shortArrayField).isEqualTo(record.shortArrayField);
+    }
+
+    @Test
+    public void testStringField() {
+        TestRecord record = new TestRecord();
+        record.stringArrayField = new String[]{"", "one", "HelloWorld"};
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.stringArrayField).isEqualTo(record.stringArrayField);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveWrapperTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveWrapperTest.java
@@ -1,0 +1,105 @@
+package com.fasterxml.jackson.dataformat.avro.interop.records;
+
+import lombok.Data;
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests serializing wrapper types for primitives on records
+ */
+public class RecordWithPrimitiveWrapperTest extends InteropTestBase {
+    @Data
+    public static class TestRecord {
+        private Byte      byteField      = 0;
+        private Short     shortField     = 0;
+        private Character characterField = 'A';
+        private Integer   integerField   = 0;
+        private Long      longField      = 0L;
+        private Float     floatField     = 0F;
+        private Double    doubleField    = 0D;
+        private String    stringField    = "";
+    }
+
+    @Test
+    public void testByteField() {
+        TestRecord record = new TestRecord();
+        record.byteField = Byte.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.byteField).isEqualTo(record.byteField);
+    }
+
+    @Test
+    public void testCharacterField() {
+        TestRecord record = new TestRecord();
+        record.characterField = Character.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.characterField).isEqualTo(record.characterField);
+    }
+
+    @Test
+    public void testDoubleField() {
+        TestRecord record = new TestRecord();
+        record.doubleField = Double.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.doubleField).isEqualTo(record.doubleField);
+    }
+
+    @Test
+    public void testFloatField() {
+        TestRecord record = new TestRecord();
+        record.floatField = Float.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.floatField).isEqualTo(record.floatField);
+    }
+
+    @Test
+    public void testInteger() {
+        TestRecord record = new TestRecord();
+        record.integerField = Integer.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.integerField).isEqualTo(record.integerField);
+    }
+
+    @Test
+    public void testLongField() {
+        TestRecord record = new TestRecord();
+        record.longField = Long.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.longField).isEqualTo(record.longField);
+    }
+
+    @Test
+    public void testShortField() {
+        TestRecord record = new TestRecord();
+        record.shortField = Short.MAX_VALUE;
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.shortField).isEqualTo(record.shortField);
+    }
+
+    @Test
+    public void testStringField() {
+        TestRecord record = new TestRecord();
+        record.stringField = "Hello World";
+        //
+        TestRecord result = roundTrip(record);
+        //
+        assertThat(result.stringField).isEqualTo(record.stringField);
+    }
+}


### PR DESCRIPTION
As per the discussion in https://github.com/FasterXML/jackson-dataformats-binary/pull/44, I have rebased the following onto the 2.8 branch:

* Various fixes for Arrays and fixed how Character, Character[], char, and char[] are handled
* Rebuilt the test suite to make it much more fine-grained, so individual tests can be disabled
* Added support for `@AvroIgnore` and `@AvroName`

This should be the rest of the changes in the original PR that did not depend upon the native type ID work, and each commit should be fairly self contained if you want to review commit-by-commit.

I think the only non-trivial merge conflict with master was the `CharReader`, which needs to be updated to look like it does [here](https://github.com/FasterXML/jackson-dataformats-binary/pull/44/files#diff-0156682d65c5d63cbc4d3b03852b5828).

Let me know if there's anything I missed style-wise or if there is a better way to implement one of these features.