### PR TITLE
Cache record names to avoid hitting class loader

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.avro.schema;
 
+import com.fasterxml.jackson.databind.util.LRUMap;
 import java.io.File;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -24,7 +25,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 
 public abstract class AvroSchemaHelper
 {
-    private static final Map<String, String> SCHEMA_NAME_CACHE = new HashMap<>();
+    private static final LRUMap<String, String> SCHEMA_NAME_CACHE = new LRUMap<>(16, 1024);
 
     /**
      * Dedicated mapper for handling default values (String &lt;-&gt; JsonNode &lt;-&gt; Object)


### PR DESCRIPTION
We use Jackson in our stream processing pipeline, and we noticed that the serialization process was consuming most of the CPU time. After some profiling, we tracked down the issue to the method which resolves the record's name. In the current implementation, for every record visited, the class loader checks if a class with the record's name exists, causing an IO bottleneck in high loads. By caching the result, we were able to boost our performance by 7000%.