### PR TITLE
[Help needed] Fix custom null serialization

### DIFF
--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/CustomSerializationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/CustomSerializationTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.avro.interop.annotations;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import java.io.IOException;
 import java.util.Objects;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -104,5 +105,60 @@ public final class CustomSerializationTest {
         House result = jacksonDeserialize(schema, House.class, bytes);
 
         assertThat(result).isEqualTo(house);
+    }
+
+    @JsonSerialize(using = NullValue.Serializer.class)
+    @JsonDeserialize(using = NullValue.Deserializer.class)
+    public final static class NullValue {
+        public NullValue() {
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof NullValue;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getClass());
+        }
+
+        public static class Serializer extends JsonSerializer<NullValue> {
+            @Override
+            public void serialize(
+                final NullValue house,
+                final JsonGenerator generator,
+                final SerializerProvider serializers
+            ) throws IOException {
+                generator.writeNull();
+            }
+        }
+
+        public static class Deserializer extends JsonDeserializer<NullValue> {
+            @Override
+            public NullValue deserialize(
+                final JsonParser parser,
+                final DeserializationContext context
+            ) throws IOException {
+                return null;
+            }
+
+            @Override
+            public NullValue getNullValue(final DeserializationContext ctxt) {
+                return null;
+            }
+        }
+    }
+
+    @Test
+    public void testNullDeSerialization() throws IOException {
+        final Schema schema = Schema.create(Schema.Type.NULL);
+
+        NullValue nullValue = new NullValue();
+
+        byte[] bytes = jacksonSerialize(schema, nullValue);
+        NullValue result = jacksonDeserialize(schema, NullValue.class, bytes);
+
+        assertThat(result).isEqualTo(nullValue);
     }
 }


### PR DESCRIPTION
@cowtowncoder implementing a null custom serialization for an internal library, I stumbled upon a bug that prevents serialized null from being deserialized (which should affect other packages, such as JSR-353). For now, this PR only includes a test that reproduces the problem.

Error message:
```
com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
```

Could you give me some guidance on how to fix it?