### PR TITLE
implement property and optionalProperty(String, JsonFormatVisitable, JavaType) methods 

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schemagen/AnnotationBasedTagGenerator.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schemagen/AnnotationBasedTagGenerator.java
@@ -13,4 +13,9 @@ public class AnnotationBasedTagGenerator implements TagGenerator
         throw new IllegalStateException("No index metadata found for " + writer.getFullName()
                 + " (usually annotated with @JsonProperty.index): either annotate all properties of type " + writer.getWrapperName().getSimpleName() + " with indexes or none at all");
     }
+
+    @Override
+    public int nextTag() {
+        throw new IllegalStateException("Index metadata not found, (usually annotated with @JsonProperty.index): either annotate all properties with indexes or none at all");
+    }
 }

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schemagen/TagGenerator.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schemagen/TagGenerator.java
@@ -4,4 +4,6 @@ import com.fasterxml.jackson.databind.BeanProperty;
 
 interface TagGenerator {
 	int nextTag(BeanProperty writer);
+
+	int nextTag();
 }


### PR DESCRIPTION
implemented the propery methods that take property name and type as inputs. This is needed to support custom (de)serializers that are using these methods. This can only be used with the DefaultTagGenerator so an IllegalStateException will be thrown if this gets mixed with properties annotated with @JsonProperty.index

I created this one on the 2.12 branch because my master branch was not compiling. can be cherry picked to master as well