### PR TITLE
Optimize IonParser.getNumberType() and Ion decimals as BigDecimal to support arbitraty precision

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -268,19 +268,17 @@ public class IonParser
             // harder to pin down exact type. But let's try some checks still.
             switch (type) {
             case DECIMAL:
-                // Could be float, double or big decimal; hard to check, let's choose doubel
-                return NumberType.DOUBLE;
+                //Ion decimals can be arbitrary precision, need to read as big decimal
+                return NumberType.BIG_DECIMAL;
             case INT:
-                // TODO: It would be good if IonReader directly told us which type to use.
-                BigInteger i = _reader.bigIntegerValue();
-                if ((i.compareTo(LONG_MIN_VALUE) < 0) || 
-                        (i.compareTo(LONG_MAX_VALUE) > 0)) {
-                    return NumberType.BIG_INTEGER;
-                } else if ((i.compareTo(INT_MIN_VALUE) < 0) || 
-                        (i.compareTo(INT_MAX_VALUE) > 0)) {
-                    return NumberType.LONG;
-                } else {
+                IntegerSize size = _reader.getIntegerSize();
+                switch (size) {
+                case INT:
                     return NumberType.INT;
+                case LONG:
+                    return NumberType.LONG;
+                default:
+                    return NumberType.BIG_INTEGER;
                 }
             case FLOAT:
                 return NumberType.DOUBLE;

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonParserTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonParserTest.java
@@ -21,12 +21,14 @@ import com.fasterxml.jackson.dataformat.ion.IonParser;
 
 import org.junit.Assert;
 
+import com.amazon.ion.IonDecimal;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonSystemBuilder;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.Test;
 
@@ -34,34 +36,54 @@ import org.junit.Test;
 public class IonParserTest
 {
     @Test
-    public void testGetNumberType() throws Exception {
+    public void testGetNumberTypeAndValue() throws Exception {
         IonSystem ion = IonSystemBuilder.standard().build();
  
-        IonValue ionInt = ion.newInt(Integer.MAX_VALUE);
+        Integer intValue = Integer.MAX_VALUE;
+        IonValue ionInt = ion.newInt(intValue);
         IonParser intParser = new IonFactory().createParser(ionInt);
         Assert.assertEquals(JsonToken.VALUE_NUMBER_INT, intParser.nextToken());
         Assert.assertEquals(JsonParser.NumberType.INT, intParser.getNumberType());
+        Assert.assertEquals(intValue, intParser.getNumberValue());
  
-        IonValue ionLong = ion.newInt(Long.MAX_VALUE);
+        Long longValue = Long.MAX_VALUE;
+        IonValue ionLong = ion.newInt(longValue);
         IonParser longParser = new IonFactory().createParser(ionLong);
         Assert.assertEquals(JsonToken.VALUE_NUMBER_INT, longParser.nextToken());
         Assert.assertEquals(JsonParser.NumberType.LONG, longParser.getNumberType());
+        Assert.assertEquals(longValue, longParser.getNumberValue());
  
-        IonValue ionBigInt = ion.newInt(new BigInteger(Long.MAX_VALUE + "1"));
+        BigInteger bigIntValue = new BigInteger(Long.MAX_VALUE + "1");
+        IonValue ionBigInt = ion.newInt(bigIntValue);
         IonParser bigIntParser = new IonFactory().createParser(ionBigInt);
         Assert.assertEquals(JsonToken.VALUE_NUMBER_INT, bigIntParser.nextToken());
         Assert.assertEquals(JsonParser.NumberType.BIG_INTEGER, bigIntParser.getNumberType());
+        Assert.assertEquals(bigIntValue, bigIntParser.getNumberValue());
  
-        // JoiParser is currently deficient with decimals -- all decimals are reported as Double. So this is all we can test.
-        IonValue ionDecimal = ion.newDecimal(Double.MAX_VALUE);
-        IonParser floatParser = new IonFactory().createParser(ionDecimal);
+        Double decimalValue = Double.MAX_VALUE;
+        IonValue ionDecimal = ion.newDecimal(decimalValue);
+        IonParser decimalParser = new IonFactory().createParser(ionDecimal);
+        Assert.assertEquals(JsonToken.VALUE_NUMBER_FLOAT, decimalParser.nextToken());
+        Assert.assertEquals(JsonParser.NumberType.BIG_DECIMAL, decimalParser.getNumberType());
+        Assert.assertTrue(new BigDecimal("" + decimalValue).compareTo((BigDecimal)decimalParser.getNumberValue()) == 0);
+        
+        Double floatValue = Double.MAX_VALUE;
+        IonValue ionFloat = ion.newFloat(floatValue);
+        IonParser floatParser = new IonFactory().createParser(ionFloat);
         Assert.assertEquals(JsonToken.VALUE_NUMBER_FLOAT, floatParser.nextToken());
         Assert.assertEquals(JsonParser.NumberType.DOUBLE, floatParser.getNumberType());
+        Assert.assertEquals(floatValue, floatParser.getNumberValue());
+
+        BigDecimal bigDecimalValue = new BigDecimal(Double.MAX_VALUE + "1");
+        IonValue ionBigDecimal = ion.newDecimal(bigDecimalValue);
+        IonParser bigDecimalParser = new IonFactory().createParser(ionBigDecimal);
+        Assert.assertEquals(JsonToken.VALUE_NUMBER_FLOAT, bigDecimalParser.nextToken());
+        Assert.assertEquals(JsonParser.NumberType.BIG_DECIMAL, bigDecimalParser.getNumberType());
+        Assert.assertTrue(bigDecimalValue.compareTo((BigDecimal)bigDecimalParser.getNumberValue()) == 0);
     }
 
     @Test
-    public void testFloatType() throws IOException
-    {
+    public void testFloatType() throws IOException {
         final byte[] data =  "{ score:0.291e0 }".getBytes();
         IonSystem ion = IonSystemBuilder.standard().build();
         final IonValue ionFloat = ion.newFloat(Float.MAX_VALUE);


### PR DESCRIPTION
2 changes included here:
1. Address the optimization noted here: https://github.com/FasterXML/jackson-dataformats-binary/issues/212
2. Switch to reading [Ion decimals](http://amzn.github.io/ion-docs/docs/spec.html#real-numbers) as BigDecimals since Ion decimals can be arbitrary precision. 