### PR TITLE
[Avro] Fix nested record field names returning wrong type ID when deserialized as Object

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/RecordReader.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/RecordReader.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.avro.deser;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 
 abstract class RecordReader extends AvroStructureReader
 {
@@ -68,9 +69,9 @@ abstract class RecordReader extends AvroStructureReader
             return super.getTypeId();
         }
         if (_currToken == JsonToken.FIELD_NAME) {
-            return _fieldReaders[_index].getTypeId();
+            return AvroSchemaHelper.getTypeId(String.class);
         }
-        // When reading a value type ID, the index pointer has already advanced to the field, so look at the previous
+        // When reading a value type ID, the index pointer has already advanced to the next field, so look at the previous
         return _fieldReaders[_index - 1].getTypeId();
     }
 

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/InteropTestBase.java
@@ -35,7 +35,7 @@ public abstract class InteropTestBase
      *
      * @return A type representing the bound {@code baseClass}
      */
-    protected static ParameterizedType type(Class<?> baseClass, Type... parameters) {
+    public static ParameterizedType type(Class<?> baseClass, Type... parameters) {
         if (baseClass.getTypeParameters().length != parameters.length) {
             throw new IllegalArgumentException("Incorrect number of type parameters, expected "
                                                + baseClass.getTypeParameters().length

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithMissingType.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/records/RecordWithMissingType.java
@@ -1,0 +1,68 @@
+package com.fasterxml.jackson.dataformat.avro.interop.records;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.getJacksonSchema;
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.jacksonDeserialize;
+import static com.fasterxml.jackson.dataformat.avro.interop.ApacheAvroInteropUtil.jacksonSerialize;
+import static com.fasterxml.jackson.dataformat.avro.interop.InteropTestBase.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordWithMissingType {
+
+    public static class WrapperOuter<T> {
+
+        @JsonProperty(required = true)
+        public T inner;
+    }
+
+    public static class WrapperInner<T> {
+
+        @JsonProperty(required = true)
+        public T holder;
+
+    }
+
+    public static class Holder<T> {
+
+        @JsonProperty(required = true)
+        public T value;
+
+    }
+
+    // Schema for WrapperOuter<WrapperInner<Holder<Double>>>, but with the namespace changed so that the POJOs can't be resolved
+    public static final String SCHEMA =
+        "{\n  \"type\" : \"record\",\n  \"name\" : \"WrapperOuter\",\n  \"namespace\" : \"bad-namespace\",\n"
+            + "  \"fields\" : [ {\n    \"name\" : \"inner\",\n    \"type\" : {\n      \"type\" : \"record\",\n"
+            + "      \"name\" : \"WrapperInner\",\n      \"fields\" : [ {\n        \"name\" : \"holder\",\n"
+            + "        \"type\" : {\n          \"type\" : \"record\",\n          \"name\" : \"Holder\",\n"
+            + "          \"fields\" : [ {\n            \"name\" : \"value\",\n            \"type\" : {\n"
+            + "              \"type\" : \"double\",\n              \"java-class\" : \"java.lang.Double\"\n            }\n"
+            + "          } ]\n        }\n      } ]\n    }\n  } ]\n}";
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRecordWithPolymorphicKeyDeserialization() throws IOException {
+        Schema schema = getJacksonSchema(type(WrapperOuter.class, type(WrapperInner.class, type(Holder.class, Double.class))));
+        Holder<Double> holder = new Holder<>();
+        holder.value = 10.5D;
+        WrapperInner<Holder<Double>> inner = new WrapperInner<>();
+        inner.holder = holder;
+        WrapperOuter<WrapperInner<Holder<Double>>> outer = new WrapperOuter<>();
+        outer.inner = inner;
+
+        byte[] data = jacksonSerialize(schema, outer);
+
+        Object result = jacksonDeserialize((new Schema.Parser()).parse(SCHEMA), Object.class, data);
+
+        assertThat(result).isInstanceOf(Map.class);
+        assertThat(((Map<String, Map<String, Map<String, Double>>>) result).get("inner").get("holder").get("value")).isEqualTo(10.5D);
+    }
+}


### PR DESCRIPTION
If you have nested objects:

```java
public class Level1 {
    public Level2 inner;
}

public class Level2 {
    public Level3 inner;
}

public class Level3 {
    public String value;
}
```

and the types cannot be found during deserialization, it will fail because it gets mapped to `Map<Object, Object>` which triggers polymorphic type lookups on keys, and the `RecordReader` does not report type ID of field names correctly:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
	at com.fasterxml.jackson.dataformat.avro.deser.RecordReader.getTypeId(RecordReader.java:74)
	at com.fasterxml.jackson.dataformat.avro.deser.RecordReader$Std.getTypeId(RecordReader.java:83)
	at com.fasterxml.jackson.dataformat.avro.deser.AvroFieldReader$Structured.getTypeId(AvroFieldReader.java:66)
	at com.fasterxml.jackson.dataformat.avro.deser.RecordReader.getTypeId(RecordReader.java:71)
	at com.fasterxml.jackson.dataformat.avro.deser.RecordReader$Std.getTypeId(RecordReader.java:83)
	at com.fasterxml.jackson.dataformat.avro.AvroParser.getTypeId(AvroParser.java:240)
	at com.fasterxml.jackson.dataformat.avro.AvroUntypedDeserializer.mapObject(AvroUntypedDeserializer.java:76)
	at com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer.deserialize(UntypedObjectDeserializer.java:220)
	at com.fasterxml.jackson.dataformat.avro.AvroUntypedDeserializer.deserialize(AvroUntypedDeserializer.java:35)
	at com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase._deserializeWithNativeTypeId(TypeDeserializerBase.java:262)
	at com.fasterxml.jackson.dataformat.avro.AvroTypeDeserializer.deserializeTypedFromAny(AvroTypeDeserializer.java:67)
	at com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer.deserializeWithType(UntypedObjectDeserializer.java:283)
	at com.fasterxml.jackson.dataformat.avro.AvroUntypedDeserializer.deserializeWithType(AvroUntypedDeserializer.java:48)
	at com.fasterxml.jackson.databind.deser.impl.TypeWrappedDeserializer.deserialize(TypeWrappedDeserializer.java:68)
	at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:1612)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1245)
```
(precise error arises because the type ID of the field value is read before the start token is consumed for that object)

This PR adds a test for this and fixes the issue.