### PR TITLE
[Avro] Fix custom deserializers not being used

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeDeserializer.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroTypeDeserializer.java
@@ -4,10 +4,7 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase;


### PR DESCRIPTION
Found an issue that wasn't caught by one of the test suites.

Turns out because I'm always returning a `TypeDeserializer` for every property, Jackson doesn't use any custom deserializers that are registered for that property. I have a workaround here that checks for one and uses it instead, but I think there's a better way whereby I don't return a `TypeResolverBuilder` for properties that have custom deserializers, but I couldn't get that working. What's the proper way to fix this?