### PR TITLE
[Avro] Include Type IDs in List schemas

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/ArrayVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/ArrayVisitor.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.dataformat.avro.schema;
 
+import java.util.List;
+
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 
@@ -35,8 +37,8 @@ public class ArrayVisitor
             throw new IllegalStateException("No element schema created for: "+_type);
         }
         Schema schema = Schema.createArray(_elementSchema);
-        if (_type.isArrayType()) {
-            schema.addProp(AVRO_SCHEMA_PROP_CLASS, _type.toCanonical());
+        if (!_type.hasRawClass(List.class)) {
+            schema.addProp(AVRO_SCHEMA_PROP_CLASS, AvroSchemaHelper.getTypeId(_type));
         }
         return schema;
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -196,6 +196,6 @@ public abstract class AvroSchemaHelper
         if (type.isPrimitive()) {
             return ClassUtil.wrapperType(type.getRawClass()).getName();
         }
-        return type.toCanonical();
+        return type.getRawClass().getName();
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/ApacheAvroInteropUtil.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/ApacheAvroInteropUtil.java
@@ -108,7 +108,7 @@ public class ApacheAvroInteropUtil {
                     }
                 }
             }
-            if (type instanceof Class<?> && ((Class<?>) type).getSuperclass() != null) {
+            if (type instanceof Class<?> && ((Class<?>) type).getSuperclass() != null && !Enum.class.isAssignableFrom((Class<?>) type)) {
                 // Raw class may extend a generic superclass
                 // extract all the type bindings and add them to the map so they can be returned by the next block
                 // Interfaces shouldn't matter here because interfaces can't have fields and avro only looks at fields.

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
@@ -1,11 +1,16 @@
 package com.fasterxml.jackson.dataformat.avro.interop;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.avro.Schema;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 
 import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.*;
 
@@ -144,5 +149,19 @@ public abstract class InteropTestBase {
             return jacksonDeserialize(schema, schemaType, serializeFunctor.apply(schema, object));
         }
         return (T) deserializeFunctor.apply(schema, serializeFunctor.apply(schema, object));
+    }
+
+    public enum DummyEnum {
+        NORTH, SOUTH, EAST, WEST
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DummyRecord {
+        @JsonProperty(required = true)
+        private String firstValue;
+        @JsonProperty(required = true)
+        private int secondValue;
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/CollectionSubtypeTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/CollectionSubtypeTest.java
@@ -1,0 +1,144 @@
+package com.fasterxml.jackson.dataformat.avro.interop.arrays;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.apacheDeserializer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests collection subtypes such as {@link ArrayList}, {@link LinkedList}, {@link Stack}, {@link Set}, {@link HashSet}, {@link TreeSet},
+ * {@link ConcurrentSkipListSet}, {@link CopyOnWriteArraySet}, and {@link CopyOnWriteArrayList} to ensure they are compatible with the
+ * {@code ARRAY} schema type.
+ */
+public class CollectionSubtypeTest extends InteropTestBase {
+    @Test
+    public void testArrayList() {
+        ArrayList<String> original = new ArrayList<>();
+        original.add("test");
+        original.add("Second");
+        //
+        ArrayList<String> result = roundTrip(type(ArrayList.class, String.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testConcurrentSkipListSet() {
+        ConcurrentSkipListSet<Integer> original = new ConcurrentSkipListSet<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        ConcurrentSkipListSet<Integer> result = roundTrip(type(ConcurrentSkipListSet.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testCopyOnWriteArrayList() {
+        CopyOnWriteArrayList<Integer> original = new CopyOnWriteArrayList<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        CopyOnWriteArrayList<Integer> result = roundTrip(type(CopyOnWriteArrayList.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testCopyOnWriteArraySet() {
+        CopyOnWriteArraySet<Integer> original = new CopyOnWriteArraySet<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        CopyOnWriteArraySet<Integer> result = roundTrip(type(CopyOnWriteArraySet.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testEnumSet() {
+        // Bug in apache deserializer, can't handle EnumSet
+        Assume.assumeTrue(deserializeFunctor != apacheDeserializer);
+        EnumSet<DummyEnum> original = EnumSet.of(DummyEnum.EAST, DummyEnum.NORTH);
+        //
+        EnumSet<DummyEnum> result = roundTrip(type(EnumSet.class, DummyEnum.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testHashSet() {
+        HashSet<Integer> original = new HashSet<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        HashSet<Integer> result = roundTrip(type(HashSet.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testLinkedList() {
+        LinkedList<Integer> original = new LinkedList<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        LinkedList<Integer> result = roundTrip(type(LinkedList.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testList() {
+        List<String> original = new ArrayList<>();
+        original.add("test");
+        original.add("Second");
+        //
+        List<String> result = roundTrip(type(List.class, String.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testSet() {
+        // Bug in apache deserializer, can't handle Set
+        Assume.assumeTrue(deserializeFunctor != apacheDeserializer);
+        Set<Integer> original = new HashSet<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        Set<Integer> result = roundTrip(type(Set.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testStack() {
+        Stack<Integer> original = new Stack<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        Stack<Integer> result = roundTrip(type(Stack.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testTreeSet() {
+        TreeSet<Integer> original = new TreeSet<>();
+        original.add(1234);
+        original.add(98768234);
+        //
+        TreeSet<Integer> result = roundTrip(type(TreeSet.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithComplexTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithComplexTest.java
@@ -1,0 +1,92 @@
+package com.fasterxml.jackson.dataformat.avro.interop.arrays;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Tests lists involving complex element types (Lists, Records, Maps, Enums)
+ */
+public class ListWithComplexTest extends InteropTestBase {
+    @Test
+    public void testEmptyListWithRecordElements() {
+        List<DummyRecord> original = new ArrayList<>();
+        //
+        List<DummyRecord> result = roundTrip(type(List.class, DummyRecord.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithEnumElements() {
+        List<DummyEnum> original = new ArrayList<>();
+        original.add(DummyEnum.EAST);
+        original.add(DummyEnum.WEST);
+        //
+        List<DummyEnum> result = roundTrip(type(List.class, DummyEnum.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithListElements() {
+        List<List<List<String>>> original = new ArrayList<>();
+        original.add(new ArrayList<List<String>>());
+        original.get(0).add(Collections.singletonList("Hello"));
+        original.add(new ArrayList<List<String>>());
+        original.get(1).add(Collections.singletonList("World"));
+        //
+        List<List<List<String>>> result = roundTrip(type(List.class, type(List.class, type(List.class, String.class))), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithMapElements() {
+        List<Map<String, Integer>> original = new ArrayList<>();
+        original.add(Collections.singletonMap("Hello", 1));
+        original.add(Collections.singletonMap("World", 2));
+        //
+        List<Map<String, Integer>> result = roundTrip(type(List.class, type(Map.class, String.class, Integer.class)), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithNullElements() {
+        List<DummyRecord> original = new ArrayList<>();
+        original.add(null);
+        //
+        try {
+            roundTrip(type(List.class, DummyRecord.class), original);
+            fail("Should throw an NPE");
+        } catch (Throwable e) {
+            // Avro NullPointerException
+            // Jackson RuntimeException -> JsonMappingException -> NullPointerException
+            while (e.getCause() != null && e.getCause() != e) {
+                e = e.getCause();
+            }
+            assertThat(e).isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Test
+    public void testListWithRecordElements() {
+        List<DummyRecord> original = new ArrayList<>();
+        original.add(new DummyRecord("test", 2));
+        original.add(new DummyRecord("test 2", 1235));
+        original.add(new DummyRecord("test 3", -234));
+        //
+        List<DummyRecord> result = roundTrip(type(List.class, DummyRecord.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithPrimitiveArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithPrimitiveArrayTest.java
@@ -1,0 +1,114 @@
+package com.fasterxml.jackson.dataformat.avro.interop.arrays;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that maps behave as expected when primitive arrays (byte[], short[], char[], int[], long[], float[], double[]) are used as the
+ * value type
+ */
+public class ListWithPrimitiveArrayTest extends InteropTestBase {
+    @Test
+    public void testListWithBytes() {
+        List<byte[]> original = new ArrayList<>();
+        original.add(new byte[]{(byte) 1});
+        original.add(new byte[0]);
+        original.add(new byte[]{(byte) -1});
+        original.add(new byte[]{Byte.MIN_VALUE});
+        original.add(new byte[]{Byte.MAX_VALUE});
+        //
+        List<byte[]> result = roundTrip(type(List.class, byte[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new byte[0][]));
+    }
+
+    @Test
+    public void testListWithCharacters() {
+        List<char[]> original = new ArrayList<>();
+        original.add(new char[]{(char) 1});
+        original.add(new char[0]);
+        original.add(new char[]{(char) -1});
+        original.add(new char[]{Character.MIN_VALUE});
+        original.add(new char[]{Character.MAX_VALUE});
+        //
+        List<char[]> result = roundTrip(type(List.class, char[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new char[0][]));
+    }
+
+    @Test
+    public void testListWithDoubles() {
+        List<double[]> original = new ArrayList<>();
+        original.add(new double[]{(double) 1});
+        original.add(new double[0]);
+        original.add(new double[]{(double) -1});
+        original.add(new double[]{Double.MIN_VALUE});
+        original.add(new double[]{Double.MAX_VALUE});
+        //
+        List<double[]> result = roundTrip(type(List.class, double[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new double[0][]));
+    }
+
+    @Test
+    public void testListWithFloats() {
+        List<float[]> original = new ArrayList<>();
+        original.add(new float[]{(float) 1});
+        original.add(new float[0]);
+        original.add(new float[]{(float) -1});
+        original.add(new float[]{Float.MIN_VALUE});
+        original.add(new float[]{Float.MAX_VALUE});
+        //
+        List<float[]> result = roundTrip(type(List.class, float[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new float[0][]));
+    }
+
+    @Test
+    public void testListWithIntegers() {
+        List<int[]> original = new ArrayList<>();
+        original.add(new int[]{(int) 1});
+        original.add(new int[0]);
+        original.add(new int[]{(int) -1});
+        original.add(new int[]{Integer.MIN_VALUE});
+        original.add(new int[]{Integer.MAX_VALUE});
+        //
+        List<int[]> result = roundTrip(type(List.class, int[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new int[0][]));
+    }
+
+    @Test
+    public void testListWithLongs() {
+        List<long[]> original = new ArrayList<>();
+        original.add(new long[]{(long) 1});
+        original.add(new long[0]);
+        original.add(new long[]{(long) -1});
+        original.add(new long[]{Long.MIN_VALUE});
+        original.add(new long[]{Long.MAX_VALUE});
+        //
+        List<long[]> result = roundTrip(type(List.class, long[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new long[0][]));
+    }
+
+    @Test
+    public void testListWithShorts() {
+        List<short[]> original = new ArrayList<>();
+        original.add(new short[]{(short) 1});
+        original.add(new short[0]);
+        original.add(new short[]{(short) -1});
+        original.add(new short[]{Short.MIN_VALUE});
+        original.add(new short[]{Short.MAX_VALUE});
+        //
+        List<short[]> result = roundTrip(type(List.class, short[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new short[0][]));
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithPrimitiveWrapperArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithPrimitiveWrapperArrayTest.java
@@ -1,0 +1,128 @@
+package com.fasterxml.jackson.dataformat.avro.interop.arrays;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that lists behave as expected when primitive wrapper arrays (Byte[], Short[], Character[], Integer[], Long[], Float[], Double[])
+ * are used as the value type
+ */
+public class ListWithPrimitiveWrapperArrayTest extends InteropTestBase {
+    @Test
+    public void testListWithBytes() {
+        List<Byte[]> original = new ArrayList<>();
+        original.add(new Byte[]{(byte) 1});
+        original.add(new Byte[0]);
+        original.add(new Byte[]{(byte) -1});
+        original.add(new Byte[]{Byte.MIN_VALUE});
+        original.add(new Byte[]{Byte.MAX_VALUE});
+        //
+        List<Byte[]> result = roundTrip(type(List.class, Byte[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new Byte[0][]));
+    }
+
+    @Test
+    public void testListWithCharacters() {
+        List<Character[]> original = new ArrayList<>();
+        original.add(new Character[]{(char) 1});
+        original.add(new Character[0]);
+        original.add(new Character[]{(char) -1});
+        original.add(new Character[]{Character.MIN_VALUE});
+        original.add(new Character[]{Character.MAX_VALUE});
+        //
+        List<Character[]> result = roundTrip(type(List.class, Character[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new Character[0][]));
+    }
+
+    @Test
+    public void testListWithDoubles() {
+        List<Double[]> original = new ArrayList<>();
+        original.add(new Double[]{(double) 1});
+        original.add(new Double[0]);
+        original.add(new Double[]{(double) -1});
+        original.add(new Double[]{Double.MIN_VALUE});
+        original.add(new Double[]{Double.MAX_VALUE});
+        //
+        List<Double[]> result = roundTrip(type(List.class, Double[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new Double[0][]));
+    }
+
+    @Test
+    public void testListWithFloats() {
+        List<Float[]> original = new ArrayList<>();
+        original.add(new Float[]{(float) 1});
+        original.add(new Float[0]);
+        original.add(new Float[]{(float) -1});
+        original.add(new Float[]{Float.MIN_VALUE});
+        original.add(new Float[]{Float.MAX_VALUE});
+        //
+        List<Float[]> result = roundTrip(type(List.class, Float[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new Float[0][]));
+    }
+
+    @Test
+    public void testListWithIntegers() {
+        List<Integer[]> original = new ArrayList<>();
+        original.add(new Integer[]{(int) 1});
+        original.add(new Integer[0]);
+        original.add(new Integer[]{(int) -1});
+        original.add(new Integer[]{Integer.MIN_VALUE});
+        original.add(new Integer[]{Integer.MAX_VALUE});
+        //
+        List<Integer[]> result = roundTrip(type(List.class, Integer[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new Integer[0][]));
+    }
+
+    @Test
+    public void testListWithLongs() {
+        List<Long[]> original = new ArrayList<>();
+        original.add(new Long[]{(long) 1});
+        original.add(new Long[0]);
+        original.add(new Long[]{(long) -1});
+        original.add(new Long[]{Long.MIN_VALUE});
+        original.add(new Long[]{Long.MAX_VALUE});
+        //
+        List<Long[]> result = roundTrip(type(List.class, Long[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new Long[0][]));
+    }
+
+    @Test
+    public void testListWithShorts() {
+        List<Short[]> original = new ArrayList<>();
+        original.add(new Short[]{(short) 1});
+        original.add(new Short[0]);
+        original.add(new Short[]{(short) -1});
+        original.add(new Short[]{Short.MIN_VALUE});
+        original.add(new Short[]{Short.MAX_VALUE});
+        //
+        List<Short[]> result = roundTrip(type(List.class, Short[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new Short[0][]));
+    }
+
+    @Test
+    public void testListWithStrings() {
+        List<String[]> original = new ArrayList<>();
+        original.add(new String[]{"1"});
+        original.add(new String[0]);
+        original.add(new String[]{""});
+        original.add(new String[]{"a really long string for testing"});
+        original.add(new String[]{"multiple", "string", "values", "here"});
+        //
+        List<String[]> result = roundTrip(type(List.class, String[].class), original);
+        //
+        assertThat(result).containsExactly(original.toArray(new String[0][]));
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithPrimitiveWrapperTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/arrays/ListWithPrimitiveWrapperTest.java
@@ -1,0 +1,126 @@
+package com.fasterxml.jackson.dataformat.avro.interop.arrays;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that Lists behave as expected when primitive wrappers (Byte, Short, Character, Integer, Long, Float, Double) are used as the value
+ * type
+ */
+public class ListWithPrimitiveWrapperTest extends InteropTestBase {
+    @Test
+    public void testListWithBytes() {
+        List<Byte> original = new ArrayList<>();
+        original.add((byte) 1);
+        original.add((byte) 0);
+        original.add((byte) -1);
+        original.add(Byte.MIN_VALUE);
+        original.add(Byte.MAX_VALUE);
+        //
+        List<Byte> result = roundTrip(type(List.class, Byte.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithCharacters() {
+        List<Character> original = new ArrayList<>();
+        original.add((char) 1);
+        original.add((char) 0);
+        original.add((char) -1);
+        original.add(Character.MIN_VALUE);
+        original.add(Character.MAX_VALUE);
+        //
+        List<Character> result = roundTrip(type(List.class, Character.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithDoubles() {
+        List<Double> original = new ArrayList<>();
+        original.add(1D);
+        original.add(0D);
+        original.add(-1D);
+        original.add(Double.MIN_VALUE);
+        original.add(Double.MAX_VALUE);
+        //
+        List<Double> result = roundTrip(type(List.class, Double.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithFloats() {
+        List<Float> original = new ArrayList<>();
+        original.add(1F);
+        original.add(0F);
+        original.add(-1F);
+        original.add(Float.MIN_VALUE);
+        original.add(Float.MAX_VALUE);
+        //
+        List<Float> result = roundTrip(type(List.class, Float.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithIntegers() {
+        List<Integer> original = new ArrayList<>();
+        original.add(1);
+        original.add(0);
+        original.add(-1);
+        original.add(Integer.MIN_VALUE);
+        original.add(Integer.MAX_VALUE);
+        //
+        List<Integer> result = roundTrip(type(List.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithLongs() {
+        List<Long> original = new ArrayList<>();
+        original.add(1L);
+        original.add(0L);
+        original.add(-1L);
+        original.add(Long.MIN_VALUE);
+        original.add(Long.MAX_VALUE);
+        //
+        List<Long> result = roundTrip(type(List.class, Long.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithShorts() {
+        List<Short> original = new ArrayList<>();
+        original.add((short) 1);
+        original.add((short) 0);
+        original.add((short) -1);
+        original.add(Short.MIN_VALUE);
+        original.add(Short.MAX_VALUE);
+        //
+        List<Short> result = roundTrip(type(List.class, Short.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testListWithStrings() {
+        List<String> original = new ArrayList<>();
+        original.add("1");
+        original.add("");
+        original.add("a really long string for testing");
+        //
+        List<String> result = roundTrip(type(List.class, String.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapSubtypeTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapSubtypeTest.java
@@ -1,16 +1,19 @@
 package com.fasterxml.jackson.dataformat.avro.interop.maps;
 
-import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
 import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.apacheDeserializer;
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.getApacheSchema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -65,6 +68,20 @@ public class MapSubtypeTest extends InteropTestBase {
         original.put("Second", 98768234);
         //
         TreeMap<String, Integer> result = roundTrip(type(TreeMap.class, String.class, Integer.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testEnumMap() {
+        // Apache schema generator can't handle EnumMaps
+        Assume.assumeTrue(schemaFunctor != getApacheSchema);
+
+        EnumMap<DummyEnum, Integer> original = new EnumMap<>(DummyEnum.class);
+        original.put(DummyEnum.NORTH, 1234);
+        original.put(DummyEnum.SOUTH, 98768234);
+        //
+        EnumMap<DummyEnum, Integer> result = roundTrip(type(EnumMap.class, DummyEnum.class, Integer.class), original);
         //
         assertThat(result).isEqualTo(original);
     }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithComplexTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithComplexTest.java
@@ -1,0 +1,93 @@
+package com.fasterxml.jackson.dataformat.avro.interop.maps;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Tests Maps involving complex value types (Lists, Records, Maps, Enums)
+ */
+public class MapWithComplexTest extends InteropTestBase {
+
+    @Test
+    public void testMapWithRecordValues() {
+        Map<String, DummyRecord> original = new HashMap<>();
+        original.put("one", new DummyRecord("test", 2));
+        original.put("two", new DummyRecord("test 2", 1235));
+        original.put("three", new DummyRecord("test 3", -234));
+        //
+        Map<String, DummyRecord> result = roundTrip(type(Map.class, String.class, DummyRecord.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testEmptyMapWithRecordValues() {
+        Map<String, DummyRecord> original = new HashMap<>();
+        //
+        Map<String, DummyRecord> result = roundTrip(type(Map.class, String.class, DummyRecord.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithNullValues() {
+        Map<String, DummyRecord> original = new HashMap<>();
+        original.put("test", null);
+        //
+        try {
+            roundTrip(type(Map.class, String.class, DummyRecord.class), original);
+            fail("Should throw an NPE");
+        } catch (Throwable e) {
+            // Avro NullPointerException
+            // Jackson RuntimeException -> JsonMappingException -> NullPointerException
+            while (e.getCause() != null && e.getCause() != e) {
+                e = e.getCause();
+            }
+            assertThat(e).isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Test
+    public void testMapWithEnumValues() {
+        Map<String, DummyEnum> original = new HashMap<>();
+        original.put("one", DummyEnum.EAST);
+        original.put("two", DummyEnum.WEST);
+        //
+        Map<String, DummyEnum> result = roundTrip(type(Map.class, String.class, DummyEnum.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithListValues() {
+        Map<String, List<List<String>>> original = new HashMap<>();
+        original.put("one", new ArrayList<List<String>>());
+        original.get("one").add(Collections.singletonList("Hello"));
+        original.put("two", new ArrayList<List<String>>());
+        original.get("two").add(Collections.singletonList("World"));
+        //
+        Map<String, List<List<String>>> result =
+            roundTrip(type(Map.class, String.class, type(List.class, type(List.class, String.class))), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testMapWithMapValues() {
+        Map<String, Map<String, Integer>> original = new HashMap<>();
+        original.put("one", Collections.singletonMap("Hello", 1));
+        original.put("two", Collections.singletonMap("World", 2));
+        //
+        Map<String, Map<String, Integer>> result =
+            roundTrip(type(Map.class, String.class, type(Map.class, String.class, Integer.class)), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveArrayTest.java
@@ -1,17 +1,17 @@
 package com.fasterxml.jackson.dataformat.avro.interop.maps;
 
-import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests that maps behave as expected when primitive arrays (byte[], short[], char[], int[], long[], float[], double[]) are used as the
- * value
- * type
+ * value type
  */
 public class MapWithPrimitiveArrayTest extends InteropTestBase {
     @Test
@@ -29,7 +29,6 @@ public class MapWithPrimitiveArrayTest extends InteropTestBase {
     }
 
     @Test
-    //@Ignore // Jackson doesn't support deserializing char[] properly yet
     public void testMapWithCharacters() {
         Map<String, char[]> original = new HashMap<>();
         original.put("one", new char[]{(char) 1});

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperArrayTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperArrayTest.java
@@ -1,10 +1,11 @@
 package com.fasterxml.jackson.dataformat.avro.interop.maps;
 
-import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapWithPrimitiveWrapperTest.java
@@ -1,10 +1,11 @@
 package com.fasterxml.jackson.dataformat.avro.interop.maps;
 
-import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -120,6 +121,6 @@ public class MapWithPrimitiveWrapperTest extends InteropTestBase {
         //
         Map<String, String> result = roundTrip(type(Map.class, String.class, String.class), original);
         //
-        assertThat(result).containsAllEntriesOf(original);
+        assertThat(result).isEqualTo(original);
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithComplexTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithComplexTest.java
@@ -1,0 +1,130 @@
+package com.fasterxml.jackson.dataformat.avro.interop.records;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.apache.avro.reflect.Nullable;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Tests records involving complex value types (Lists, Records, Maps, Enums)
+ */
+public class RecordWithComplexTest extends InteropTestBase {
+    @Data
+    @ToString(callSuper = true)
+    @EqualsAndHashCode(callSuper = true)
+    @RequiredArgsConstructor
+    public static class RecursiveDummyRecord extends DummyRecord {
+        @Nullable
+        private DummyRecord next;
+        private Map<String, Integer> simpleMap = new HashMap<>();
+        private Map<String, RecursiveDummyRecord> recursiveMap = new HashMap<>();
+        private List<Integer> requiredList = new ArrayList<>();
+        @JsonProperty(required = true)
+        private DummyEnum requiredEnum = DummyEnum.EAST;
+        @Nullable
+        private DummyEnum optionalEnum = null;
+
+        public RecursiveDummyRecord(String firstValue, Integer secondValue, DummyRecord next) {
+            super(firstValue, secondValue);
+            this.next = next;
+        }
+    }
+
+    @Test
+    public void testEmptyRecordWithRecordValues() {
+        Map<String, DummyRecord> original = new HashMap<>();
+        //
+        Map<String, DummyRecord> result = roundTrip(type(Map.class, String.class, DummyRecord.class), original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testRecordWithListFields() {
+        RecursiveDummyRecord original = new RecursiveDummyRecord("Hello", 12353, new DummyRecord("World", 234));
+        original.getRequiredList().add(9682584);
+        //
+        RecursiveDummyRecord result = roundTrip(RecursiveDummyRecord.class, original);
+        //
+        assertThat(result).isEqualTo(original);
+        assertThat(result.getRequiredList()).isEqualTo(original.getRequiredList());
+    }
+
+    @Test
+    public void testRecordWithMapFields() {
+        RecursiveDummyRecord original = new RecursiveDummyRecord("Hello", 12353, new DummyRecord("World", 234));
+        original.getSimpleMap().put("Hello World", 9682584);
+        //
+        RecursiveDummyRecord result = roundTrip(RecursiveDummyRecord.class, original);
+        //
+        assertThat(result).isEqualTo(original);
+        assertThat(result.getSimpleMap().get("Hello World")).isEqualTo(original.getSimpleMap().get("Hello World"));
+    }
+
+    @Test
+    public void testRecordWithMissingRequiredEnumFields() {
+        RecursiveDummyRecord original = new RecursiveDummyRecord("Hello", 12353, new DummyRecord("World", 234));
+        original.setRequiredEnum(null);
+        //
+        try {
+            roundTrip(RecursiveDummyRecord.class, original);
+            fail("Should throw an NPE");
+        } catch (Throwable e) {
+            // Avro NullPointerException
+            // Jackson RuntimeException -> JsonMappingException -> NullPointerException
+            while (e.getCause() != null && e.getCause() != e) {
+                e = e.getCause();
+            }
+            assertThat(e).isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Test
+    public void testRecordWithNullRequiredFields() {
+        RecursiveDummyRecord original = new RecursiveDummyRecord(null, 12353, new DummyRecord("World", 234));
+        //
+        try {
+            roundTrip(RecursiveDummyRecord.class, original);
+            fail("Should throw an NPE");
+        } catch (Throwable e) {
+            // Avro NullPointerException
+            // Jackson RuntimeException -> JsonMappingException -> NullPointerException
+            while (e.getCause() != null && e.getCause() != e) {
+                e = e.getCause();
+            }
+            assertThat(e).isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Test
+    public void testRecordWithOptionalEnumField() {
+        RecursiveDummyRecord original = new RecursiveDummyRecord("Hello", 12353, new DummyRecord("World", 234));
+        original.setOptionalEnum(DummyEnum.SOUTH);
+        //
+        RecursiveDummyRecord result = roundTrip(RecursiveDummyRecord.class, original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    public void testRecordWithRecordValues() {
+        RecursiveDummyRecord original = new RecursiveDummyRecord("Hello", 12353, new DummyRecord("World", 234));
+        //
+        RecursiveDummyRecord result = roundTrip(RecursiveDummyRecord.class, original);
+        //
+        assertThat(result).isEqualTo(original);
+    }
+}


### PR DESCRIPTION
This fixes several issues with type IDs in generated schemas, particularly around lists. The tests suites for maps and lists are also fleshed out, which helped to catch these issues.