### PR TITLE
[ProtoBuf]always call checkEnd() when skip unknown field

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -911,10 +911,10 @@ public class ProtobufParser extends ParserMinimalBase
         }
         while (true) {
             _skipUnknownValue(wireType);
+            if (_checkEnd()) {
+                return (_currToken = JsonToken.END_OBJECT);
+            }
             if (_state == STATE_NESTED_KEY) {
-                if (_checkEnd()) {
-                    return (_currToken = JsonToken.END_OBJECT);
-                }
                 if (_inputPtr >= _inputEnd) {
                     loadMoreGuaranteed();
                 }


### PR DESCRIPTION
We encounter a bug when _skipUnknownField(). The types involved are a little bit complicated and I'll submit a test case if necessary when I manage to simplify the types.

The problem is checkEnd() is not called when _state != STATE_NESTED_KEY, and tag = _decodeVInt(); on line 927 will be called. If the skipped field **is** the last field of an object, line 927 will decode a field of another object and try to find the field in the currently ended object on line 931.  