### PR TITLE
Fix bug when deserializing Avro data using schema evolution 

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
@@ -288,7 +288,7 @@ public abstract class AvroReaderFactory
                 String valueTypeId = readerSchema.getValueType().getProp(AvroSchemaHelper.AVRO_SCHEMA_PROP_CLASS);
                 return MapReader.construct(dec, typeId, keyTypeId, valueTypeId);
             }
-            return MapReader.construct(createReader(writerElementType, readerSchema.getElementType()), typeId, keyTypeId);
+            return MapReader.construct(createReader(writerElementType, readerSchema.getValueType()), typeId, keyTypeId);
         }
 
         protected AvroStructureReader createRecordReader(Schema writerSchema, Schema readerSchema)


### PR DESCRIPTION
This little typo caused us a serious problem when deploying to production a new version last week. We took several hours until we managed to track this bug down. It was hard to debug because it involves schema evolution.

When combining two schemas, if one of them has a map field, you got the following error:

```
Not an array: {“type”:“map”,“values”:..}
```

@cowtowncoder any chances of releases a patch version anytime soon? It'd help us a lot.