### PR TITLE
Refactoring - Deleted Unnecessary conversion to String and Deleted Redundant Interface Modifier

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/SchemaBuilder.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/SchemaBuilder.java
@@ -3,5 +3,5 @@ package com.fasterxml.jackson.dataformat.avro.schema;
 import org.apache.avro.Schema;
 
 public interface SchemaBuilder {
-    public Schema builtAvroSchema();
+    Schema builtAvroSchema();
 }

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/WireType.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/WireType.java
@@ -5,10 +5,10 @@ package com.fasterxml.jackson.dataformat.protobuf.schema;
  */
 public interface WireType
 {
-    public final static int VINT = 0;
-    public final static int FIXED_64BIT = 1;
-    public final static int LENGTH_PREFIXED = 2;
-    public final static int GROUP_START = 3;
-    public final static int GROUP_END = 4;
-    public final static int FIXED_32BIT = 5;
+    int VINT = 0;
+    int FIXED_64BIT = 1;
+    int LENGTH_PREFIXED = 2;
+    int GROUP_START = 3;
+    int GROUP_END = 4;
+    int FIXED_32BIT = 5;
 }

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/parse/NumberParsingTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/parse/NumberParsingTest.java
@@ -317,7 +317,7 @@ public class NumberParsingTest
     public void testBigInteger() throws IOException
     {
         ByteArrayOutputStream bo = new ByteArrayOutputStream();
-        BigInteger in = new BigInteger(String.valueOf(Long.MIN_VALUE)+"0012575934");
+        BigInteger in = new BigInteger(Long.MIN_VALUE +"0012575934");
         SmileGenerator g = _smileGenerator(bo, false);
         g.writeNumber(in);
         g.close();


### PR DESCRIPTION
Hi, I committed two commits

Deleted Unnecessary conversion to String
Deleted Redundant Interface Modifier

This commitment supports to open source community for **Hacktoberfest**.