### PR TITLE
TokenBuffer.copyCurrentEvent does not expect getNumberType return null.

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -245,6 +245,8 @@ public class IonParser
                 } else {
                     return NumberType.INT;
                 }
+            case FLOAT:
+                return NumberType.DOUBLE;
             default:
             }
         }

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonParserTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonParserTest.java
@@ -13,18 +13,18 @@
  */
 
 package com.fasterxml.jackson.dataformat.ion;
- 
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.ObjectReadContext;
-import com.fasterxml.jackson.dataformat.ion.IonFactory;
-import com.fasterxml.jackson.dataformat.ion.IonParser;
 
 import org.junit.Assert;
+import software.amazon.ion.IonReader;
 import software.amazon.ion.IonSystem;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.system.IonSystemBuilder;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import org.junit.Test;
 
@@ -56,6 +56,25 @@ public class IonParserTest
         IonValue ionDecimal = ion.newDecimal(Double.MAX_VALUE);
         IonParser floatParser = new IonFactory().createParser(EMPTY_READ_CTXT, ionDecimal);
         Assert.assertEquals(JsonToken.VALUE_NUMBER_FLOAT, floatParser.nextToken());
+        Assert.assertEquals(JsonParser.NumberType.DOUBLE, floatParser.getNumberType());
+    }
+
+    @Test
+    public void testFloatType() throws IOException
+    {
+        final ObjectReadContext ctxt = ObjectReadContext.empty();
+
+        final byte[] data =  "{ score:0.291e0 }".getBytes();
+        IonSystem ion = IonSystemBuilder.standard().build();
+        final IonValue ionFloat = ion.newFloat(Float.MAX_VALUE);
+        IonReader reader = ionFloat.getSystem().newReader(data, 0, data.length);
+        // Find the object
+        reader.next();
+        // Step into the object
+        reader.stepIn();
+        // Step next.
+        reader.next();
+        final IonParser floatParser = new IonFactory().createParser(ctxt, reader);
         Assert.assertEquals(JsonParser.NumberType.DOUBLE, floatParser.getNumberType());
     }
 }


### PR DESCRIPTION
ObjectDeserialization fails with a NPE when a float exists in the ion structure.

There may be other problems when getNumberType() returns null since TokenBuffer.copyCurrentEvent does not expect nulls.

https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/util/TokenBuffer.java#L1054-L1062