### PR TITLE
fix calling _skipUnknownValue() twice

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -923,7 +923,6 @@ public class ProtobufParser extends ParserMinimalBase
             // Note: may be null; if so, value needs to be skipped
             _currentField = _currentMessage.field(tag >> 3);
             if (_currentField == null) {
-                _skipUnknownValue(wireType);
                 continue;
             }
             _parsingContext.setCurrentName(_currentField.name);


### PR DESCRIPTION
When continue, will _skipUnknownValue(wireType) again. Is this the right way to fix?