### PR TITLE
Add getIonSystem() accessor in IonFactory

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
@@ -135,6 +135,10 @@ public class IonFactory extends JsonFactory {
         return new IonFactory(this, null);
     }
 
+    public IonSystem getIonSystem() {
+        return _system;
+    }
+
     @Override
     public Version version() {
         return PackageVersion.VERSION;


### PR DESCRIPTION
It is sometimes necessary to access the underlying IonSystem when interacting
with an IonObjectMapper or ObjectWriter (eg. to replicate the logic in
IonObjectMapper#writeValueAsIonValue()).