### PR TITLE
Issue with broken surrogate pairs

### DIFF
--- a/jackson-bom-pom.xml
+++ b/jackson-bom-pom.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-parent</artifactId>
+        <version>2.9.pr1b</version>
+    </parent>
+
+    <artifactId>jackson-bom</artifactId>
+    <version>2.9.0.pr2-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <url>https://github.com/FasterXML/jackson-bom</url>
+    <scm>
+        <connection>scm:git:git@github.com:FasterXML/jackson-bom.git</connection>
+        <developerConnection>scm:git:git@github.com:FasterXML/jackson-bom.git</developerConnection>
+        <url>http://github.com/FasterXML/jackson-bom</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <jackson.version>2.9.0.pr2-SNAPSHOT</jackson.version>
+
+        <jackson.version.annotations>2.9.0.pr1</jackson.version.annotations>
+        <jackson.version.core>${jackson.version}</jackson.version.core>
+        <jackson.version.databind>${jackson.version}</jackson.version.databind>
+
+        <jackson.version.dataformat>${jackson.version}</jackson.version.dataformat>
+        <jackson.version.datatype>${jackson.version}</jackson.version.datatype>
+        <jackson.version.jaxrs>${jackson.version}</jackson.version.jaxrs>
+        <jackson.version.jacksonjr>${jackson.version}</jackson.version.jacksonjr>
+
+        <jackson.version.module>${jackson.version}</jackson.version.module>
+        <jackson.version.module.kotlin>${jackson.version.module}</jackson.version.module.kotlin>
+        <jackson.version.module.scala>${jackson.version.module}</jackson.version.module.scala>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- Core -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version.annotations}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version.core}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version.databind}</version>
+            </dependency>
+
+            <!-- Data Formats -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-avro</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-csv</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-properties</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-protobuf</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-smile</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${jackson.version.dataformat}</version>
+            </dependency>
+
+            <!-- Data Types -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-guava</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-hibernate3</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-hibernate4</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-hibernate5</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-hppc</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jaxrs</artifactId>
+                <!-- Should this follow datatype or JAX-RS version info?
+                  -->
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-joda</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-json-org</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr353</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-pcollections</artifactId>
+                <version>${jackson.version.datatype}</version>
+            </dependency>
+
+            <!-- JAX-RS -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base</artifactId>
+                <version>${jackson.version.jaxrs}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-cbor-provider</artifactId>
+                <version>${jackson.version.jaxrs}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson.version.jaxrs}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-smile-provider</artifactId>
+                <version>${jackson.version.jaxrs}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-xml-provider</artifactId>
+                <version>${jackson.version.jaxrs}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-yaml-provider</artifactId>
+                <version>${jackson.version.jaxrs}</version>
+            </dependency>
+
+            <!-- Jackson Jr. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.jr</groupId>
+                <artifactId>jackson-jr-all</artifactId>
+                <version>${jackson.version.jacksonjr}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jr</groupId>
+                <artifactId>jackson-jr-objects</artifactId>
+                <version>${jackson.version.jacksonjr}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jr</groupId>
+                <artifactId>jackson-jr-retrofit2</artifactId>
+                <version>${jackson.version.jacksonjr}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jr</groupId>
+                <artifactId>jackson-jr-stree</artifactId>
+                <version>${jackson.version.jacksonjr}</version>
+            </dependency>
+
+            <!-- Modules, basic -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-afterburner</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-guice</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jsonSchema</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-kotlin</artifactId>
+                <version>${jackson.version.module.kotlin}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-mrbean</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-osgi</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-paranamer</artifactId>
+                <version>${jackson.version.module}</version>
+            </dependency>
+
+            <!-- Language Modules -->
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-scala_2.10</artifactId>
+                <version>${jackson.version.module.scala}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-scala_2.11</artifactId>
+                <version>${jackson.version.module.scala}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-scala_2.12</artifactId>
+                <version>${jackson.version.module.scala}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-bom</artifactId>
     <version>2.9.0.pr2-SNAPSHOT</version>
+    <relativePath>./jackson-bom-pom.xml</relativePath>
   </parent>
   <groupId>com.fasterxml.jackson.dataformat</groupId>
   <artifactId>jackson-dataformats-binary</artifactId>

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileFactory.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileFactory.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.format.InputAccessor;
 import com.fasterxml.jackson.core.format.MatchStrength;
 import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.json.PackageVersion;
 
 /**
  * Factory used for constructing {@link SmileParser} and {@link SmileGenerator}

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.*;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.core.base.GeneratorBase;
+import com.fasterxml.jackson.core.json.PackageVersion;
 
 import static com.fasterxml.jackson.dataformat.smile.SmileConstants.*;
 

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParser.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.ParserBase;
 import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;
 
 import static com.fasterxml.jackson.dataformat.smile.SmileConstants.BYTE_MARKER_END_OF_STRING;

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingParserImpl.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingParserImpl.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.ParserBase;
 import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;
 import com.fasterxml.jackson.dataformat.smile.*;
 

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/BrokenSurrogatePair.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/BrokenSurrogatePair.java
@@ -1,0 +1,24 @@
+package com.fasterxml.jackson.dataformat.smile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class BrokenSurrogatePair {
+    @Test
+    public void brokenSurrogatePair() throws IOException {
+        // The string '{"val":"conclu<d92f> e"}' written as bytes to avoid any encoding issues, etc
+        byte[] bytes = {123, 34, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 34, 58, 34, 99, 111, 110, 99, 108, 117, -19, -92, -81, 32, 101, 34, 125, 10};
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode response = objectMapper.readValue(bytes, JsonNode.class);
+
+        ObjectMapper smileMapper = new ObjectMapper(new SmileFactory());
+        SequenceWriter sequenceWriter = smileMapper.writerFor(JsonNode.class)
+                                                   .writeValuesAsArray(new File("./temp.txt"));
+        sequenceWriter.write(response);
+    }
+}

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/VersionsTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/VersionsTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.smile;
 import java.io.*;
 
 import com.fasterxml.jackson.core.Versioned;
+import com.fasterxml.jackson.core.json.PackageVersion;
 
 /**
  * Tests to verify [JACKSON-278]


### PR DESCRIPTION
The test in the class BrokenSurrogatePair demonstrates an issue that appears to be rooted somewhere in the SMILE format. The byte array at the top includes a byte sequence that is outside the BMP (https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane). There is no problem writing the value to a JSON node, but when trying to write it in SMILE format, the program crashes:
`com.fasterxml.jackson.databind.JsonMappingException: Broken surrogate pair: first char 0xd92f, second 0x20; illegal combination`

This branch isn't intended to fix this problem, just demonstrate its existence in the hopes that it can be more easily identified and fixed. Thanks!