### PR TITLE
Issue #76: fix wire type checking for packed repeated fields

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/ProtobufField.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/ProtobufField.java
@@ -191,7 +191,7 @@ public class ProtobufField
     }
 
     public final boolean isValidFor(int typeTag) {
-        return (typeTag == type.getWireType());
+        return (typeTag == type.getWireType() || packed && repeated && typeTag == WireType.LENGTH_PREFIXED);
     }
 
     @Override

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedRepeatedTest.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedRepeatedTest.java
@@ -21,9 +21,8 @@ public class ReadPackedRepeatedTest extends ProtobufTestBase
         ProtobufSchema schema = MAPPER.schemaLoader().load(new StringReader(SCHEMA_STR));
         JsonNode t = MAPPER.readerFor(JsonNode.class).with(schema).readValue(pb);
 
-        String s = t.get("f").asText();
-        assertEquals(t.get("f").size(), 2);
-        assertEquals(t.get("f").get(0).asInt(), 100);
-        assertEquals(t.get("f").get(1).asInt(), 200);
+        assertEquals(2, t.get("f").size());
+        assertEquals(100, t.get("f").get(0).asInt());
+        assertEquals(200, t.get("f").get(1).asInt());
     }
 }

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedRepeatedTest.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedRepeatedTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
 
 import java.io.StringReader;
-import java.util.Base64;
 
 public class ReadPackedRepeatedTest extends ProtobufTestBase
 {
@@ -17,8 +16,7 @@ public class ReadPackedRepeatedTest extends ProtobufTestBase
             + "message t {\n"
             + "        repeated uint32 f = 1 [packed=true];\n"
             + "}";
-        final String base64pb = "CgNkyAE=";         // f = [100, 200]
-        final byte[] pb = Base64.getDecoder().decode(base64pb);
+        final byte[] pb = {0xa, 0x3, 0x64, (byte)0xc8, 0x1}; // f = [100, 200]
 
         ProtobufSchema schema = MAPPER.schemaLoader().load(new StringReader(SCHEMA_STR));
         JsonNode t = MAPPER.readerFor(JsonNode.class).with(schema).readValue(pb);

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedRepeatedTest.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedRepeatedTest.java
@@ -1,0 +1,31 @@
+package com.fasterxml.jackson.dataformat.protobuf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
+
+import java.io.StringReader;
+import java.util.Base64;
+
+public class ReadPackedRepeatedTest extends ProtobufTestBase
+{
+    final ProtobufMapper MAPPER = new ProtobufMapper();
+
+    public void testPacked() throws Exception
+    {
+        final String SCHEMA_STR =
+            "package mypackage;\n"
+            + "message t {\n"
+            + "        repeated uint32 f = 1 [packed=true];\n"
+            + "}";
+        final String base64pb = "CgNkyAE=";         // f = [100, 200]
+        final byte[] pb = Base64.getDecoder().decode(base64pb);
+
+        ProtobufSchema schema = MAPPER.schemaLoader().load(new StringReader(SCHEMA_STR));
+        JsonNode t = MAPPER.readerFor(JsonNode.class).with(schema).readValue(pb);
+
+        String s = t.get("f").asText();
+        assertEquals(t.get("f").size(), 2);
+        assertEquals(t.get("f").get(0).asInt(), 100);
+        assertEquals(t.get("f").get(1).asInt(), 200);
+    }
+}


### PR DESCRIPTION
Fixed the isValidFor method.  The deserializing of the repeated field to an array seems to be fine.