### PR TITLE
Reference to #149 in CBORParser should be #124

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -3361,7 +3361,7 @@ public class CBORParser extends ParserBase
     }
 
     private final BigInteger _bigNegative(long l) {
-        // 03-Dec-2017, tatu: [dataformats-binary#149] Careful with overflow
+        // 03-Dec-2017, tatu: [dataformats-binary#124] Careful with overflow
         BigInteger unsignedBase = _bigPositive(l);
         return unsignedBase.negate().subtract(BigInteger.ONE);
     }


### PR DESCRIPTION
#124 relates to a CBOR invalid integer value issue, whereas #149 is about polymorphic Ion serialization.