### PR TITLE
[Avro] Add support for `@Union` and polymorphic types

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroAnnotationIntrospector.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.avro;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 /**
  * Adds support for the following annotations from the Apache Avro implementation:
  * <ul>
@@ -26,6 +28,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
  * <li>{@link Nullable @Nullable} - Alias for <code>JsonProperty(required = false)</code></li>
  * <li>{@link Stringable @Stringable} - Alias for <code>JsonCreator</code> on the constructor and <code>JsonValue</code> on
  * the {@link #toString()} method. </li>
+ * <li>{@link Union @Union} - Alias for <code>JsonSubTypes</code></li>
  * </ul>
  *
  * @since 2.9
@@ -106,5 +109,18 @@ public class AvroAnnotationIntrospector extends AnnotationIntrospector
             return ToStringSerializer.class;
         }
         return null;
+    }
+
+    @Override
+    public List<NamedType> findSubtypes(Annotated a) {
+        Union union = _findAnnotation(a, Union.class);
+        if (union == null) {
+            return null;
+        }
+        ArrayList<NamedType> names = new ArrayList<>(union.value().length);
+        for (Class<?> subtype : union.value()) {
+            names.add(new NamedType(subtype, AvroSchemaHelper.getTypeId(subtype)));
+        }
+        return names;
     }
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
@@ -1,17 +1,25 @@
 package com.fasterxml.jackson.dataformat.avro;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.core.base.GeneratorBase;
-import com.fasterxml.jackson.core.io.IOContext;
-import com.fasterxml.jackson.dataformat.avro.ser.AvroWriteContext;
-
-import org.apache.avro.io.BinaryEncoder;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+
+import org.apache.avro.io.BinaryEncoder;
+
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.FormatFeature;
+import com.fasterxml.jackson.core.FormatSchema;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.base.GeneratorBase;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.dataformat.avro.ser.AvroWriteContext;
 
 public class AvroGenerator extends GeneratorBase
 {
@@ -379,6 +387,17 @@ public class AvroGenerator extends GeneratorBase
     public final void writeStartObject() throws IOException {
         _avroContext = _avroContext.createChildObjectContext();
         _complete = false;
+    }
+
+    @Override
+    public void writeStartObject(Object forValue) throws IOException {
+        _avroContext = _avroContext.createChildObjectContext(forValue);
+        _complete = false;
+        if(this._writeContext != null && forValue != null) {
+            this._writeContext.setCurrentValue(forValue);
+        }
+
+        this.setCurrentValue(forValue);
     }
 
     @Override

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroMapper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroMapper.java
@@ -1,16 +1,16 @@
 package com.fasterxml.jackson.dataformat.avro;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 
 import org.apache.avro.Schema;
 
 import com.fasterxml.jackson.core.Version;
-
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
 
 /**

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroModule.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroModule.java
@@ -37,6 +37,8 @@ public class AvroModule extends SimpleModule
         addSerializer(File.class, new ToStringSerializer(File.class));
         // 08-Mar-2016, tatu: to fix [dataformat-avro#35], need to prune 'schema' property:
         setSerializerModifier(new AvroSerializerModifier());
+        // Override untyped deserializer to one that checks for type information in the schema before going to default handling
+        addDeserializer(Object.class, new AvroUntypedDeserializer());
     }
 
     @Override

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroParser.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroParser.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.dataformat.avro;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Writer;
 import java.math.BigDecimal;
 
@@ -228,6 +227,16 @@ public abstract class AvroParser extends ParserBase
     }
 
     protected abstract void _initSchema(AvroSchema schema) throws JsonProcessingException;
+
+    @Override
+    public boolean canReadTypeId() {
+        return true;
+    }
+
+    @Override
+    public Object getTypeId() throws IOException {
+        return _avroContext != null ? _avroContext.getTypeId() : null;
+    }
 
     /*
     /**********************************************************

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeDeserializer.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeDeserializer.java
@@ -1,0 +1,74 @@
+package com.fasterxml.jackson.dataformat.avro;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
+
+public class AvroTypeDeserializer extends TypeDeserializerBase {
+
+    protected AvroTypeDeserializer(JavaType baseType, TypeIdResolver idRes, String typePropertyName, boolean typeIdVisible,
+                                   JavaType defaultImpl) {
+        super(baseType, idRes, typePropertyName, typeIdVisible, defaultImpl);
+    }
+
+    protected AvroTypeDeserializer(TypeDeserializerBase src, BeanProperty property) {
+        super(src, property);
+    }
+
+    @Override
+    public TypeDeserializer forProperty(BeanProperty prop) {
+        return new AvroTypeDeserializer(this, prop);
+    }
+
+    @Override
+    public JsonTypeInfo.As getTypeInclusion() {
+        // Don't do any restructuring of the incoming JSON tokens
+        return JsonTypeInfo.As.EXISTING_PROPERTY;
+    }
+
+    @Override
+    public Object deserializeTypedFromObject(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return deserializeTypedFromAny(p, ctxt);
+    }
+
+    @Override
+    public Object deserializeTypedFromArray(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return deserializeTypedFromAny(p, ctxt);
+    }
+
+    @Override
+    public Object deserializeTypedFromScalar(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return deserializeTypedFromAny(p, ctxt);
+    }
+
+    @Override
+    public Object deserializeTypedFromAny(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (p.getTypeId() == null && getDefaultImpl() == null) {
+            JsonDeserializer<Object> deser = _findDeserializer(ctxt, AvroSchemaHelper.getTypeId(_baseType));
+            if (deser == null) {
+                ctxt.reportInputMismatch(_baseType, "No (native) type id found when one was expected for polymorphic type handling");
+                return null;
+            }
+            return deser.deserialize(p, ctxt);
+        }
+        return _deserializeWithNativeTypeId(p, ctxt, p.getTypeId());
+    }
+
+    @Override
+    protected JavaType _handleUnknownTypeId(DeserializationContext ctxt, String typeId)
+        throws IOException {
+        if (ctxt.hasValueDeserializerFor(_baseType, null)) {
+            return _baseType;
+        }
+        return super._handleUnknownTypeId(ctxt, typeId);
+    }
+}

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeIdResolver.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeIdResolver.java
@@ -1,0 +1,63 @@
+package com.fasterxml.jackson.dataformat.avro;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.jsontype.impl.ClassNameIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+/**
+ * {@link com.fasterxml.jackson.databind.jsontype.TypeIdResolver} for Avro type IDs embedded in schemas. Avro generally uses class names,
+ * but we want to also support named subtypes so that developers can easily remap the embedded type IDs to a different runtime class.
+ */
+public class AvroTypeIdResolver extends ClassNameIdResolver {
+
+    private final Map<String, Class<?>> _idTypes = new HashMap<>();
+
+    private final Map<Class<?>, String> _typeIds = new HashMap<>();
+
+    public AvroTypeIdResolver(JavaType baseType, TypeFactory typeFactory, Collection<NamedType> subTypes) {
+        this(baseType, typeFactory);
+        if (subTypes != null) {
+            for (NamedType namedType : subTypes) {
+                registerSubtype(namedType.getType(), namedType.getName());
+            }
+        }
+    }
+
+    public AvroTypeIdResolver(JavaType baseType, TypeFactory typeFactory) {
+        super(baseType, typeFactory);
+    }
+
+    @Override
+    public void registerSubtype(Class<?> type, String name) {
+        _idTypes.put(name, type);
+        _typeIds.put(type, name);
+    }
+
+    @Override
+    protected JavaType _typeFromId(String id, DatabindContext ctxt) throws IOException {
+        // base types don't have subclasses
+        if (_baseType.isPrimitive()) {
+            return _baseType;
+        }
+        // check if there's a specific type we should be using for this ID
+        Class<?> subType = _idTypes.get(id);
+        if (subType != null) {
+            id = _idFrom(null, subType, _typeFactory);
+        }
+        try {
+            return super._typeFromId(id, ctxt);
+        } catch (InvalidTypeIdException | IllegalArgumentException e) {
+            // AvroTypeDeserializer expects null if we can't map the type ID to a class; It will throw an appropriate error if we can't
+            // find a usable type.
+            return null;
+        }
+    }
+}

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeResolverBuilder.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeResolverBuilder.java
@@ -1,0 +1,50 @@
+package com.fasterxml.jackson.dataformat.avro;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
+
+
+public class AvroTypeResolverBuilder extends StdTypeResolverBuilder {
+
+    public AvroTypeResolverBuilder() {
+        super();
+        typeIdVisibility(false).typeProperty("@class");
+    }
+
+    @Override
+    public TypeSerializer buildTypeSerializer(SerializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
+        // All type information is encoded in the schema, never in the data.
+        return null;
+    }
+
+    @Override
+    public TypeDeserializer buildTypeDeserializer(DeserializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
+        JavaType defaultImpl = null;
+        if (getDefaultImpl() != null) {
+            defaultImpl = config.constructType(getDefaultImpl());
+        }
+
+        return new AvroTypeDeserializer(baseType,
+                                        idResolver(config, baseType, subtypes, true, true),
+                                        getTypeProperty(),
+                                        isTypeIdVisible(),
+                                        defaultImpl
+        );
+
+    }
+
+    @Override
+    protected TypeIdResolver idResolver(MapperConfig<?> config, JavaType baseType, Collection<NamedType> subtypes, boolean forSer,
+                                        boolean forDeser) {
+        return new AvroTypeIdResolver(baseType, config.getTypeFactory(), subtypes);
+    }
+}

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroUntypedDeserializer.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroUntypedDeserializer.java
@@ -1,0 +1,131 @@
+package com.fasterxml.jackson.dataformat.avro;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+
+/**
+ * Deserializer for handling when we have no target type, just schema type. Normally, the {@link UntypedObjectDeserializer} doesn't look
+ * for native type information when handling scalar values, but Avro sometimes includes type information in the schema for scalar values;
+ * This subclass checks for the presence of valid type information and calls out to the type deserializer even for scalar values. The
+ * same goes for map keys.
+ */
+public class AvroUntypedDeserializer extends UntypedObjectDeserializer {
+
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        // Make sure we have a native type ID *AND* that we can resolve it to a type; otherwise, we'll end up in a recursive loop
+        if (p.canReadTypeId() && p.getTypeId() != null) {
+            TypeDeserializer deser = ctxt.getConfig().findTypeDeserializer(ctxt.constructType(Object.class));
+            if (deser != null) {
+                TypeIdResolver resolver = deser.getTypeIdResolver();
+                if (resolver != null && resolver.typeFromId(ctxt, p.getTypeId().toString()) != null) {
+                    return deser.deserializeTypedFromAny(p, ctxt);
+                }
+            }
+        }
+        return super.deserialize(p, ctxt);
+    }
+
+    @Override
+    public Object deserializeWithType(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+        // Use type deserializer if we have type information, even for scalar values
+        if (p.canReadTypeId() && p.getTypeId() != null && typeDeserializer != null) {
+            TypeIdResolver resolver = typeDeserializer.getTypeIdResolver();
+            // Make sure that we actually can resolve the type ID, otherwise we'll end up in a recursive loop
+            if (resolver != null && resolver.typeFromId(ctxt, p.getTypeId().toString()) != null) {
+                return typeDeserializer.deserializeTypedFromAny(p, ctxt);
+            }
+        }
+        return super.deserializeWithType(p, ctxt, typeDeserializer);
+    }
+
+    /**
+     * Method called to map a JSON Object into a Java value.
+     */
+    // Would we just be better off deferring to the Map<Object,Object> deserializer?
+    protected Object mapObject(JsonParser p, DeserializationContext ctxt) throws IOException {
+        Object key1;
+        JsonToken t = p.getCurrentToken();
+
+        if (t == JsonToken.START_OBJECT) {
+
+            key1 = p.nextFieldName();
+        } else if (t == JsonToken.FIELD_NAME) {
+            key1 = p.getCurrentName();
+        } else {
+            if (t != JsonToken.END_OBJECT) {
+                return ctxt.handleUnexpectedToken(handledType(), p);
+            }
+            key1 = null;
+        }
+        if (key1 == null) {
+            // empty map might work; but caller may want to modify... so better just give small modifiable
+            return new LinkedHashMap<>(2);
+        }
+
+        KeyDeserializer deserializer = null;
+        if (p.getTypeId() != null) {
+            TypeDeserializer typeDeserializer = ctxt.getConfig().findTypeDeserializer(ctxt.constructType(Object.class));
+            if (typeDeserializer != null) {
+                TypeIdResolver idResolver = typeDeserializer.getTypeIdResolver();
+                JavaType keyType = idResolver.typeFromId(ctxt, p.getTypeId().toString());
+                if (keyType != null) {
+                    deserializer = ctxt.findKeyDeserializer(keyType, null);
+                }
+            }
+        }
+        if (deserializer != null) {
+            key1 = deserializer.deserializeKey(key1.toString(), ctxt);
+        }
+        // minor optimization; let's handle 1 and 2 entry cases separately
+        // 24-Mar-2015, tatu: Ideally, could use one of 'nextXxx()' methods, but for
+        //   that we'd need new method(s) in JsonDeserializer. So not quite yet.
+        p.nextToken();
+        Object value1 = deserialize(p, ctxt);
+
+        Object key2 = p.nextFieldName();
+        if (key2 == null) { // has to be END_OBJECT, then
+            // single entry; but we want modifiable
+            LinkedHashMap<Object, Object> result = new LinkedHashMap<>(2);
+            result.put(key1, value1);
+            return result;
+        }
+        if (deserializer != null) {
+            key2 = deserializer.deserializeKey(key2.toString(), ctxt);
+        }
+
+        p.nextToken();
+        Object value2 = deserialize(p, ctxt);
+
+        Object key = p.nextFieldName();
+
+        if (key == null) {
+            LinkedHashMap<Object, Object> result = new LinkedHashMap<>(4);
+            result.put(key1, value1);
+            result.put(key2, value2);
+            return result;
+        }
+        // And then the general case; default map size is 16
+        LinkedHashMap<Object, Object> result = new LinkedHashMap<>();
+        result.put(key1, value1);
+        result.put(key2, value2);
+
+        do {
+            if (deserializer != null) {
+                key = deserializer.deserializeKey(key.toString(), ctxt);
+            }
+            p.nextToken();
+            result.put(key, deserialize(p, ctxt));
+        } while ((key = p.nextFieldName()) != null);
+        return result;
+    }
+}

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroFieldReader.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroFieldReader.java
@@ -12,10 +12,12 @@ public abstract class AvroFieldReader
 {
     protected final String _name;
     protected final boolean _isSkipper;
+    protected final String _typeId;
 
-    protected AvroFieldReader(String name, boolean isSkipper) {
+    protected AvroFieldReader(String name, boolean isSkipper, String typeId) {
         _name = name;
         _isSkipper = isSkipper;
+        _typeId = typeId;
     }
 
     public static AvroFieldReader construct(String name, AvroStructureReader structureReader) {
@@ -33,6 +35,10 @@ public abstract class AvroFieldReader
 
     public abstract void skipValue(AvroParserImpl parser) throws IOException;
 
+    public String getTypeId() {
+        return _typeId;
+    }
+
     /**
      * Implementation used for non-scalar-valued (structured) fields
      */
@@ -40,7 +46,7 @@ public abstract class AvroFieldReader
         protected final AvroStructureReader _reader;
 
         public Structured(String name, boolean skipper, AvroStructureReader r) {
-            super(name, skipper);
+            super(name, skipper, null);
             _reader = r;
         }
 
@@ -53,6 +59,11 @@ public abstract class AvroFieldReader
         @Override
         public void skipValue(AvroParserImpl parser) throws IOException {
             _reader.skipValue(parser);
+        }
+
+        @Override
+        public String getTypeId() {
+            return _reader.getTypeId();
         }
     }
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReadContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReadContext.java
@@ -13,16 +13,19 @@ public abstract class AvroReadContext extends JsonStreamContext
 {
     protected final AvroReadContext _parent;
 
+    protected final String _typeId;
+
     /*
     /**********************************************************************
     /* Instance construction
     /**********************************************************************
      */
 
-    public AvroReadContext(AvroReadContext parent)
+    public AvroReadContext(AvroReadContext parent, String typeId)
     {
         super();
         _parent = parent;
+        _typeId = typeId;
     }
 
     public abstract JsonToken nextToken() throws IOException;
@@ -44,6 +47,10 @@ public abstract class AvroReadContext extends JsonStreamContext
     public final AvroReadContext getParent() { return _parent; }
     
     protected abstract void appendDesc(StringBuilder sb);
+
+    public String getTypeId() {
+        return _typeId;
+    }
 
     // !!! TODO: implement from here
     /**

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
@@ -22,7 +22,6 @@ public abstract class AvroReaderFactory
     protected final static ScalarDecoder READER_LONG = new LongReader();
     protected final static ScalarDecoder READER_NULL = new NullReader();
     protected final static ScalarDecoder READER_STRING = new StringReader();
-    protected final static ScalarDecoder READER_CHAR = new CharReader();
 
     /**
      * To resolve cyclic types, need to keep track of resolved named
@@ -62,21 +61,24 @@ public abstract class AvroReaderFactory
         case DOUBLE: 
             return READER_DOUBLE;
         case ENUM: 
-            return new EnumDecoder(type.getFullName(), type.getEnumSymbols());
+            return new EnumDecoder(AvroSchemaHelper.getFullName(type), type.getEnumSymbols());
         case FIXED: 
-            return new FixedDecoder(type.getFixedSize());
+            return new FixedDecoder(type.getFixedSize(), AvroSchemaHelper.getFullName(type));
         case FLOAT: 
             return READER_FLOAT;
         case INT:
-            if (Character.class.getName().equals(type.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS))) {
-                return READER_CHAR;
+            if (AvroSchemaHelper.getTypeId(type) != null) {
+                return new IntReader(AvroSchemaHelper.getTypeId(type));
             }
             return READER_INT;
         case LONG: 
             return READER_LONG;
         case NULL: 
             return READER_NULL;
-        case STRING: 
+        case STRING:
+            if (AvroSchemaHelper.getTypeId(type) != null) {
+                return new StringReader(AvroSchemaHelper.getTypeId(type));
+            }
             return READER_STRING;
         case UNION:
             /* Union is a "scalar union" if all the alternative types
@@ -118,7 +120,7 @@ public abstract class AvroReaderFactory
      */
     public AvroStructureReader createReader(Schema schema)
     {
-        AvroStructureReader reader = _knownReaders.get(_typeName(schema));
+        AvroStructureReader reader = _knownReaders.get(AvroSchemaHelper.getFullName(schema));
         if (reader != null) {
             return reader;
         }
@@ -141,28 +143,45 @@ public abstract class AvroReaderFactory
     {
         Schema elementType = schema.getElementType();
         ScalarDecoder scalar = createScalarValueDecoder(elementType);
-        if (scalar != null) {
-            return ArrayReader.construct(scalar);
+        String typeId = AvroSchemaHelper.getTypeId(schema);
+        String elementTypeId = schema.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_ELEMENT_CLASS);
+        if (elementTypeId == null) {
+            elementTypeId = AvroSchemaHelper.getTypeId(elementType);
         }
-        return ArrayReader.construct(createReader(elementType));
+
+        if (scalar != null) {
+            // EnumSet has to know element type information up front; take advantage of the fact that the id resolver handles canonical IDs
+            if (EnumSet.class.getName().equals(typeId)) {
+                typeId += "<" + elementTypeId + ">";
+            }
+            return ArrayReader.construct(scalar, typeId, elementTypeId);
+        }
+        return ArrayReader.construct(createReader(elementType), typeId, elementTypeId);
     }
 
     protected AvroStructureReader createMapReader(Schema schema)
     {
         Schema elementType = schema.getValueType();
         ScalarDecoder dec = createScalarValueDecoder(elementType);
-        if (dec != null) {
-            return MapReader.construct(dec);
+        String typeId = AvroSchemaHelper.getTypeId(schema);
+        String keyTypeId = schema.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_KEY_CLASS);
+        // EnumMap requires value type information up front; take advantage of the fact that the id resolver handles canonical IDs
+        if (EnumMap.class.getName().equals(typeId)) {
+            typeId += "<" + keyTypeId + "," + Object.class.getName() + ">";
         }
-        return MapReader.construct(createReader(elementType));
+        if (dec != null) {
+            String valueTypeId = AvroSchemaHelper.getTypeId(elementType);
+            return MapReader.construct(dec, typeId, keyTypeId, valueTypeId);
+        }
+        return MapReader.construct(createReader(elementType), typeId, keyTypeId);
     }
 
     protected AvroStructureReader createRecordReader(Schema schema)
     {
         final List<Schema.Field> fields = schema.getFields();
         AvroFieldReader[] fieldReaders = new AvroFieldReader[fields.size()];
-        RecordReader reader = new RecordReader.Std(fieldReaders);
-        _knownReaders.put(_typeName(schema), reader);
+        RecordReader reader = new RecordReader.Std(fieldReaders, AvroSchemaHelper.getTypeId(schema));
+        _knownReaders.put(AvroSchemaHelper.getFullName(schema), reader);
         int i = 0;
         for (Schema.Field field : fields) {
             fieldReaders[i++] = createFieldReader(field);
@@ -190,16 +209,6 @@ public abstract class AvroReaderFactory
             return scalar.asFieldReader(name, false);
         }
         return AvroFieldReader.construct(name, createReader(type));
-    }
-
-    /*
-    /**********************************************************************
-    /* Internal methods
-    /**********************************************************************
-     */
-
-    protected final String _typeName(Schema schema) {
-        return schema.getFullName();
     }
 
     /*
@@ -234,7 +243,7 @@ public abstract class AvroReaderFactory
         {
             // NOTE: it is assumed writer-schema has been modified with aliases so
             //   that the names are same, so we could use either name:
-            AvroStructureReader reader = _knownReaders.get(_typeName(readerSchema));
+            AvroStructureReader reader = _knownReaders.get(AvroSchemaHelper.getFullName(readerSchema));
             if (reader != null) {
                 return reader;
             }
@@ -260,11 +269,13 @@ public abstract class AvroReaderFactory
             readerSchema = _verifyMatchingStructure(readerSchema, writerSchema);
             Schema writerElementType = writerSchema.getElementType();
             ScalarDecoder scalar = createScalarValueDecoder(writerElementType);
+            String typeId = AvroSchemaHelper.getTypeId(readerSchema);
+            String elementTypeId = readerSchema.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_ELEMENT_CLASS);
+
             if (scalar != null) {
-                return ArrayReader.construct(scalar);
+                return ArrayReader.construct(scalar, typeId, elementTypeId);
             }
-            return ArrayReader.construct(createReader(writerElementType,
-                    readerSchema.getElementType()));
+            return ArrayReader.construct(createReader(writerElementType, readerSchema.getElementType()), typeId, elementTypeId);
         }
 
         protected AvroStructureReader createMapReader(Schema writerSchema, Schema readerSchema)
@@ -272,11 +283,13 @@ public abstract class AvroReaderFactory
             readerSchema = _verifyMatchingStructure(readerSchema, writerSchema);
             Schema writerElementType = writerSchema.getValueType();
             ScalarDecoder dec = createScalarValueDecoder(writerElementType);
+            String typeId = AvroSchemaHelper.getTypeId(readerSchema);
+            String keyTypeId = readerSchema.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_KEY_CLASS);
             if (dec != null) {
-                return MapReader.construct(dec);
+                String valueTypeId = readerSchema.getValueType().getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS);
+                return MapReader.construct(dec, typeId, keyTypeId, valueTypeId);
             }
-            return MapReader.construct(createReader(writerElementType,
-                    readerSchema.getElementType()));
+            return MapReader.construct(createReader(writerElementType, readerSchema.getElementType()), typeId, keyTypeId);
         }
 
         protected AvroStructureReader createRecordReader(Schema writerSchema, Schema readerSchema)
@@ -312,10 +325,10 @@ public abstract class AvroReaderFactory
             // ones from writer schema -- some may skip, but there's entry there
             AvroFieldReader[] fieldReaders = new AvroFieldReader[writerFields.size()
                                                                    + defaultFields.size()];
-            RecordReader reader = new RecordReader.Resolving(fieldReaders);
+            RecordReader reader = new RecordReader.Resolving(fieldReaders, AvroSchemaHelper.getTypeId(readerSchema));
 
             // as per earlier, names should be the same
-            _knownReaders.put(_typeName(readerSchema), reader);
+            _knownReaders.put(AvroSchemaHelper.getFullName(readerSchema), reader);
             int i = 0;
             for (Schema.Field writerField : writerFields) {
                 Schema.Field readerField = readerFields.get(writerField.name());

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroStructureReader.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroStructureReader.java
@@ -14,8 +14,8 @@ public abstract class AvroStructureReader
 {
     protected JsonToken _currToken;
 
-    protected AvroStructureReader(AvroReadContext parent, int type) {
-        super(parent);
+    protected AvroStructureReader(AvroReadContext parent, int type, String typeId) {
+        super(parent, typeId);
         _type = type;
     }
     

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/MapReader.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/MapReader.java
@@ -13,26 +13,30 @@ public abstract class MapReader extends AvroStructureReader
     protected final static int STATE_DONE = 4;
 
     protected final AvroParserImpl _parser;
+    protected final String _keyTypeId;
+    protected final String _valueTypeId;
 
     protected String _currentName;
 
     protected int _state;
     
-    protected MapReader() {
-        this(null, null);
+    protected MapReader(String typeId, String keyTypeId, String valueTypeId) {
+        this(null, null, typeId, keyTypeId, valueTypeId);
     }
 
-    protected MapReader(AvroReadContext parent, AvroParserImpl parser) {
-        super(parent, TYPE_OBJECT);
+    protected MapReader(AvroReadContext parent, AvroParserImpl parser, String typeId, String keyTypeId, String valueTypeId) {
+        super(parent, TYPE_OBJECT, typeId);
         _parser = parser;
+        _keyTypeId = keyTypeId;
+        _valueTypeId = valueTypeId;
     }
 
-    public static MapReader construct(ScalarDecoder dec) {
-        return new Scalar(dec);
+    public static MapReader construct(ScalarDecoder dec, String typeId, String keyTypeId, String valueTypeId) {
+        return new Scalar(dec, typeId, keyTypeId, valueTypeId);
     }
 
-    public static MapReader construct(AvroStructureReader reader) {
-        return new NonScalar(reader);
+    public static MapReader construct(AvroStructureReader reader, String typeId, String keyTypeId) {
+        return new NonScalar(reader, typeId, keyTypeId);
     }
 
     @Override
@@ -70,6 +74,17 @@ public abstract class MapReader extends AvroStructureReader
         sb.append('}');
     }
 
+    @Override
+    public String getTypeId() {
+        if (_currToken == JsonToken.START_OBJECT || _currToken == JsonToken.END_OBJECT) {
+            return super.getTypeId();
+        }
+        if (_currToken == JsonToken.FIELD_NAME && _state == STATE_VALUE) {
+            return _keyTypeId;
+        }
+        return _valueTypeId;
+    }
+
     /*
     /**********************************************************************
     /* Implementations
@@ -81,19 +96,20 @@ public abstract class MapReader extends AvroStructureReader
         private final ScalarDecoder _scalarDecoder;
         protected long _count;
 
-        protected Scalar(ScalarDecoder dec) {
+        protected Scalar(ScalarDecoder dec, String typeId, String keyTypeId, String valueTypeId) {
+            super(typeId, keyTypeId, valueTypeId != null ? valueTypeId : dec.getTypeId());
             _scalarDecoder = dec;
         }
 
         protected Scalar(AvroReadContext parent,
-                AvroParserImpl parser, ScalarDecoder sd) {
-            super(parent, parser);
+                AvroParserImpl parser, ScalarDecoder sd, String typeId, String keyTypeId, String valueTypeId) {
+            super(parent, parser, typeId, keyTypeId, valueTypeId != null ? valueTypeId : sd.getTypeId());
             _scalarDecoder = sd;
         }
         
         @Override
         public MapReader newReader(AvroReadContext parent, AvroParserImpl parser) {
-            return new Scalar(parent, parser, _scalarDecoder);
+            return new Scalar(parent, parser, _scalarDecoder, _typeId, _keyTypeId, _valueTypeId);
         }
 
         @Override
@@ -152,19 +168,20 @@ public abstract class MapReader extends AvroStructureReader
         private final AvroStructureReader _structureReader;
         protected long _count;
 
-        public NonScalar(AvroStructureReader reader) {
+        public NonScalar(AvroStructureReader reader, String typeId, String keyTypeId) {
+            super(typeId, keyTypeId, null);
             _structureReader = reader;
         }
 
         public NonScalar(AvroReadContext parent,
-                AvroParserImpl parser, AvroStructureReader reader) {
-            super(parent, parser);
+                AvroParserImpl parser, AvroStructureReader reader, String typeId, String keyTypeId) {
+            super(parent, parser, typeId, keyTypeId, null);
             _structureReader = reader;
         }
         
         @Override
         public MapReader newReader(AvroReadContext parent, AvroParserImpl parser) {
-            return new NonScalar(parent, parser, _structureReader);
+            return new NonScalar(parent, parser, _structureReader, _typeId, _keyTypeId);
         }
         @Override
         public JsonToken nextToken() throws IOException

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/MissingReader.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/MissingReader.java
@@ -9,7 +9,7 @@ public class MissingReader extends AvroReadContext
     public final static MissingReader instance = new MissingReader();
     
     public MissingReader() {
-        super(null);
+        super(null, null);
         _type = TYPE_ROOT;
     }
 

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/RootReader.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/RootReader.java
@@ -15,7 +15,7 @@ public final class RootReader extends AvroReadContext
 
     public RootReader(AvroParserImpl parser,
             AvroStructureReader valueReader) {
-        super(null);
+        super(null, null);
         _type = TYPE_ROOT;
         _parser = parser;
         _valueReader = valueReader;
@@ -46,5 +46,10 @@ public final class RootReader extends AvroReadContext
     public String nextFieldName() throws IOException {
         AvroStructureReader r = _valueReader.newReader(this, _parser);
         return r.nextFieldName();
+    }
+
+    @Override
+    public String getTypeId() {
+        return _valueReader.getTypeId();
     }
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 
 /**
  * Helper classes for reading non-structured values, and can thereby usually
@@ -19,6 +20,8 @@ public abstract class ScalarDecoder
         throws IOException;
 
     public abstract AvroFieldReader asFieldReader(String name, boolean skipper);
+
+    public abstract String getTypeId();
     
     /*
     /**********************************************************************
@@ -39,13 +42,18 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return AvroSchemaHelper.getTypeId(boolean.class);
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
+            return new FR(name, skipper, getTypeId());
         }
         
         private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, String typeId) {
+                super(name, skipper, typeId);
             }
 
             @Override
@@ -73,13 +81,18 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return AvroSchemaHelper.getTypeId(double.class);
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
+            return new FR(name, skipper, getTypeId());
         }
         
         private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, String typeId) {
+                super(name, skipper, typeId);
             }
 
             @Override
@@ -106,13 +119,18 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return AvroSchemaHelper.getTypeId(float.class);
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
+            return new FR(name, skipper, getTypeId());
         }
         
         private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, String typeId) {
+                super(name, skipper, typeId);
             }
 
             @Override
@@ -129,9 +147,24 @@ public abstract class ScalarDecoder
     
     protected final static class IntReader extends ScalarDecoder
     {
+        private final String _typeId;
+
+        public IntReader(String typeId) {
+            _typeId = typeId;
+        }
+
+        public IntReader() {
+            this(AvroSchemaHelper.getTypeId(int.class));
+        }
+
         @Override
         public JsonToken decodeValue(AvroParserImpl parser) throws IOException {
-            return parser.decodeIntToken();
+            JsonToken token = parser.decodeIntToken();
+            // Character deserializer expects parser.getText() to return something. Make sure it's populated!
+            if (Character.class.getName().equals(getTypeId())) {
+                return parser.setString(Character.toString((char) parser.getIntValue()));
+            }
+            return token;
         }
 
         @Override
@@ -140,13 +173,18 @@ public abstract class ScalarDecoder
         }
 
         @Override
-        public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
+        public String getTypeId() {
+            return _typeId;
         }
-        
+
+        @Override
+        public AvroFieldReader asFieldReader(String name, boolean skipper) {
+            return new FR(name, skipper, getTypeId());
+        }
+
         private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, String typeId) {
+                super(name, skipper, typeId);
             }
 
             @Override
@@ -172,16 +210,22 @@ public abstract class ScalarDecoder
         protected void skipValue(AvroParserImpl parser) throws IOException {
             parser.skipLong();
         }
-
+        
+        @Override
+        public String getTypeId() {
+            return AvroSchemaHelper.getTypeId(long.class);
+        }
+        
         @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
+            return new FR(name, skipper, getTypeId());
         }
         
         private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, String typeId) {
+                super(name, skipper, typeId);
             }
+
 
             @Override
             public JsonToken readValue(AvroReadContext parent, AvroParserImpl parser) throws IOException {
@@ -191,41 +235,6 @@ public abstract class ScalarDecoder
             @Override
             public void skipValue(AvroParserImpl parser) throws IOException {
                 parser.skipLong();
-            }
-        }
-    }
-
-    protected final static class CharReader extends ScalarDecoder {
-        @Override
-        public JsonToken decodeValue(AvroParserImpl parser) throws IOException {
-            return parser.setString(Character.toString((char)parser.decodeInt()));
-        }
-
-        @Override
-        protected void skipValue(AvroParserImpl parser) throws IOException {
-            // ints use variable-length zigzagging; alas, no native skipping
-            parser.skipInt();
-        }
-
-        @Override
-        public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
-        }
-
-        private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
-            }
-
-            @Override
-            public JsonToken readValue(AvroReadContext parent, AvroParserImpl parser)
-                    throws IOException {
-                return parser.setString(Character.toString((char) parser.decodeInt()));
-            }
-
-            @Override
-            public void skipValue(AvroParserImpl parser) throws IOException {
-                parser.skipInt();
             }
         }
     }
@@ -243,13 +252,18 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return null;
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
             return new FR(name, skipper);
         }
         
         private final static class FR extends AvroFieldReader {
             public FR(String name, boolean skipper) {
-                super(name, skipper);
+                super(name, skipper, null);
             }
 
             @Override
@@ -264,6 +278,16 @@ public abstract class ScalarDecoder
     
     protected final static class StringReader extends ScalarDecoder
     {
+        private final String _typeId;
+
+        public StringReader(String typeId) {
+            _typeId = typeId;
+        }
+
+        public StringReader() {
+            this(AvroSchemaHelper.getTypeId(String.class));
+        }
+
         @Override
         public JsonToken decodeValue(AvroParserImpl parser) throws IOException {
             return parser.decodeString();
@@ -275,13 +299,18 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return _typeId;
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
+            return new FR(name, skipper, getTypeId());
         }
         
         private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, String typeId) {
+                super(name, skipper, typeId);
             }
 
             @Override
@@ -307,15 +336,19 @@ public abstract class ScalarDecoder
         protected void skipValue(AvroParserImpl parser) throws IOException {
             parser.skipBytes();
         }
+        @Override
+        public String getTypeId() {
+            return AvroSchemaHelper.getTypeId(byte[].class);
+        }
 
         @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper);
+            return new FR(name, skipper, getTypeId());
         }
         
         private final static class FR extends AvroFieldReader {
-            public FR(String name, boolean skipper) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, String typeId) {
+                super(name, skipper, typeId);
             }
 
             @Override
@@ -358,6 +391,11 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return null;
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
             return new FR(name, skipper, _readers);
         }
@@ -366,7 +404,7 @@ public abstract class ScalarDecoder
             public final ScalarDecoder[] _readers;
 
             public FR(String name, boolean skipper, ScalarDecoder[] readers) {
-                super(name, skipper);
+                super(name, skipper, null);
                 _readers = readers;
             }
 
@@ -421,15 +459,20 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return _name;
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper, this);
+            return new FR(name, skipper, this, _name);
         }
         
         private final static class FR extends AvroFieldReader {
             protected final String[] _values;
 
-            public FR(String name, boolean skipper, EnumDecoder base) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, EnumDecoder base, String typeId) {
+                super(name, skipper, typeId);
                 _values = base._values;
             }
 
@@ -458,9 +501,11 @@ public abstract class ScalarDecoder
         extends ScalarDecoder
     {
         private final int _size;
+        private final String _typeId;
         
-        public FixedDecoder(int fixedSize) {
+        public FixedDecoder(int fixedSize, String typeId) {
             _size = fixedSize;
+            _typeId = typeId;
         }
         
         @Override
@@ -474,15 +519,20 @@ public abstract class ScalarDecoder
         }
 
         @Override
+        public String getTypeId() {
+            return _typeId;
+        }
+
+        @Override
         public AvroFieldReader asFieldReader(String name, boolean skipper) {
-            return new FR(name, skipper, _size);
+            return new FR(name, skipper, _size, _typeId);
         }
         
         private final static class FR extends AvroFieldReader {
             private final int _size;
 
-            public FR(String name, boolean skipper, int size) {
-                super(name, skipper);
+            public FR(String name, boolean skipper, int size, String typeId) {
+                super(name, skipper, typeId);
                 _size = size;
             }
 

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoderWrapper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoderWrapper.java
@@ -24,7 +24,7 @@ final class ScalarDecoderWrapper extends AvroStructureReader
     private ScalarDecoderWrapper(AvroReadContext parent,
             AvroParserImpl parser, ScalarDecoder valueDecoder)
     {
-        super(parent, TYPE_ROOT);
+        super(parent, TYPE_ROOT, null);
         _valueDecoder = valueDecoder;
         _parser = parser;
     }
@@ -39,6 +39,11 @@ final class ScalarDecoderWrapper extends AvroStructureReader
     {
         _parser.setAvroContext(getParent());
         return (_currToken = _valueDecoder.decodeValue(_parser));
+    }
+
+    @Override
+    public String getTypeId() {
+        return _valueDecoder.getTypeId();
     }
 
     @Override

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDefaults.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDefaults.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.avro.deser;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 
 /**
  * Container for various {@link ScalarDecoder} implementations that are
@@ -13,8 +14,8 @@ public class ScalarDefaults
     protected abstract static class DefaultsBase
         extends AvroFieldReader
     {
-        protected DefaultsBase(String name) {
-            super(name, false); // false -> not skip-only
+        protected DefaultsBase(String name, String typeId) {
+            super(name, false, typeId); // false -> not skip-only
         }
 
         @Override
@@ -32,7 +33,7 @@ public class ScalarDefaults
         protected final JsonToken _defaults;
 
         public BooleanDefaults(String name, boolean v) {
-            super(name);
+            super(name, AvroSchemaHelper.getTypeId(boolean.class));
             _defaults = v ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE;
         }
 
@@ -47,7 +48,7 @@ public class ScalarDefaults
         protected final String _defaults;
 
         public StringDefaults(String name, String v) {
-            super(name);
+            super(name, AvroSchemaHelper.getTypeId(String.class));
             _defaults = v;
         }
 
@@ -62,7 +63,7 @@ public class ScalarDefaults
         protected final byte[] _defaults;
 
         public BytesDefaults(String name, byte[] v) {
-            super(name);
+            super(name, AvroSchemaHelper.getTypeId(byte[].class));
             _defaults = v;
         }
 
@@ -77,7 +78,7 @@ public class ScalarDefaults
         protected final double _defaults;
 
         public DoubleDefaults(String name, double v) {
-            super(name);
+            super(name, AvroSchemaHelper.getTypeId(double.class));
             _defaults = v;
         }
 
@@ -92,7 +93,7 @@ public class ScalarDefaults
         protected final float _defaults;
 
         public FloatDefaults(String name, float v) {
-            super(name);
+            super(name, AvroSchemaHelper.getTypeId(float.class));
             _defaults = v;
         }
 
@@ -107,7 +108,7 @@ public class ScalarDefaults
         protected final int _defaults;
 
         public IntDefaults(String name, int v) {
-            super(name);
+            super(name, AvroSchemaHelper.getTypeId(int.class));
             _defaults = v;
         }
 
@@ -122,7 +123,7 @@ public class ScalarDefaults
         protected final long _defaults;
 
         public LongDefaults(String name, long v) {
-            super(name);
+            super(name, AvroSchemaHelper.getTypeId(long.class));
             _defaults = v;
         }
 
@@ -135,7 +136,7 @@ public class ScalarDefaults
     protected final static class NullDefaults extends DefaultsBase
     {
         public NullDefaults(String name) {
-            super(name);
+            super(name, null);
         }
 
         @Override

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/StructDefaults.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/StructDefaults.java
@@ -36,7 +36,7 @@ public class StructDefaults
         public ObjectDefaults(AvroReadContext parent,
                 AvroParserImpl parser, AvroFieldReader[] fieldReaders)
         {
-            super(parent, parser);
+            super(parent, parser, null, null, null);
             _fieldReaders = fieldReaders;
         }
 
@@ -87,7 +87,7 @@ public class StructDefaults
         public ArrayDefaults(AvroReadContext parent,
                 AvroParserImpl parser, AvroFieldReader[] valueReaders)
         {
-            super(parent, parser);
+            super(parent, parser, null, null);
             _valueReaders = valueReaders;
         }
 

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/UnionReader.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/UnionReader.java
@@ -20,7 +20,7 @@ final class UnionReader extends AvroStructureReader
     private UnionReader(AvroReadContext parent,
             AvroStructureReader[] memberReaders, AvroParserImpl parser)
     {
-        super(parent, TYPE_ROOT);
+        super(parent, TYPE_ROOT, null);
         _memberReaders = memberReaders;
         _parser = parser;
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -192,6 +192,10 @@ public abstract class AvroSchemaHelper
         throw new UnsupportedOperationException("Format variation not supported");
     }
 
+    public static String getTypeId(JavaType type) {
+        return getTypeId(type.getRawClass());
+    }
+
     /**
      * Initializes a record schema with metadata from the given class; this schema is returned in a non-finalized state, and still
      * needs to have fields added to it.
@@ -227,11 +231,11 @@ public abstract class AvroSchemaHelper
     /**
      * Returns the Avro type ID for a given type
      */
-    protected static String getTypeId(JavaType type) {
+    public static String getTypeId(Class<?> type) {
         // Primitives use the name of the wrapper class as their type ID
         if (type.isPrimitive()) {
-            return ClassUtil.wrapperType(type.getRawClass()).getName();
+            return ClassUtil.wrapperType(type).getName();
         }
-        return type.getRawClass().getName();
+        return type.getName();
     }
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
@@ -5,6 +5,7 @@ import org.apache.avro.Schema;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonMapFormatVisitor;
 
@@ -32,23 +33,12 @@ public class MapVisitor extends JsonMapFormatVisitor.Base
         if (_valueSchema == null) {
             throw new IllegalStateException("Missing value type for "+_type);
         }
-
-        Schema schema = Schema.createMap(_valueSchema);
-
-        // add the key type if there is one
-        if (_keyType != null && AvroSchemaHelper.isStringable(getProvider()
-                                                                  .getConfig()
-                                                                  .introspectClassAnnotations(_keyType)
-                                                                  .getClassInfo())) {
-            schema.addProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_KEY_CLASS, AvroSchemaHelper.getTypeId(_keyType));
-        } else if (_keyType != null && !_keyType.isEnumType()) {
-            // Avro handles non-stringable keys by converting the map to an array of key/value records
-            // TODO add support for these in the schema, and custom serializers / deserializers to handle map restructuring
-            throw new UnsupportedOperationException(
-                "Key " + _keyType + " is not stringable and non-stringable map keys are not supported yet.");
+        AnnotatedClass ac = _provider.getConfig().introspectClassAnnotations(_keyType).getClassInfo();
+        if (AvroSchemaHelper.isStringable(ac)) {
+            return AvroSchemaHelper.stringableKeyMapSchema(_type, _keyType, _valueSchema);
+        } else {
+            throw new UnsupportedOperationException("Maps with non-stringable keys are not supported yet");
         }
-
-        return schema;
     }
 
     /*

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/StringVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/StringVisitor.java
@@ -52,7 +52,7 @@ public class StringVisitor extends JsonStringFormatVisitor.Base
         }
         Schema schema = Schema.create(Schema.Type.STRING);
         // Stringable classes need to include the type
-        if (AvroSchemaHelper.isStringable(bean.getClassInfo())) {
+        if (AvroSchemaHelper.isStringable(bean.getClassInfo()) && !_type.hasRawClass(String.class)) {
             schema.addProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS, AvroSchemaHelper.getTypeId(_type));
         }
         return schema;

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/ArrayWriteContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/ArrayWriteContext.java
@@ -34,7 +34,14 @@ public final class ArrayWriteContext
         _array.add(child.rawValue());
         return child;
     }
-    
+
+    @Override
+    public AvroWriteContext createChildObjectContext(Object object) throws JsonMappingException {
+        AvroWriteContext child = _createObjectContext(_schema.getElementType(), object);
+        _array.add(child.rawValue());
+        return child;
+    }
+
     @Override
     public void writeValue(Object value) {
         _array.add(value);

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/AvroWriteContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/AvroWriteContext.java
@@ -218,6 +218,10 @@ public abstract class AvroWriteContext
             int subOptimal = -1;
             for(int i = 0, size = unionSchema.getTypes().size(); i < size; i++) {
                 Schema schema = unionSchema.getTypes().get(i);
+                // Exact schema match?
+                if (AvroSchemaHelper.getTypeId(datum.getClass()).equals(AvroSchemaHelper.getTypeId(schema))) {
+                    return i;
+                }
                 if (datum instanceof BigDecimal) {
                     // BigDecimals can be shoved into a double, but optimally would be a String or byte[] with logical type information
                     if (schema.getType() == Type.DOUBLE) {

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
@@ -4,15 +4,12 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.Encoder;
-
-import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 
 /**
  * Need to sub-class to prevent encoder from crapping on writing an optional
@@ -31,52 +28,7 @@ public class NonBSGenericDatumWriter<D>
 
     @Override
     public int resolveUnion(Schema union, Object datum) {
-        // Alas, we need a work-around first...
-        if (datum == null) {
-            return union.getIndexNamed(Type.NULL.getName());
-        }
-        List<Schema> schemas = union.getTypes();
-        if (datum instanceof String) { // String or Enum or Character or char[]
-            for (int i = 0, len = schemas.size(); i < len; i++) {
-                Schema s = schemas.get(i);
-                switch (s.getType()) {
-                case STRING:
-                case ENUM:
-                    return i;
-                case INT:
-                    // Avro distinguishes between String and Character, whereas Jackson doesn't
-                    // Check if the schema is expecting a Character and handle appropriately
-                    if (Character.class.getName().equals(s.getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS))) {
-                        return i;
-                    }
-                    break;
-                case ARRAY:
-                    // Avro distinguishes between String and char[], whereas Jackson doesn't
-                    // Check if the schema is expecting a char[] and handle appropriately
-                    if (s.getElementType().getType() == Type.INT && Character.class
-			    .getName().equals(s.getElementType().getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS))) {
-                        return i;
-                    }
-                    break;
-                default:
-                }
-            }
-        } else if (datum instanceof BigDecimal) {
-            int subOptimal = -1;
-            for (int i = 0, len = schemas.size(); i < len; i++) {
-                if (schemas.get(i).getType() == Type.STRING) {
-                    return i;
-                }
-                if (schemas.get(i).getType() == Type.DOUBLE) {
-                    subOptimal = i;
-                }
-            }
-            if (subOptimal > -1) {
-                return subOptimal;
-            }
-        }
-        // otherwise just default to base impl, stupid as it is...
-        return super.resolveUnion(union, datum);
+        return AvroWriteContext.resolveUnionIndex(union, datum);
     }
 
     @Override

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/ObjectWriteContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/ObjectWriteContext.java
@@ -1,14 +1,15 @@
 package com.fasterxml.jackson.dataformat.avro.ser;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.dataformat.avro.AvroGenerator;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 
-import java.nio.ByteBuffer;
-import java.util.Arrays;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.dataformat.avro.AvroGenerator;
 
 public final class ObjectWriteContext
     extends KeyValueContext
@@ -53,6 +54,18 @@ public final class ObjectWriteContext
             return new NopWriteContext(TYPE_OBJECT, this, _generator);
         }
         AvroWriteContext child = _createObjectContext(field.schema());
+        _record.put(_currentName, child.rawValue());
+        return child;
+    }
+
+    @Override
+    public AvroWriteContext createChildObjectContext(Object object) throws JsonMappingException {
+        _verifyValueWrite();
+        Schema.Field field = _findField();
+        if (field == null) { // unknown, to ignore
+            return new NopWriteContext(TYPE_OBJECT, this, _generator);
+        }
+        AvroWriteContext child = _createObjectContext(field.schema(), object);
         _record.put(_currentName, child.rawValue());
         return child;
     }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
@@ -167,10 +167,6 @@ public abstract class InteropTestBase
     @SuppressWarnings("unchecked")
     protected <T> T roundTrip(Type schemaType, T object) throws IOException {
         Schema schema = schemaFunctor.apply(schemaType);
-        // Temporary hack until jackson supports native type Ids and we don't need to give it a target type
-        if (deserializeFunctor == ApacheAvroInteropUtil.jacksonDeserializer) {
-            return ApacheAvroInteropUtil.jacksonDeserialize(schema, schemaType, serializeFunctor.apply(schema, object));
-        }
         return (T) deserializeFunctor.apply(schema, serializeFunctor.apply(schema, object));
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/UnionTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/UnionTest.java
@@ -1,0 +1,119 @@
+package com.fasterxml.jackson.dataformat.avro.interop.annotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.avro.reflect.Nullable;
+import org.apache.avro.reflect.Union;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.jacksonDeserializer;
+
+/**
+ * Tests for @Union
+ */
+public class UnionTest extends InteropTestBase {
+
+    @Union({ Cat.class, Dog.class })
+    public interface Animal {
+
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Cat implements Animal {
+
+        @Nullable
+        private String color;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Dog implements Animal {
+
+        private int size;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Bird implements Animal {
+
+        private boolean flying;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Cage {
+
+        private Animal animal;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PetShop {
+
+        public PetShop(Animal... pets) {
+            this(Arrays.asList(pets));
+        }
+
+        private List<Animal> pets;
+    }
+
+    /*
+     * Jackson deserializer doesn't understand native TypeIDs yet, so it can't handle deserialization of unions.
+     */
+    @Before
+    public void ignoreJacksonDeserializer() {
+        Assume.assumeTrue(deserializeFunctor != jacksonDeserializer);
+    }
+
+    @Test
+    public void testInterfaceUnionWithCat() {
+        Cage cage = new Cage(new Cat("test"));
+        //
+        Cage result = roundTrip(cage);
+        //
+        assertThat(result).isEqualTo(cage);
+    }
+
+    @Test
+    public void testInterfaceUnionWithDog() {
+        Cage cage = new Cage(new Dog(4));
+        //
+        Cage result = roundTrip(cage);
+        //
+        assertThat(result).isEqualTo(cage);
+    }
+
+    @Test(expected = Exception.class)
+    public void testInterfaceUnionWithBird() {
+        Cage cage = new Cage(new Bird(true));
+        //
+        roundTrip(cage);
+    }
+
+    @Test
+    public void testListWithInterfaceUnion() {
+        PetShop shop = new PetShop(new Cat("tabby"), new Dog(4), new Dog(5), new Cat("calico"));
+        //
+        PetShop result = roundTrip(shop);
+        //
+        assertThat(result).isEqualTo(shop);
+    }
+
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapSubtypeTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/maps/MapSubtypeTest.java
@@ -26,7 +26,11 @@ public class MapSubtypeTest extends InteropTestBase {
     public void ignoreApacheMapSubtypeBug() {
         // The Apache Avro implementation has a bug that causes all of these tests to fail. Conditionally ignore these tests when running
         // with Apache deserializer implementation
+
+        // Apache ignores any type information for maps
         Assume.assumeTrue(deserializeFunctor != apacheDeserializer);
+        // Apache doesn't encode type information for maps
+        Assume.assumeTrue(schemaFunctor != getApacheSchema);
     }
 
     @Test

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveWrapperTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithPrimitiveWrapperTest.java
@@ -1,11 +1,11 @@
 package com.fasterxml.jackson.dataformat.avro.interop.records;
 
+import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
+
 import lombok.Data;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Alright, another stab at the native type ID stuff to support Generics / unions / polymorphic types. I think I managed to take care of the remaining comments that were left on the original PR, and additionally fixed handling of primitives when deserializing into `Object`

(Note, this was quickly rebased at 2:20am... make sure I didn't accidentally revert your performance fixes. I think I preserved them...)