### PR TITLE
[Avro] Use configured introspector in module

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroModule.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroModule.java
@@ -88,7 +88,7 @@ public class AvroModule extends Module
     protected void _addIntrospector(SetupContext context) {
         if (_intr != null) {
             // insert (instead of append) to have higher precedence
-            context.insertAnnotationIntrospector(INTR);
+            context.insertAnnotationIntrospector(_intr);
         }
     }
 


### PR DESCRIPTION
The module was ignoring the configured introspector (set via `withAnnotationIntrospector`)