### PR TITLE
Add convenience methods to for constructing IonObjectMapper.Builder

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonObjectMapper.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonObjectMapper.java
@@ -26,8 +26,10 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonReader;
+import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
+import com.amazon.ion.system.IonSystemBuilder;
 
 /**
  * Specialization of {@link ObjectMapper} that will set underlying
@@ -46,8 +48,57 @@ public class IonObjectMapper extends ObjectMapper
      */
     public static class Builder extends MapperBuilder<IonObjectMapper, Builder>
     {
+        protected final IonFactory _streamFactory;
+
         public Builder(IonObjectMapper m) {
             super(m);
+            _streamFactory = m.getFactory();
+        }
+
+        public Builder enable(IonParser.Feature... features) {
+            for (IonParser.Feature feature : features) {
+                _streamFactory.enable(feature);
+            }
+            return this;
+        }
+
+        public Builder disable(IonParser.Feature... features) {
+            for (IonParser.Feature feature : features) {
+                _streamFactory.disable(feature);
+            }
+            return this;
+        }
+
+        public Builder configure(IonParser.Feature feature, boolean state) {
+            if (state) {
+                _streamFactory.enable(feature);
+            } else {
+                _streamFactory.disable(feature);
+            }
+            return this;
+        }
+
+        public Builder enable(IonGenerator.Feature... features) {
+            for (IonGenerator.Feature feature : features) {
+                _streamFactory.enable(feature);
+            }
+            return this;
+        }
+
+        public Builder disable(IonGenerator.Feature... features) {
+            for (IonGenerator.Feature feature : features) {
+                _streamFactory.disable(feature);
+            }
+            return this;
+        }
+
+        public Builder configure(IonGenerator.Feature feature, boolean state) {
+            if (state) {
+                _streamFactory.enable(feature);
+            } else {
+                _streamFactory.disable(feature);
+            }
+            return this;
         }
     }
 
@@ -57,10 +108,17 @@ public class IonObjectMapper extends ObjectMapper
     /**********************************************************************
      */
 
+    /**
+     * Constructor that will construct the mapper with a standard {@link IonFactory}
+     * as codec, using textual writers by default.
+     */
     public IonObjectMapper() {
         this(new IonFactory());
     }
 
+    /**
+     * Constructor that will construct the mapper with a given {@link IonFactory}.
+     */
     public IonObjectMapper(IonFactory f) {
         super(f);
         f.setCodec(this);
@@ -77,8 +135,54 @@ public class IonObjectMapper extends ObjectMapper
         super(src);
     }
 
