### PR TITLE
[Avro] Fix MapWriteContext not correctly resolving union values

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/MapWriteContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/MapWriteContext.java
@@ -53,6 +53,14 @@ public final class MapWriteContext
     }
 
     @Override
+    public final AvroWriteContext createChildObjectContext(Object currValue) throws JsonMappingException {
+        _verifyValueWrite();
+        AvroWriteContext child = _createObjectContext(_schema.getValueType(), currValue);
+        _data.put(_currentName, child.rawValue());
+        return child;
+    }
+
+    @Override
     public void writeValue(Object value) {
         _verifyValueWrite();
         _data.put(_currentName, value);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/UnionTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/UnionTest.java
@@ -2,7 +2,9 @@ package com.fasterxml.jackson.dataformat.avro.interop.annotations;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.avro.UnresolvedUnionException;
 import org.apache.avro.reflect.Nullable;
@@ -87,9 +89,12 @@ public class UnionTest extends InteropTestBase {
     public static class PetShop {
         public List<Animal> pets;
 
+        public Map<String, Animal> specialPets;
+
         protected PetShop() { }
         public PetShop(Animal... p) {
             pets = Arrays.asList(p);
+            specialPets = new HashMap<>();
         }
 
         @Override
@@ -97,7 +102,8 @@ public class UnionTest extends InteropTestBase {
             if (o.getClass() == getClass()) {
                 PetShop other = (PetShop) o;
                 if (pets == null) return other.pets == null;
-                else return pets.equals(other.pets);
+                if (specialPets == null) return other.specialPets == null;
+                else return pets.equals(other.pets) && specialPets.equals(other.specialPets);
             }
             return false;
         }
@@ -136,6 +142,17 @@ public class UnionTest extends InteropTestBase {
     @Test
     public void testListWithInterfaceUnion() throws IOException {
         PetShop shop = new PetShop(new Cat("tabby"), new Dog(4), new Dog(5), new Cat("calico"));
+        //
+        PetShop result = roundTrip(shop);
+        //
+        assertThat(result).isEqualTo(shop);
+    }
+
+    @Test
+    public void testMapWithInterfaceUnion() throws IOException {
+        PetShop shop = new PetShop(new Cat("tabby"), new Dog(4), new Dog(5), new Cat("calico"));
+        shop.specialPets.put("pet1", new Cat("siamese"));
+        shop.specialPets.put("pet2", new Dog(6));
         //
         PetShop result = roundTrip(shop);
         //


### PR DESCRIPTION
We recently discovered a bug with the Avro serializer where using a map whose values are a union of multiple record schemas fails because the `MapWriteContext` does not pass each item to `createChildObjectContext()`, so Jackson can't resolve which schema in the union should be used.

I've added a test that demonstrates the issue and the associated fix in `MapWriteContext`.

It looks like this issue was fixed upstream as a part of the refactoring in 8b9171c5ba724f9d56f27ec70a120f6aaa89be8c for 3.0, but we'd like to utilize this in 2.9.