### PR TITLE
[ion] Make IonValueModule public for use outside of IonValueMapper

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapper.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapper.java
@@ -27,8 +27,8 @@ import software.amazon.ion.IonValue;
 /**
  * Supports serializing Ion to POJO and back using the Jackson Ion framework.
  *
- * Direct serialization to and from IonValue fields is supported. The POJO can declare fields subclassing IonValue and
- * the direct value will be provided.
+ * Direct serialization to and from IonValue fields is supported. The POJO can declare fields of type IonValue (or a
+ * subclass) and the direct value will be provided.
  * 
  * Enums are serialized as symbols by default.
  */

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueModule.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueModule.java
@@ -19,11 +19,15 @@ import com.fasterxml.jackson.dataformat.ion.PackageVersion;
 
 import software.amazon.ion.Timestamp;
 
-class IonValueModule extends SimpleModule {
+/**
+ * A module which allows for the direct serialization to and from IonValue fields. The POJO can declare fields of type
+ * IonValue (or a subclass) and the direct value will be provided.
+ */
+public class IonValueModule extends SimpleModule {
 
     private static final long serialVersionUID = 1L;
 
-    IonValueModule() {
+    public IonValueModule() {
         super("IonValueModule", PackageVersion.VERSION);
         addSerializer(new TimestampSerializer());
         addSerializer(new IonValueSerializer());


### PR DESCRIPTION
Catching the ion branch up with some changes made internally at Amazon. There are several more changes but I am fairly new to github and this is my first pull request so I wanted to give a small change a trial run. 