### PR TITLE
Should skip the positive byte which is the last byte of an varint

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -2148,7 +2148,7 @@ public class ProtobufParser extends ParserMinimalBase
         }
         // but loop beyond
         for (int end = ptr+6; ptr < end; ++ptr) {
-            if (buf[ptr] >= 0) {
+            if (buf[ptr++] >= 0) {
                 _inputPtr = ptr;
                 return;
             }


### PR DESCRIPTION
Should skip the positive byte which is the last byte of an varint