### PR TITLE
Add support for deserializing IonTimestamps and IonBlobs

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -159,6 +159,10 @@ public class IonParser
         return PackageVersion.VERSION;
     }
 
+    public IonSystem getIonSystem() {
+        return _system;
+    }
+
     /*
     /**********************************************************
     /* Capability introspection

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapperTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueMapperTest.java
@@ -128,6 +128,38 @@ public class IonValueMapperTest {
         assertRoundTrip(value, TestPojo2.class);
     }
 
+    @Test
+    public void testPojo2WithTimestamp() throws Exception {
+        String value = "{" +
+                "raw_value:2017-05-25T15:33:08Z," +
+                "raw_sexp:(this that)," +
+                "wrapped_sexp:{sexp:(other)}," +
+                "}";
+
+        TestPojo2 t = ionValueMapper.parse(ionSystem.singleValue(value), TestPojo2.class);
+        assertEquals(ionSystem.singleValue("2017-05-25T15:33:08Z"), t.rawValue);
+        assertEquals(ionSystem.singleValue("(this that)"), t.rawSexp);
+        assertEquals(ionSystem.singleValue("(other)"), t.wrappedSexp.sexp);
+
+        assertRoundTrip(value, TestPojo2.class);
+    }
+
+    @Test
+    public void testPojo2WithBlob() throws Exception {
+        String value = "{" +
+                "raw_value:{{YmxvYl92YWx1ZQ==}}," +
+                "raw_sexp:(this that)," +
+                "wrapped_sexp:{sexp:(other)}," +
+                "}";
+
+        TestPojo2 t = ionValueMapper.parse(ionSystem.singleValue(value), TestPojo2.class);
+        assertEquals(ionSystem.newBlob("blob_value".getBytes()), t.rawValue);
+        assertEquals(ionSystem.singleValue("(this that)"), t.rawSexp);
+        assertEquals(ionSystem.singleValue("(other)"), t.wrappedSexp.sexp);
+
+        assertRoundTrip(value, TestPojo2.class);
+    }
+
     /**
      * This Pojo supports open content
      */
@@ -154,12 +186,16 @@ public class IonValueMapperTest {
                 "expected:1," +
                 "something_unexpected:(boo!)," +
                 "another_random_struct:{yikes:scared}," +
+                "timestamp_att:2021-02-15T18:40:40Z," +
+                "blob_att:{{YmxvYl92YWx1ZQ==}}," +
                 "}";
 
         TestPojo3 t = ionValueMapper.parse(ionSystem.singleValue(value), TestPojo3.class);
         assertEquals(1, t.expected);
         assertEquals(ionSystem.singleValue("(boo!)"), t.any().get("something_unexpected"));
         assertEquals(ionSystem.singleValue("{yikes:scared}"), t.any().get("another_random_struct"));
+        assertEquals(ionSystem.singleValue("2021-02-15T18:40:40Z"), t.any().get("timestamp_att"));
+        assertEquals(ionSystem.newBlob("blob_value".getBytes()), t.any().get("blob_att"));
 
         assertRoundTrip(value, TestPojo3.class);
     }


### PR DESCRIPTION
Fixes #243 

When using the IonValueDeserializer, if the embeddedObject is _not_ an IonValue, wraps it in the appropriate IonValue.

I'm suggesting we merge this into 2.12, but it may be worth merging into previous versions as well.