### PR TITLE
copyStructure(): avoid duplicate tags when copying tagged binary.

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -843,6 +843,7 @@ public final class CBORParser extends ParserMinimalBase
         }
         _numberBigInt = nr;
         _numTypesValid = NR_BIGINT;
+        _tagValue = -1;
         return (_currToken = JsonToken.VALUE_NUMBER_INT);
     }
 

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/GeneratorSimpleTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/GeneratorSimpleTest.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.dataformat.cbor;
 
 import java.io.*;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.*;
 
 import org.junit.Assert;
@@ -398,7 +399,7 @@ public class GeneratorSimpleTest extends CBORTestBase
             targetBytes.toByteArray());
     }
 
-    public void testCopyCurrentSturctureWithTag() throws Exception {
+    public void testCopyCurrentStructureWithTaggedArray() throws Exception {
         final ByteArrayOutputStream sourceBytes = new ByteArrayOutputStream();
         final CBORGenerator sourceGen = cborGenerator(sourceBytes);
         sourceGen.writeNumber(BigDecimal.ONE);
@@ -420,6 +421,26 @@ public class GeneratorSimpleTest extends CBORTestBase
                 0,
                 1,
             },
+            targetBytes.toByteArray());
+    }
+
+
+    public void testCopyCurrentStructureWithTaggedBinary() throws Exception {
+        final ByteArrayOutputStream sourceBytes = new ByteArrayOutputStream();
+        final CBORGenerator sourceGen = cborGenerator(sourceBytes);
+        sourceGen.writeNumber(BigInteger.ZERO);
+        sourceGen.close();
+
+        final ByteArrayOutputStream targetBytes = new ByteArrayOutputStream();
+        final CBORGenerator gen = cborGenerator(targetBytes);
+        final CBORParser cborParser = cborParser(sourceBytes);
+        cborParser.nextToken();
+        gen.copyCurrentStructure(cborParser);
+        gen.close();
+        cborParser.close();
+
+        Assert.assertArrayEquals(
+            sourceBytes.toByteArray(),
             targetBytes.toByteArray());
     }
 }


### PR DESCRIPTION
`_handleTaggedArray` resets `_tagValue`, so I assume `_handleTaggedBinary()` should too.