### PR TITLE
[Avro] Add support for @AvroMeta, @AvroSchema, and Jackson class/property descriptions

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -8,10 +8,12 @@ import java.net.URL;
 import java.util.*;
 
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
 import org.apache.avro.reflect.Stringable;
 import org.apache.avro.specific.SpecificData;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
@@ -186,6 +188,27 @@ public abstract class AvroSchemaHelper
 
     protected static <T> T throwUnsupported() {
         throw new UnsupportedOperationException("Format variation not supported");
+    }
+
+    /**
+     * Initializes a record schema with metadata from the given class; this schema is returned in a non-finalized state, and still
+     * needs to have fields added to it.
+     */
+    public static Schema initializeRecordSchema(BeanDescription bean) {
+        return Schema.createRecord(
+            getName(bean.getType()),
+            bean.findClassDescription(),
+            getNamespace(bean.getType()),
+            bean.getType().isTypeOrSubTypeOf(Throwable.class)
+        );
+    }
+
+    /**
+     * Parses a JSON-formatted representation of a schema
+     */
+    public static Schema parseJsonSchema(String json) {
+        Schema.Parser parser = new Parser();
+        return parser.parse(json);
     }
 
     /**

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.dataformat.avro.AvroFixedSize;
 
 import org.apache.avro.Schema;
+import org.apache.avro.reflect.AvroMeta;
 import org.apache.avro.reflect.AvroSchema;
 
 public class RecordVisitor
@@ -47,6 +48,10 @@ public class RecordVisitor
             String description = getProvider().getAnnotationIntrospector().findClassDescription(ac);
             _avroSchema = Schema.createRecord(AvroSchemaHelper.getName(type), description, AvroSchemaHelper.getNamespace(type), false);
             _overridden = false;
+            AvroMeta meta = ac.getAnnotation(AvroMeta.class);
+            if (meta != null) {
+                _avroSchema.addProp(meta.key(), meta.value());
+            }
         }
         schemas.addSchema(type, _avroSchema);
     }
@@ -159,6 +164,13 @@ public class RecordVisitor
             }
         }
         String description = getProvider().getAnnotationIntrospector().findPropertyDescription(prop.getMember());
-        return new Schema.Field(prop.getName(), writerSchema, description, null);
+        Schema.Field field = new Schema.Field(prop.getName(), writerSchema, description, null);
+
+        AvroMeta meta = prop.getAnnotation(AvroMeta.class);
+        if (meta != null) {
+            field.addProp(meta.key(), meta.value());
+        }
+
+        return field;
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroMetaTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroMetaTest.java
@@ -1,0 +1,77 @@
+package com.fasterxml.jackson.dataformat.avro.interop.annotations;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import lombok.Data;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.reflect.AvroMeta;
+import org.apache.avro.reflect.AvroSchema;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AvroMetaTest extends InteropTestBase {
+
+    @Data
+    @AvroMeta(key = "class-meta", value = "class value")
+    static class MetaTest {
+
+        @AvroMeta(key = "custom Property", value = "Some Value")
+        private String someProperty;
+
+        @AvroMeta(key = "required custom Property", value = "Some required Value")
+        @JsonProperty(required = true)
+        private String someRequiredProperty;
+    }
+
+    @Data
+    static class BadMetaTest {
+
+        @AvroMeta(key = "name", value = "colliding property")
+        private String types;
+    }
+
+    @Data
+    @AvroSchema("{\"type\":\"string\"}")
+    @AvroMeta(key="overridden", value = "true")
+    static class OverriddenClassSchema {
+
+        private int field;
+    }
+
+    @Test
+    public void testAnnotationPrecedence() {
+        Schema schema = schemaFunctor.apply(OverriddenClassSchema.class);
+        //
+        assertThat(schema.getProp("overridden")).isNull();
+    }
+
+    @Test
+    public void testOptionalFieldMetaProperty() {
+        Schema schema = schemaFunctor.apply(MetaTest.class);
+        //
+        assertThat(schema.getField("someProperty").getProp("custom Property")).isEqualTo("Some Value");
+    }
+
+    @Test
+    public void testRequiredFieldMetaProperty() {
+        Schema schema = schemaFunctor.apply(MetaTest.class);
+        //
+        assertThat(schema.getField("someRequiredProperty").getProp("required custom Property")).isEqualTo("Some required Value");
+    }
+
+    @Test
+    public void testClassMetaProperty() {
+        Schema schema = schemaFunctor.apply(MetaTest.class);
+        //
+        assertThat(schema.getProp("class-meta")).isEqualTo("class value");
+    }
+
+    @Test(expected = AvroRuntimeException.class)
+    public void testCollidingMeta() {
+        schemaFunctor.apply(BadMetaTest.class);
+    }
+
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroSchemaTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroSchemaTest.java
@@ -1,0 +1,99 @@
+package com.fasterxml.jackson.dataformat.avro.interop.annotations;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil;
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import lombok.Data;
+import org.apache.avro.Schema;
+import org.apache.avro.reflect.AvroSchema;
+import org.apache.avro.reflect.Nullable;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that {@code @AvroSchema} is handled correctly. Specifically:
+ * <ul>
+ * <li>When present on a type, it completely and wholly overrides any other schema-related information on that type and its fields,
+ * including name, meta properties, defaults, and docs</li>
+ * <li>When present on a field, it completely and wholly overrides any other schema-related information on that field (but not
+ * other properties, like name, defaults, docs, or meta properties)</li>
+ * </ul>
+ * <p>
+ * Additionally, tests that class and property descriptions are picked up correctly when using Jackson annotations
+ */
+public class AvroSchemaTest extends InteropTestBase {
+
+    @Data
+    @AvroSchema("{\"type\":\"string\"}")
+    public static class OverriddenClassSchema {
+
+        private int field;
+    }
+
+    @Data
+    @JsonClassDescription("A cool class!")
+    public static class OverriddenFieldSchema {
+
+        @AvroSchema("{\"type\":\"int\"}")
+        private String myField;
+
+        @Nullable
+        @JsonPropertyDescription("the best field in the world")
+        private OverriddenClassSchema recursiveOverride;
+
+        @Nullable
+        @AvroSchema("{\"type\":\"long\"}")
+        private OverriddenClassSchema precedenceField;
+    }
+
+    @Test
+    public void testJacksonClassDescription() {
+        Schema schema = ApacheAvroInteropUtil.getJacksonSchema(OverriddenFieldSchema.class);
+        //
+        assertThat(schema.getDoc()).isEqualTo("A cool class!");
+    }
+
+    @Test
+    public void testJacksonPropertyDescription() {
+        Schema schema = ApacheAvroInteropUtil.getJacksonSchema(OverriddenFieldSchema.class);
+        //
+        assertThat(schema.getField("recursiveOverride").doc()).isEqualTo("the best field in the world");
+    }
+
+    @Test
+    public void testTypeOverride() {
+        Schema schema = schemaFunctor.apply(OverriddenClassSchema.class);
+        //
+        assertThat(schema.getType()).isEqualTo(Schema.Type.STRING);
+    }
+
+    @Test
+    public void testFieldOverride() {
+        Schema schema = schemaFunctor.apply(OverriddenFieldSchema.class);
+        //
+        assertThat(schema.getType()).isEqualTo(Schema.Type.RECORD);
+        assertThat(schema.getField("myField").schema().getType()).isEqualTo(Schema.Type.INT);
+    }
+
+    @Test
+    public void testRecursiveFieldOverride() {
+        Schema schema = schemaFunctor.apply(OverriddenFieldSchema.class);
+        //
+        assertThat(schema.getType()).isEqualTo(Schema.Type.RECORD);
+        assertThat(schema.getField("recursiveOverride").schema().getType()).isEqualTo(Schema.Type.UNION);
+        assertThat(schema.getField("recursiveOverride").schema().getTypes().get(0).getType()).isEqualTo(Schema.Type.NULL);
+        assertThat(schema.getField("recursiveOverride").schema().getTypes().get(1).getType()).isEqualTo(Schema.Type.STRING);
+    }
+
+    @Test
+    public void testOverridePrecedence() {
+        Schema schema = schemaFunctor.apply(OverriddenFieldSchema.class);
+        //
+        assertThat(schema.getType()).isEqualTo(Schema.Type.RECORD);
+        assertThat(schema.getField("precedenceField").schema().getType()).isEqualTo(Schema.Type.LONG);
+    }
+
+}


### PR DESCRIPTION
This adds support for `@AvroMeta`, which allows a custom property to be added to the schema of a class, and `@AvroSchema`, which allows the schema for a class or field to be overridden entirely (including any `@AvroMeta` annotation which might also be applied). Support for using the class and property descriptions from the `AnnotationIntrospector` as schema and field documentation was also added.