### PR TITLE
[ProtoBuf]fix NPE in skip unknown nested key

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -736,6 +736,10 @@ public class ProtobufParser extends ParserMinimalBase
         if ((_currentField == null) || (f = _currentField.nextOrThisIf(id)) == null) {
             f = _currentMessage.field(id);
         }
+        // Note: may be null; if so, value needs to be skipped
+        if (f == null) {
+            return _skipUnknownField(id, wireType);
+        }
         _parsingContext.setCurrentName(f.name);
         if (!f.isValidFor(wireType)) {
             _reportIncompatibleType(f, wireType);


### PR DESCRIPTION
Should _skipUnknownField() in _handleNestedKey() just like in _handleRootKey().
Unit test to reproduce NPE.

```java
import static org.junit.Assert.assertEquals;

import com.fasterxml.jackson.annotation.JsonProperty;
import com.fasterxml.jackson.core.JsonParser;
import com.fasterxml.jackson.databind.ObjectReader;
import com.fasterxml.jackson.databind.ObjectWriter;
import com.fasterxml.jackson.dataformat.protobuf.ProtobufMapper;
import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
import com.fasterxml.jackson.dataformat.protobuf.schemagen.ProtobufSchemaGenerator;
import java.io.ByteArrayInputStream;
import java.io.ByteArrayOutputStream;
import org.junit.Test;

public class PBHandleUnknownNestedKeyTest {

  @Test
  public void test() throws Exception {
    ProtobufMapper mapper = new ProtobufMapper();
    mapper.configure(JsonParser.Feature.IGNORE_UNDEFINED, true);

    NestedTwoField nestedTwoField = new NestedTwoField();
    nestedTwoField.setNested1(1);
    nestedTwoField.setNested2(2);
    MoreNestedField moreNestedField = new MoreNestedField();
    moreNestedField.setF1(nestedTwoField);

    ByteArrayOutputStream out = new ByteArrayOutputStream();
    ObjectWriter writer = mapper.writerFor(MoreNestedField.class).with(schemaForClass(MoreNestedField.class, mapper));
    writer.writeValue(out, moreNestedField);

    ObjectReader reader = mapper.readerFor(LessNestedField.class).with(schemaForClass(LessNestedField.class, mapper));
    LessNestedField lessNestedField = reader.readValue(new ByteArrayInputStream(out.toByteArray()));

    assertEquals(moreNestedField.getF1().getNested2(), lessNestedField.getF1().getNested2());
  }

  private ProtobufSchema schemaForClass(Class<?> clazz, ProtobufMapper mapper) throws Exception {
    ProtobufSchemaGenerator gen = new ProtobufSchemaGenerator();
    mapper.acceptJsonFormatVisitor(clazz, gen);
    return gen.getGeneratedSchema();
  }


  public static class LessNestedField {

    @JsonProperty(value = "f1", index = 1)
    private NestedOneField f1;

    public NestedOneField getF1() {
      return f1;
    }

    public void setF1(NestedOneField f1) {
      this.f1 = f1;
    }
  }

  public static class MoreNestedField {

    @JsonProperty(value = "f1", index = 1)
    private NestedTwoField f1;

    public NestedTwoField getF1() {
      return f1;
    }

    public void setF1(NestedTwoField f1) {
      this.f1 = f1;
    }
  }

  public static class NestedOneField {

    @JsonProperty(value = "nested2", index = 2)
    private int nested2;

    public int getNested2() {
      return nested2;
    }

    public void setNested2(int nested2) {
      this.nested2 = nested2;
    }
  }

  public static class NestedTwoField {

    @JsonProperty(value = "nested1", index = 1)
    private int nested1;

    @JsonProperty(value = "nested2", index = 2)
    private int nested2;

    public int getNested1() {
      return nested1;
    }

    public void setNested1(int nested1) {
      this.nested1 = nested1;
    }

    public int getNested2() {
      return nested2;
    }

    public void setNested2(int nested2) {
      this.nested2 = nested2;
    }
  }

}

```