### PR TITLE
Update `ion-java` dependency

### DIFF
--- a/ion/pom.xml
+++ b/ion/pom.xml
@@ -24,9 +24,9 @@ tree model)
   <dependencies>
     <!-- actual decoding by core streaming Ion lib -->
     <dependency>
-      <groupId>software.amazon.ion</groupId>
+      <groupId>com.amazon.ion</groupId>
       <artifactId>ion-java</artifactId>
-      <version>1.0.2</version>
+      <version>1.4.0</version>
     </dependency>
 
     <!-- Extends Jackson core, databind -->

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
@@ -22,11 +22,11 @@ import com.fasterxml.jackson.core.base.DecorableTSFactory;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.dataformat.ion.util.CloseSafeUTF8Writer;
 
-import software.amazon.ion.IonReader;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.IonWriter;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.system.IonSystemBuilder;
 
 /**
  * Sub-class of {@link TokenStreamFactory} that will work on Ion content, instead of JSON

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactoryBuilder.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactoryBuilder.java
@@ -2,8 +2,8 @@ package com.fasterxml.jackson.dataformat.ion;
 
 import com.fasterxml.jackson.core.base.DecorableTSFactory.DecorableTSFBuilder;
 
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.system.IonSystemBuilder;
 
 /**
  * {@link com.fasterxml.jackson.core.TokenStreamFactory.TSFBuilder}

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
@@ -27,10 +27,10 @@ import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.core.type.WritableTypeId;
 
-import software.amazon.ion.IonType;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.IonWriter;
-import software.amazon.ion.Timestamp;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.Timestamp;
 
 /**
  * Implementation of {@link JsonGenerator} that will use an underlying

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonObjectMapper.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonObjectMapper.java
@@ -29,10 +29,10 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import com.fasterxml.jackson.dataformat.ion.ionvalue.IonValueModule;
 
-import software.amazon.ion.IonDatagram;
-import software.amazon.ion.IonReader;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.IonWriter;
+import com.amazon.ion.IonDatagram;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.IonWriter;
 
 /**
  * Specialization of {@link ObjectMapper} that will set underlying

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.core.base.ParserMinimalBase;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.json.JsonReadContext;
 
-import software.amazon.ion.*;
+import com.amazon.ion.*;
 
 /**
  * Implementation of {@link JsonParser} that will use an underlying

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonTimestampDeserializers.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonTimestampDeserializers.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.DateDeserializers.DateDeserializer;
 import com.fasterxml.jackson.databind.deser.std.DateDeserializers.SqlDateDeserializer;
-import software.amazon.ion.Timestamp;
+import com.amazon.ion.Timestamp;
 
 /**
  * A date deserializer that uses native Ion timestamps instead of JSON strings.

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/DeserializersEx.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/DeserializersEx.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleDeserializers;
 import com.fasterxml.jackson.databind.type.CollectionType;
-import software.amazon.ion.IonContainer;
-import software.amazon.ion.IonValue;
+import com.amazon.ion.IonContainer;
+import com.amazon.ion.IonValue;
 
 class DeserializersEx extends SimpleDeserializers
 {

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import software.amazon.ion.IonValue;
+import com.amazon.ion.IonValue;
 
 /**
  * Deserializer that knows how to deserialize an IonValue.

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapper.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapper.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import com.fasterxml.jackson.dataformat.ion.IonFactory;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonValue;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonValue;
 
 /**
  * Supports serializing Ion to POJO and back using the Jackson Ion framework.

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueModule.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueModule.java
@@ -17,7 +17,7 @@ package com.fasterxml.jackson.dataformat.ion.ionvalue;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.ion.PackageVersion;
 
-import software.amazon.ion.Timestamp;
+import com.amazon.ion.Timestamp;
 
 /**
  * A module which allows for the direct serialization to and from IonValue fields. The POJO can declare fields of type

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueSerializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueSerializer.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import com.fasterxml.jackson.dataformat.ion.IonGenerator;
 
-import software.amazon.ion.IonValue;
+import com.amazon.ion.IonValue;
 
 /**
  * Serializer that knows how to serialize an IonValue.

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/TimestampDeserializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/TimestampDeserializer.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import software.amazon.ion.Timestamp;
+import com.amazon.ion.Timestamp;
 
 /**
  * Deserializer that knows how to deserialize a Timestamp.

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/TimestampSerializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/TimestampSerializer.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import com.fasterxml.jackson.dataformat.ion.IonGenerator;
 
-import software.amazon.ion.Timestamp;
+import com.amazon.ion.Timestamp;
 
 /**
  * Serializer that knows how to serialize a Timestamp.

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindReadTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindReadTest.java
@@ -21,12 +21,12 @@ import org.junit.Test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
-import software.amazon.ion.IonReader;
-import software.amazon.ion.IonStruct;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonType;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonSystemBuilder;
 
 import static org.junit.Assert.*;
 

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindRoundtripTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindRoundtripTest.java
@@ -36,10 +36,10 @@ import com.fasterxml.jackson.dataformat.ion.EnumAsIonSymbolSerializer;
 import com.fasterxml.jackson.dataformat.ion.IonSymbolSerializer;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
-import software.amazon.ion.IonStruct;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonSystemBuilder;
 
 /**
  * Simple unit tests to check that write-then-read works as expected

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindWriteTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindWriteTest.java
@@ -26,12 +26,12 @@ import org.junit.Test;
 import com.fasterxml.jackson.dataformat.ion.IonFactory;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
-import software.amazon.ion.IonDatagram;
-import software.amazon.ion.IonList;
-import software.amazon.ion.IonStruct;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonWriter;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonDatagram;
+import com.amazon.ion.IonList;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.system.IonSystemBuilder;
 
 public class DataBindWriteTest {
     

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonGeneratorTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonGeneratorTest.java
@@ -25,11 +25,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.ion.IonGenerator;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
-import software.amazon.ion.IonDatagram;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.IonStruct;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonDatagram;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.system.IonSystemBuilder;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonParserTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonParserTest.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.ObjectReadContext;
 
 import org.junit.Assert;
-import software.amazon.ion.IonReader;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonSystemBuilder;
 
 import java.io.IOException;
 import java.math.BigInteger;

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonTimestampRoundTripTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonTimestampRoundTripTest.java
@@ -26,12 +26,12 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
-import software.amazon.ion.IonDatagram;
-import software.amazon.ion.IonLoader;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonType;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonDatagram;
+import com.amazon.ion.IonLoader;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonSystemBuilder;
 
 public class IonTimestampRoundTripTest {
     IonSystem ionSystem = IonSystemBuilder.standard().build();

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/SimpleWriteTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/SimpleWriteTest.java
@@ -25,12 +25,12 @@ import com.fasterxml.jackson.core.ObjectWriteContext;
 import com.fasterxml.jackson.dataformat.ion.IonFactory;
 import com.fasterxml.jackson.dataformat.ion.IonGenerator;
 
-import software.amazon.ion.IonDatagram;
-import software.amazon.ion.IonLoader;
-import software.amazon.ion.IonStruct;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonType;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonDatagram;
+import com.amazon.ion.IonLoader;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonType;
+import com.amazon.ion.system.IonSystemBuilder;
 
 public class SimpleWriteTest
 {

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/failing/PolymorphicRoundtripTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/failing/PolymorphicRoundtripTest.java
@@ -45,10 +45,10 @@ import com.fasterxml.jackson.dataformat.ion.polymorphism.IonAnnotationIntrospect
 import com.fasterxml.jackson.dataformat.ion.polymorphism.IonAnnotationTypeResolverBuilder;
 import com.fasterxml.jackson.dataformat.ion.polymorphism.MultipleTypeIdResolver;
 
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonType;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonSystemBuilder;
 
 public class PolymorphicRoundtripTest
 {

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapperTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapperTest.java
@@ -34,11 +34,11 @@ import com.fasterxml.jackson.dataformat.ion.IonSymbolSerializer;
 import com.fasterxml.jackson.dataformat.ion.IonFactory;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
-import software.amazon.ion.IonSexp;
-import software.amazon.ion.IonSystem;
-import software.amazon.ion.IonValue;
-import software.amazon.ion.Timestamp;
-import software.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.IonSexp;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.system.IonSystemBuilder;
 
 @SuppressWarnings("deprecation")
 public class IonValueMapperTest {


### PR DESCRIPTION
Updates the ion-java dependency to its newest version, 1.4.0 and new maven
groupId com.amazon.ion.

See http://amzn.github.io/ion-docs/news/2019/04/24/ion-java-1_4_0-released.html