### PR TITLE
[Avro] Add support for @AvroDefault and @Nullable annotations

### DIFF
--- a/avro/pom.xml
+++ b/avro/pom.xml
@@ -21,6 +21,10 @@ abstractions.
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
     <!--  Hmmh. Need databind for Avro Schema generation... -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -32,13 +36,7 @@ abstractions.
       <version>1.7.7</version>
     </dependency>
 
-     <!-- and for testing we need annotations -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- plus logback -->
+    <!-- and for testing we need logback -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.avro;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.PropertyName;
@@ -9,6 +10,7 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import org.apache.avro.reflect.AvroDefault;
 import org.apache.avro.reflect.AvroIgnore;
 import org.apache.avro.reflect.AvroName;
+import org.apache.avro.reflect.Nullable;
 
 /**
  * Adds support for the following annotations from the Apache Avro implementation:
@@ -18,6 +20,7 @@ import org.apache.avro.reflect.AvroName;
  * <li>{@link AvroDefault @AvroDefault("default value")} - Alias for <code>JsonProperty.defaultValue</code>, to
  *     define default value for generated Schemas
  *   </li>
+ * <li>{@link Nullable @Nullable} - Alias for <code>JsonProperty(required = false)</code></li>
  * </ul>
  *
  * @since 2.9
@@ -56,5 +59,19 @@ public class AvroAnnotationIntrospector extends AnnotationIntrospector
     {
         AvroName ann = _findAnnotation(a, AvroName.class);
         return (ann == null) ? null : PropertyName.construct(ann.value());
+    }
+
+    @Override
+    public Boolean hasRequiredMarker(AnnotatedMember m) {
+        if (_hasAnnotation(m, Nullable.class)) {
+            return false;
+        }
+        // Appears to be a bug in POJOPropertyBuilder.getMetadata()
+        // Can't specify a default unless property is known to be required or not, or we get an NPE
+        // If we have a default but no annotations indicating required or not, assume required.
+        if (_hasAnnotation(m, AvroDefault.class) && !_hasAnnotation(m, JsonProperty.class)) {
+            return true;
+        }
+        return null;
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroDefaultTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroDefaultTest.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.dataformat.avro.interop.annotations;
+
+import com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil;
+
+import org.apache.avro.Schema;
+import org.apache.avro.reflect.AvroDefault;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AvroDefaultTest {
+    static class RecordWithDefaults {
+        @AvroDefault("\"Test Field\"")
+        public String stringField;
+        @AvroDefault("1234")
+        public Integer intField;
+        @AvroDefault("true")
+        public Integer booleanField;
+    }
+
+    @Test
+    public void testUnionBooleanDefault() {
+        Schema apacheSchema = ApacheAvroInteropUtil.getApacheSchema(RecordWithDefaults.class);
+        Schema jacksonSchema = ApacheAvroInteropUtil.getJacksonSchema(RecordWithDefaults.class);
+        //
+        assertThat(jacksonSchema.getField("booleanField").defaultValue()).isEqualTo(apacheSchema.getField("booleanField").defaultValue());
+    }
+
+    @Test
+    public void testUnionIntegerDefault() {
+        Schema apacheSchema = ApacheAvroInteropUtil.getApacheSchema(RecordWithDefaults.class);
+        Schema jacksonSchema = ApacheAvroInteropUtil.getJacksonSchema(RecordWithDefaults.class);
+        //
+        assertThat(jacksonSchema.getField("intField").defaultValue()).isEqualTo(apacheSchema.getField("intField").defaultValue());
+    }
+
+    @Test
+    public void testUnionStringDefault() {
+        Schema apacheSchema = ApacheAvroInteropUtil.getApacheSchema(RecordWithDefaults.class);
+        Schema jacksonSchema = ApacheAvroInteropUtil.getJacksonSchema(RecordWithDefaults.class);
+        //
+        assertThat(jacksonSchema.getField("stringField").defaultValue()).isEqualTo(apacheSchema.getField("stringField").defaultValue());
+    }
+}


### PR DESCRIPTION
This adds support for embedding the default values (Provided by `@AvroDefault` or `@JsonProperty`) into the generated avro schemas. This also adds support for `@Nullable` in case there are multiple annotation introspectors in play and the annotations need to be recognized despite normally being the default.

I seem to have found a weird bug where if a property has a default value or a description, but is neither explicitly marked as required nor not required, `POJOPropertyBuilder.getMetadata():503` will throw an NPE when it tries to coerce the `required` marker into a boolean primitive. I wasn't sure if this was intentional or something I don't fully understand. I worked around it by providing explicit `required` markers if `@AvroDefault` is present, but there's probably a better way to handle this that I'm not aware of. Normally this isn't a problem because `@JsonProperty` doesn't allow you to specify a default value or description without also setting the required marker to `true` or `false`.

Additional PRs for `@AvroSchema`, `@AvroMeta`, and `@Union` will probably be filed tomorrow sometime. The PR for adding polymorphic deserialization backported to the 2.8 branch will follow those.