### PR TITLE
Fix issue wit input offsets when parsing CBOR from `InputStream`

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -3237,14 +3237,16 @@ public class CBORParser extends ParserMinimalBase
         // Need to move remaining data in front?
         int amount = _inputEnd - _inputPtr;
         if (amount > 0 && _inputPtr > 0) {
-            _currInputProcessed += _inputPtr;
             //_currInputRowStart -= _inputPtr;
             System.arraycopy(_inputBuffer, _inputPtr, _inputBuffer, 0, amount);
             _inputEnd = amount;
         } else {
             _inputEnd = 0;
         }
+
+        _currInputProcessed += _inputPtr;
         _inputPtr = 0;
+
         while (_inputEnd < minAvailable) {
             int count = _inputStream.read(_inputBuffer, _inputEnd, _inputBuffer.length - _inputEnd);
             if (count < 1) {


### PR DESCRIPTION
This fixes an issue I discovered where CBORParser#_loadToHaveAtLeast didn't increment _currInputProcessed pointer if array move didn't occur.  Observed because calling CBORParser#getCurrentLocation after CBORParser#finishToken returned offsets smaller than expected if a token spanned between two chunks read from the stream.