### PR TITLE
[Avro] Remove dependencies upon Jackson 1.X and Avro's JacksonUtils

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroFieldDefaulters.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroFieldDefaulters.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.dataformat.avro.deser;
 
 import java.util.*;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Factory class for various default providers
@@ -19,7 +19,7 @@ public class AvroFieldDefaulters
         case VALUE_NULL:
             return new ScalarDefaults.NullDefaults(name);
         case VALUE_NUMBER_FLOAT:
-            switch (defaultAsNode.getNumberType()) {
+            switch (defaultAsNode.numberType()) {
             case FLOAT:
                 return new ScalarDefaults.FloatDefaults(name, (float) defaultAsNode.asDouble());
             case DOUBLE:
@@ -28,7 +28,7 @@ public class AvroFieldDefaulters
                 return new ScalarDefaults.DoubleDefaults(name, defaultAsNode.asDouble());
             }
         case VALUE_NUMBER_INT:
-            switch (defaultAsNode.getNumberType()) {
+            switch (defaultAsNode.numberType()) {
             case INT:
                 return new ScalarDefaults.FloatDefaults(name, defaultAsNode.asInt());
             case BIG_INTEGER: // TODO: maybe support separately?
@@ -40,7 +40,7 @@ public class AvroFieldDefaulters
             return new ScalarDefaults.StringDefaults(name, defaultAsNode.asText());
         case START_OBJECT:
             {
-                Iterator<Map.Entry<String,JsonNode>> it = defaultAsNode.getFields();
+                Iterator<Map.Entry<String,JsonNode>> it = defaultAsNode.fields();
                 List<AvroFieldReader> readers = new ArrayList<AvroFieldReader>();
                 while (it.hasNext()) {
                     Map.Entry<String,JsonNode> entry = it.next();
@@ -64,7 +64,7 @@ public class AvroFieldDefaulters
 
     // 23-Jul-2019, tatu: With Avro 1.9, likely changed  to use "raw" JDK containers?
     //   Code would look more like this:
-/*    
+/*
     public static AvroFieldReader createDefaulter(String name,
             Object defaultValue)
     {

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.dataformat.avro.deser;
 import java.util.*;
 
 import org.apache.avro.Schema;
-import org.apache.avro.util.internal.JacksonUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.avro.deser.ScalarDecoder.*;
 import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaHelper;
 
@@ -22,6 +22,7 @@ public abstract class AvroReaderFactory
     protected final static ScalarDecoder READER_LONG = new LongReader();
     protected final static ScalarDecoder READER_NULL = new NullReader();
     protected final static ScalarDecoder READER_STRING = new StringReader();
+    private final static ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
 
     /**
      * To resolve cyclic types, need to keep track of resolved named
@@ -56,24 +57,24 @@ public abstract class AvroReaderFactory
         switch (type.getType()) {
         case BOOLEAN:
             return READER_BOOLEAN;
-        case BYTES: 
+        case BYTES:
             return READER_BYTES;
-        case DOUBLE: 
+        case DOUBLE:
             return READER_DOUBLE;
-        case ENUM: 
+        case ENUM:
             return new EnumDecoder(AvroSchemaHelper.getFullName(type), type.getEnumSymbols());
-        case FIXED: 
+        case FIXED:
             return new FixedDecoder(type.getFixedSize(), AvroSchemaHelper.getFullName(type));
-        case FLOAT: 
+        case FLOAT:
             return READER_FLOAT;
         case INT:
             if (AvroSchemaHelper.getTypeId(type) != null) {
                 return new IntReader(AvroSchemaHelper.getTypeId(type));
             }
             return READER_INT;
-        case LONG: 
+        case LONG:
             return READER_LONG;
-        case NULL: 
+        case NULL:
             return READER_NULL;
         case STRING:
             if (AvroSchemaHelper.getTypeId(type) != null) {
@@ -127,7 +128,7 @@ public abstract class AvroReaderFactory
         switch (schema.getType()) {
         case ARRAY:
             return createArrayReader(schema);
-        case MAP: 
+        case MAP:
             return createMapReader(schema);
         case RECORD:
             return createRecordReader(schema);
@@ -252,7 +253,7 @@ public abstract class AvroReaderFactory
             switch (writerSchema.getType()) {
             case ARRAY:
                 return createArrayReader(writerSchema, readerSchema);
-            case MAP: 
+            case MAP:
                 return createMapReader(writerSchema, readerSchema);
             case RECORD:
                 return createRecordReader(writerSchema, readerSchema);
@@ -303,7 +304,7 @@ public abstract class AvroReaderFactory
             final List<Schema.Field> writerFields = writerSchema.getFields();
 
             // but first: find fields that only exist in reader-side and need defaults,
-            // and remove those from 
+            // and remove those from
             Map<String,Schema.Field> readerFields = new HashMap<String,Schema.Field>();
             List<Schema.Field> defaultFields = new ArrayList<Schema.Field>();
             {
@@ -320,7 +321,7 @@ public abstract class AvroReaderFactory
                     }
                 }
             }
-            
+
             // note: despite changes, we will always have known number of field entities,
             // ones from writer schema -- some may skip, but there's entry there
             AvroFieldReader[] fieldReaders = new AvroFieldReader[writerFields.size()
@@ -339,12 +340,13 @@ public abstract class AvroReaderFactory
                         : createFieldReader(readerField.name(),
                                 writerField.schema(), readerField.schema());
             }
-            
+
             // Any defaults to consider?
             if (!defaultFields.isEmpty()) {
                 for (Schema.Field defaultField : defaultFields) {
-                    AvroFieldReader fr =
-                        AvroFieldDefaulters.createDefaulter(defaultField.name(), JacksonUtils.toJsonNode(defaultField.defaultVal()));
+                    AvroFieldReader fr = AvroFieldDefaulters.createDefaulter(defaultField.name(),
+                                                                             AvroSchemaHelper.parseDefaultValue(defaultField.defaultVal())
+                    );
                     if (fr == null) {
                         throw new IllegalArgumentException("Unsupported default type: "+defaultField.schema().getType());
                     }
@@ -359,9 +361,9 @@ public abstract class AvroReaderFactory
             final List<Schema> types = writerSchema.getTypes();
             AvroStructureReader[] typeReaders = new AvroStructureReader[types.size()];
             int i = 0;
-            
+
             // !!! TODO: actual resolution !!!
-            
+
             for (Schema type : types) {
                 typeReaders[i++] = createReader(type);
             }
@@ -414,7 +416,7 @@ public abstract class AvroReaderFactory
             //    in case there are multiple alternatives of same structured type.
             //    But since that is quite non-trivial let's wait for a good example of actual
             //    usage before tackling that.
-            
+
             if (actualType == Schema.Type.UNION) {
                 for (Schema sch : readerSchema.getTypes()) {
                     if (sch.getType() == expectedType) {

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/ApacheAvroInteropUtil.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/ApacheAvroInteropUtil.java
@@ -126,6 +126,15 @@ public class ApacheAvroInteropUtil {
                 /* 14-Jun-2018, tatu: This is 99.9% certainly wrong; IDE gives warnings and
                  *   it just... doesn't fly. Either keys are NOT Strings or...
                  */
+                /*
+                 * 26-Jun-2019, baharclerode: The keys are NOT always strings. It's a horrible hack I used to enable support for generics
+                 * in the apache implementation because otherwise it flat out doesn't support generic types correctly except for the handful
+                 * that they hand-coded support for, resulting in oddities like Set<T> not working, or List<T> working but LinkedList<T> not
+                 * working. This regression suite is a lot simpler when we don't have to disable half the tests because the reference
+                 * implementation doesn't support them.
+                 *
+                 * Note the "((Map) names).put(...)" above this else/if case.
+                 */
                 if (names.containsKey(type)) {
                     return names.get(type);
                 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroDefaultTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroDefaultTest.java
@@ -15,7 +15,7 @@ public class AvroDefaultTest {
         @AvroDefault("1234")
         public Integer intField;
         @AvroDefault("true")
-        public Integer booleanField;
+        public Boolean booleanField;
     }
 
     @Test


### PR DESCRIPTION
This is the first half of a fix for #167 

This removes the references to Jackson 1.x and `JacksonUtils` (which is internal to Avro), allowing Jackson-Avro to be binary-compatible Avro 1.9 or Avro 1.8 but not semantically-compatible in all cases, particularly around nested classes; For simple use-cases, this is sufficient to allow Jackson-Avro to work with Avro 1.9, but I would not by any means call it "supported" due to the nasty gotchas that still lurk.

This does *not* provide full backwards and forwards compatibility with Avro 1.9; Notably:
* Generating a schema using Jackson-Avro w/ Avro 1.9 will still produce a 1.8 schema for nested classes; Avro 1.9 can't use these for serialization (But Jackson-Avro w/ Avro 1.9 can). Deserialization still seems to work.
* Uses of the `@AvroAlias` annotation to create aliases to nested types will break, since previously these had to follow the Avro 1.8 conventions for namespacing nested types
* **Mixing of Avro 1.8 and Avro 1.9 anywhere is right out.** You can't generate a schema with Avro 1.8 and have Jackson-Avro w/ Avro 1.9 do anything with it if nested classes are involved, and vice versa. The same goes for using Jackson-Avro w/ Avro 1.8 to generate schemas and Avro 1.9 to serialize/deserialize, and vice versa. Don't try it. If it works, it'll work just long enough for you to forget about it not supporting nested classes.

Fixing of the above will probably require porting all of the Avro union resolver code into Jackson-Avro with modifications to allow it to resolve both 1.8- and 1.9-styled namespaces, and a mapper flag that indicates if you want 1.8 or 1.9-compatibility for `@AvroAlias` annotations and generated schemas.