### PR TITLE
Allow IonWriters to be reused.

### DIFF
--- a/ion/pom.xml
+++ b/ion/pom.xml
@@ -26,7 +26,7 @@ tree model)
     <dependency>
       <groupId>com.amazon.ion</groupId>
       <artifactId>ion-java</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.1</version>
     </dependency>
 
     <!-- Extends Jackson core, databind -->

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
@@ -189,7 +189,7 @@ public class IonFactory extends JsonFactory {
      * @since 2.7
      */
     public JsonGenerator createGenerator(IonWriter out) {
-        return _createGenerator(out, _createContext(out, false), out);
+        return _createGenerator(out, false, _createContext(out, false), out);
     }
 
     /**
@@ -214,7 +214,7 @@ public class IonFactory extends JsonFactory {
      */
     @Deprecated
     public JsonGenerator createJsonGenerator(IonWriter out) {
-        return _createGenerator(out, _createContext(out, false), out);
+        return _createGenerator(out, false, _createContext(out, false), out);
     }
 
     /*
@@ -267,7 +267,7 @@ public class IonFactory extends JsonFactory {
         if (createBinaryWriters()) {
             throw new IOException("Can only create binary Ion writers that output to OutputStream, not Writer");
         }
-        return _createGenerator(_system.newTextWriter(out), _createContext(out, false), out);
+        return _createGenerator(_system.newTextWriter(out), true, _createContext(out, false), out);
     }
 
     @Override
@@ -340,11 +340,11 @@ public class IonFactory extends JsonFactory {
             ion = _system.newTextWriter(w);
             dst = w;
         }
-        return _createGenerator(ion, ctxt, dst);
+        return _createGenerator(ion, true, ctxt, dst);
     }
 
-    protected IonGenerator _createGenerator(IonWriter ion, IOContext ctxt, Closeable dst)
+    protected IonGenerator _createGenerator(IonWriter ion, boolean ionWriterIsManaged, IOContext ctxt, Closeable dst)
     {
-        return new IonGenerator(_generatorFeatures, _objectCodec, ion, ctxt, dst);
+        return new IonGenerator(_generatorFeatures, _objectCodec, ion, ionWriterIsManaged, ctxt, dst);
     }        
 }

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
@@ -54,6 +54,8 @@ public class IonGenerator
 
     /* This is the textual or binary writer */
     protected final IonWriter _writer;
+    /* Indicates whether the IonGenerator is responsible for closing the underlying IonWriter. */
+    protected final boolean _ionWriterIsManaged;
 
     protected final IOContext _ioContext;
     
@@ -70,10 +72,11 @@ public class IonGenerator
       */  
 
     public IonGenerator(int features, ObjectCodec codec,
-            IonWriter ion, IOContext ctxt, Closeable dst)
+            IonWriter ion, boolean ionWriterIsManaged, IOContext ctxt, Closeable dst)
     {
         super(features, codec);
         _writer = ion;
+        _ionWriterIsManaged = ionWriterIsManaged;
         _ioContext = ctxt;
         _destination = dst;
     }
@@ -94,9 +97,9 @@ public class IonGenerator
     {
         if (!_closed) {
             _closed = true;
-            // force flush the writer
-            _writer.close();
-            // either way
+            if (_ionWriterIsManaged) {
+                _writer.close();
+            }
             if (_ioContext.isResourceManaged()) {
                 _destination.close();
             } else {


### PR DESCRIPTION
This PR addresses #189.

Changes:
* Bumps `ion-java` dependency from 1.4.0 to 1.5.1 (latest stable release)
* Adds `boolean _ionWriterIsManaged` field to the `IonGenerator` class, allowing it to track whether the provided `IonWriter` should be closed when the `IonGenerator` is closed.
* Modifies the `IonFactory` to specify whether the `IonWriter` it is providing to new `IonGenerator` instances was just created (`ionWriterIsManaged=true`) or if it was provided by the user (`ionWriterIsManaged=false`).
* Adds unit tests showing that the same instance of `IonWriter` can be reused for multiple calls to `IonObjectMapper#writeValue(IonWriter, Object)`.