### PR TITLE
Added including default null value to Avro schema generation

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
@@ -43,7 +43,12 @@ public class AvroGenerator extends GeneratorBase
          * of this header is not 100% reliably auto-detectable (while header has distinct marker,
          * "raw" Avro content has no limitations and could theoretically have same pre-amble from data).
          */
-        AVRO_FILE_OUTPUT(false)
+        AVRO_FILE_OUTPUT(false),
+
+        /**
+         * Feature that includes to every object type default value "null" when no real default value is defined.
+         */
+        AVRO_DEFAULT_ENABLED(false)
         ;
 
         protected final boolean _defaultState;

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -205,7 +205,8 @@ public class RecordVisitor
             }
         }
         JsonNode defaultValue = parseJson(prop.getMetadata().getDefaultValue());
-        if(isDefaultsEnabled && defaultValue == null && !prop.getType().isPrimitive()) {
+        if(isDefaultsEnabled && defaultValue == null
+                && writerSchema.getType() == Type.UNION && writerSchema.getIndexNamed(Type.NULL.getName()) != null) {
             defaultValue = NullNode.getInstance();
         }
         writerSchema = reorderUnionToMatchDefaultType(writerSchema, defaultValue);

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -5,6 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.TokenStreamFactory;
+import com.fasterxml.jackson.dataformat.avro.AvroFactory;
+import com.fasterxml.jackson.dataformat.avro.AvroGenerator;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.reflect.AvroMeta;
@@ -20,6 +23,7 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.dataformat.avro.AvroFixedSize;
 import com.fasterxml.jackson.dataformat.avro.ser.CustomEncodingSerializer;
+import org.codehaus.jackson.node.NullNode;
 
 public class RecordVisitor
     extends JsonObjectFormatVisitor.Base
@@ -38,6 +42,8 @@ public class RecordVisitor
     protected Schema _avroSchema;
     
     protected List<Schema.Field> _fields = new ArrayList<Schema.Field>();
+
+    protected boolean isDefaultsEnabled = false;
     
     public RecordVisitor(SerializerProvider p, JavaType type, DefinedSchemas schemas)
     {
@@ -49,6 +55,15 @@ public class RecordVisitor
         BeanDescription bean = config.introspectDirectClassAnnotations(_type);
         List<NamedType> subTypes = getProvider().getAnnotationIntrospector().findSubtypes(config,
                 bean.getClassInfo());
+
+        TokenStreamFactory factory = p.getGeneratorFactory();
+        if(factory instanceof AvroFactory) {
+            AvroFactory avroFactory = (AvroFactory) factory;
+            if(avroFactory.isEnabled(AvroGenerator.Feature.AVRO_DEFAULT_ENABLED)) {
+                this.isDefaultsEnabled = true;
+            }
+        }
+
         AvroSchema ann = bean.getClassInfo().getAnnotation(AvroSchema.class);
         if (ann != null) {
             _avroSchema = AvroSchemaHelper.parseJsonSchema(ann.value());
@@ -190,6 +205,9 @@ public class RecordVisitor
             }
         }
         JsonNode defaultValue = parseJson(prop.getMetadata().getDefaultValue());
+        if(isDefaultsEnabled && defaultValue == null && !prop.getType().isPrimitive()) {
+            defaultValue = NullNode.getInstance();
+        }
         writerSchema = reorderUnionToMatchDefaultType(writerSchema, defaultValue);
 
         String name = prop.getName();

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/TestSimpleGeneration.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/TestSimpleGeneration.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.avro.*;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.reflect.AvroDefault;
+import org.apache.avro.reflect.AvroName;
 
 public class TestSimpleGeneration extends AvroTestBase
 {
@@ -61,6 +62,8 @@ public class TestSimpleGeneration extends AvroTestBase
         public String noDefault;
         public int simpleInt;
         public Integer integer;
+        @JsonProperty(required = true)
+        public String required;
 
         public void setAvro(String avro) {
             this.avro = avro;
@@ -80,6 +83,10 @@ public class TestSimpleGeneration extends AvroTestBase
 
         public void setInteger(Integer integer) {
             this.integer = integer;
+        }
+
+        public void setRequired(String required) {
+            this.required = required;
         }
     }
 
@@ -212,6 +219,7 @@ public class TestSimpleGeneration extends AvroTestBase
         assertNull(schema.getField("noDefault").defaultVal());
         assertNull(schema.getField("simpleInt").defaultVal());
         assertNull(schema.getField("integer").defaultVal());
+        assertNull(schema.getField("required").defaultVal());
     }
 
     public void testEnabledDefaultValues() throws JsonMappingException {
@@ -224,6 +232,6 @@ public class TestSimpleGeneration extends AvroTestBase
         assertEquals(JsonProperties.NULL_VALUE, schema.getField("noDefault").defaultVal());
         assertNull(schema.getField("simpleInt").defaultVal());
         assertEquals(JsonProperties.NULL_VALUE, schema.getField("integer").defaultVal());
-
+        assertNull(schema.getField("required").defaultVal());
     }
 }


### PR DESCRIPTION
Added:
    new Feature enum AVRO_DEFAULT_ENABLED for enabling null inclusion
    RecordVisitor is now include NullNode if AVRO_DEFAULT_ENABLED is enabled and field is not primitive