### PR TITLE
[Avro] Add support for @AvroDefault and @Nullable annotations

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
@@ -1,18 +1,15 @@
 package com.fasterxml.jackson.dataformat.avro;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.avro.reflect.*;
+
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-
-import java.util.Collections;
-import java.util.List;
-
-import org.apache.avro.reflect.AvroAlias;
-import org.apache.avro.reflect.AvroDefault;
-import org.apache.avro.reflect.AvroIgnore;
-import org.apache.avro.reflect.AvroName;
 
 /**
  * Adds support for the following annotations from the Apache Avro implementation:
@@ -22,6 +19,7 @@ import org.apache.avro.reflect.AvroName;
  * <li>{@link AvroDefault @AvroDefault("default value")} - Alias for <code>JsonProperty.defaultValue</code>, to
  *     define default value for generated Schemas
  *   </li>
+ * <li>{@link Nullable @Nullable} - Alias for <code>JsonProperty(required = false)</code></li>
  * </ul>
  *
  * @since 2.9
@@ -69,5 +67,13 @@ public class AvroAnnotationIntrospector extends AnnotationIntrospector
     {
         AvroName ann = _findAnnotation(a, AvroName.class);
         return (ann == null) ? null : PropertyName.construct(ann.value());
+    }
+
+    @Override
+    public Boolean hasRequiredMarker(AnnotatedMember m) {
+        if (_hasAnnotation(m, Nullable.class)) {
+            return false;
+        }
+        return null;
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroDefaultTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroDefaultTest.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.dataformat.avro.interop.annotations;
+
+import com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil;
+
+import org.apache.avro.Schema;
+import org.apache.avro.reflect.AvroDefault;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AvroDefaultTest {
+    static class RecordWithDefaults {
+        @AvroDefault("\"Test Field\"")
+        public String stringField;
+        @AvroDefault("1234")
+        public Integer intField;
+        @AvroDefault("true")
+        public Integer booleanField;
+    }
+
+    @Test
+    public void testUnionBooleanDefault() {
+        Schema apacheSchema = ApacheAvroInteropUtil.getApacheSchema(RecordWithDefaults.class);
+        Schema jacksonSchema = ApacheAvroInteropUtil.getJacksonSchema(RecordWithDefaults.class);
+        //
+        assertThat(jacksonSchema.getField("booleanField").defaultValue()).isEqualTo(apacheSchema.getField("booleanField").defaultValue());
+    }
+
+    @Test
+    public void testUnionIntegerDefault() {
+        Schema apacheSchema = ApacheAvroInteropUtil.getApacheSchema(RecordWithDefaults.class);
+        Schema jacksonSchema = ApacheAvroInteropUtil.getJacksonSchema(RecordWithDefaults.class);
+        //
+        assertThat(jacksonSchema.getField("intField").defaultValue()).isEqualTo(apacheSchema.getField("intField").defaultValue());
+    }
+
+    @Test
+    public void testUnionStringDefault() {
+        Schema apacheSchema = ApacheAvroInteropUtil.getApacheSchema(RecordWithDefaults.class);
+        Schema jacksonSchema = ApacheAvroInteropUtil.getJacksonSchema(RecordWithDefaults.class);
+        //
+        assertThat(jacksonSchema.getField("stringField").defaultValue()).isEqualTo(apacheSchema.getField("stringField").defaultValue());
+    }
+}


### PR DESCRIPTION
This adds support for embedding the default values (Provided by `@AvroDefault` or `@JsonProperty`) into the generated avro schemas. This also adds support for `@Nullable` in case there are multiple annotation introspectors in play and the annotations need to be recognized despite normally being the default.

(reopened against the `master` branch)