### PR TITLE
Should skip the positive byte which is the last byte of an varint

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -2149,7 +2149,7 @@ public class ProtobufParser extends ParserMinimalBase
         // but loop beyond
         for (int end = ptr+6; ptr < end; ++ptr) {
             if (buf[ptr] >= 0) {
-                _inputPtr = ptr;
+                _inputPtr = ptr + 1;
                 return;
             }
         }


### PR DESCRIPTION
Should skip the positive byte which is the last byte of an varint