+    /**
+     * A builder for a mapper that will use textual writers by default. Same as
+     * {@link #builderForTextualWriters()}.
+     */
     public static Builder builder() {
-        return new Builder(new IonObjectMapper());
+        return builderForTextualWriters();
+    }
+
+    /**
+     * A builder for a mapper that will use textual writers by default and the
+     * provided {@link IonSystem}. Same as {@link #builderForTextualWriters(IonSystem)}.
+     */
+    public static Builder builder(IonSystem ionSystem) {
+        return builderForTextualWriters(ionSystem);
+    }
+
+    /**
+     * A builder for a mapper that will use binary writers by default.
+     */
+    public static Builder builderForBinaryWriters() {
+        return builderForBinaryWriters(IonSystemBuilder.standard().build());
+    }
+
+    /**
+     * A builder for a mapper that will use binary writers by default and the
+     * provided {@link IonSystem}
+     */
+    public static Builder builderForBinaryWriters(IonSystem ionSystem) {
+        return builder(IonFactory.builderForBinaryWriters()
+                .ionSystem(ionSystem)
+                .build());
+    }
+
+    /**
+     * A builder for a mapper that will use textual writers by default.
+     */
+    public static Builder builderForTextualWriters() {
+        return builderForTextualWriters(IonSystemBuilder.standard().build());
+    }
+
+    /**
+     * A builder for a mapper that will use textual writers by default and the
+     * provided {@link IonSystem}.
+     */
+    public static Builder builderForTextualWriters(IonSystem ionSystem) {
+        return builder(IonFactory.builderForTextualWriters()
+                .ionSystem(ionSystem)
+                .build());
     }
 
     public static Builder builder(IonFactory streamFactory) {

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindWriteTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/DataBindWriteTest.java
@@ -76,8 +76,7 @@ public class DataBindWriteTest {
     @Test
     public void testSimpleObjectWriteText() throws Exception
     {
-        IonObjectMapper m = new IonObjectMapper();
-        m.setCreateBinaryWriters(false);
+        IonObjectMapper m = IonObjectMapper.builderForTextualWriters().build();
         // now parse it using IonLoader and compare
         IonDatagram loadedDatagram = ion.newLoader().load(m.writeValueAsString(new MyBean()));
         assertEquals(expectedMyBean, loadedDatagram);
@@ -151,8 +150,7 @@ public class DataBindWriteTest {
 
     private byte[] _writeAsBytes(Object ob) throws IOException
     {
-        IonObjectMapper m = IonObjectMapper.builder(IonFactory.forBinaryWriters())
-                .build();
+        IonObjectMapper m = IonObjectMapper.builderForBinaryWriters().build();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         m.writeValue(out, ob);
         return out.toByteArray();

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/EnumAsIonSymbolSerializationTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/EnumAsIonSymbolSerializationTest.java
@@ -55,16 +55,12 @@ public class EnumAsIonSymbolSerializationTest
     }
 
     private static IonObjectMapper newMapper(boolean textual, boolean usingToString) {
-        final IonFactory f = (textual
-                ? IonFactory.builderForTextualWriters()
-                : IonFactory.builderForBinaryWriters()
-                )
-                .ionSystem(ION_SYSTEM)
-                .build();
-        final IonObjectMapper mapper = IonObjectMapper.builder(f)
-                .configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, usingToString)
+        IonObjectMapper.Builder builder = textual
+                ? IonObjectMapper.builderForTextualWriters(ION_SYSTEM)
+                : IonObjectMapper.builderForBinaryWriters(ION_SYSTEM);
+
+        return builder.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, usingToString)
                 .addModule(new EnumAsIonSymbolModule())
                 .build();
-        return mapper;
     }
 }

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/GenerateSexpTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/GenerateSexpTest.java
@@ -18,6 +18,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.system.IonSystemBuilder;
@@ -25,10 +29,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * End to end test verifying we can serialize sexps
@@ -41,7 +41,7 @@ public class GenerateSexpTest {
     @Before
     public void setup() {
         this.ionSystem = IonSystemBuilder.standard().build();
-        this.mapper = new IonObjectMapper(new IonFactory(null, ionSystem));
+        this.mapper = IonObjectMapper.builder(ionSystem).build();
     }
 
     @Test

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/failing/PrettyPrintWriteTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/failing/PrettyPrintWriteTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.ion.IonFactory;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 
 // For [dataformats-binary#245]: no pretty-printing for textual format
@@ -19,7 +18,7 @@ public class PrettyPrintWriteTest
     @Test
     public void testBasicPrettyPrintTextual() throws Exception
     {
-        IonObjectMapper mapper = IonObjectMapper.builder(IonFactory.forTextualWriters()).build();
+        IonObjectMapper mapper = IonObjectMapper.builderForTextualWriters().build();
         Assert.assertEquals("{\n  x:1,\n  y:2\n}",
                 mapper.writerWithDefaultPrettyPrinter().writeValueAsString(new Point()));
     }
@@ -28,7 +27,7 @@ public class PrettyPrintWriteTest
     @Test
     public void testIgnorePrettyPrintForBinary() throws Exception
     {
-        IonObjectMapper mapper = IonObjectMapper.builder(IonFactory.forBinaryWriters()).build();
+        IonObjectMapper mapper = IonObjectMapper.builderForBinaryWriters().build();
         byte[] encoded = mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(new Point());
         Assert.assertNotNull(encoded);
     }

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/polymorphism/SerializationAnnotationsTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/polymorphism/SerializationAnnotationsTest.java
@@ -4,7 +4,6 @@ import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.amazon.ion.util.Equivalence;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.dataformat.ion.IonFactory;
 import com.fasterxml.jackson.dataformat.ion.IonGenerator;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 import org.junit.Assert;
@@ -53,11 +52,9 @@ public class SerializationAnnotationsTest {
 
     @Test
     public void mapper() throws IOException {
-        IonObjectMapper mapper = new IonObjectMapper(
-                IonFactory.builderForTextualWriters()
-                    .disable(IonGenerator.Feature.USE_NATIVE_TYPE_ID)
-                    .build()
-        );
+        IonObjectMapper mapper = IonObjectMapper.builderForTextualWriters()
+                .disable(IonGenerator.Feature.USE_NATIVE_TYPE_ID)
+                .build();
 
         IonValue subclassAsIon = mapper.writeValueAsIonValue(subclass);
         assertEqualIonValues(SUBCLASS_TYPED_AS_PROPERTY, subclassAsIon);
@@ -75,11 +72,9 @@ public class SerializationAnnotationsTest {
 
         assertEqualIonValues(SUBCLASS_TYPED_BY_ANNOTATION, subclassAsIon);
 
-        IonObjectMapper reader = new IonObjectMapper(
-                IonFactory.builderForTextualWriters()
-                    .disable(IonGenerator.Feature.USE_NATIVE_TYPE_ID)
-                    .build()
-        );
+        IonObjectMapper reader = IonObjectMapper.builderForTextualWriters()
+                .disable(IonGenerator.Feature.USE_NATIVE_TYPE_ID)
+                .build();
 
         BaseClass roundTripInstance = reader.readValue(subclassAsIon, BaseClass.class);
 


### PR DESCRIPTION
This was referenced in https://github.com/FasterXML/jackson-dataformats-binary/issues/246 and it appears that it may have been resolved by accident. 

In any case, this serves to just add some convenience to the creation of an IonObjectMapper:
* Explicitly creating a builder for text or binary writers
* Allow a specified `IonSystem` at builder construction time
* Add convenience methods for setting `IonGenerator.Feature` or `IonParser.Feature`

These convenience methods respect the current defaults:
* [By default textual writers are enabled](https://github.com/FasterXML/jackson-dataformats-binary/blob/2.12/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java#L55-L58)
* [By default, a standard `IonSystem` is used](https://github.com/FasterXML/jackson-dataformats-binary/blob/2.12/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java#L80-L82) (`IonSystemBuilder.standard().build()`)

I've made this change to the `2.12` branch but this isn't urgent and can be moved to `2.13`, though it should be backwards compatible