### PR TITLE
Allow disabling native type ids when deserializing for #270

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
@@ -291,7 +291,7 @@ public class IonFactory extends JsonFactory {
      * @since 2.7
      */
     public IonParser createParser(IonReader in) {
-        return new IonParser(in, _system, _createContext(in, false), getCodec());
+        return new IonParser(in, _system, _createContext(in, false), getCodec(), _ionParserFeatures);
     }
 
     /**
@@ -299,7 +299,7 @@ public class IonFactory extends JsonFactory {
      */
     public IonParser createParser(IonValue value) {
         IonReader in = value.getSystem().newReader(value);
-        return new IonParser(in, _system, _createContext(in, true), getCodec());
+        return new IonParser(in, _system, _createContext(in, true), getCodec(), _ionParserFeatures);
     }
 
     // NOTE! Suboptimal return type -- but can't change safely before 3.0 as return
@@ -324,7 +324,7 @@ public class IonFactory extends JsonFactory {
      */
     @Deprecated
     public IonParser createJsonParser(IonReader in) {
-        return new IonParser(in, _system, _createContext(in, false), getCodec());
+        return new IonParser(in, _system, _createContext(in, false), getCodec(), _ionParserFeatures);
     }
 
     /**
@@ -333,7 +333,7 @@ public class IonFactory extends JsonFactory {
     @Deprecated
     public IonParser createJsonParser(IonValue value) {
         IonReader in = value.getSystem().newReader(value);
-        return new IonParser(in, _system, _createContext(in, true), getCodec());
+        return new IonParser(in, _system, _createContext(in, true), getCodec(), _ionParserFeatures);
     }
 
     /**
@@ -355,14 +355,14 @@ public class IonFactory extends JsonFactory {
         throws IOException
     {
         IonReader ion = _system.newReader(in);
-        return new IonParser(ion, _system, ctxt, getCodec());
+        return new IonParser(ion, _system, ctxt, getCodec(), _ionParserFeatures);
     }
 
     @Override
     protected JsonParser _createParser(Reader r, IOContext ctxt)
         throws IOException
     {
-        return new IonParser(_system.newReader(r), _system, ctxt, getCodec());
+        return new IonParser(_system.newReader(r), _system, ctxt, getCodec(), _ionParserFeatures);
     }
 
     @Override
@@ -376,7 +376,7 @@ public class IonFactory extends JsonFactory {
     protected JsonParser _createParser(byte[] data, int offset, int len, IOContext ctxt)
         throws IOException
     {
-        return new IonParser(_system.newReader(data, offset, len), _system, ctxt, getCodec());
+        return new IonParser(_system.newReader(data, offset, len), _system, ctxt, getCodec(), _ionParserFeatures);
     }
 
     @Override

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/polymorphism/PolymorphicTypeAnnotationsTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/polymorphism/PolymorphicTypeAnnotationsTest.java
@@ -1,0 +1,66 @@
+package com.fasterxml.jackson.dataformat.ion.polymorphism;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
+import com.fasterxml.jackson.dataformat.ion.IonParser.Feature;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonSystemBuilder;
+
+public class PolymorphicTypeAnnotationsTest {
+    private static final String SUBCLASS_TYPE_NAME = "subtype";
+
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "base",
+        visible = true
+    )
+    @JsonSubTypes({
+        @Type(value = Subclass.class, name = SUBCLASS_TYPE_NAME),
+    })
+    static public class BaseClass {
+    }
+
+
+    public static class Subclass extends BaseClass {
+        public String base;
+    }
+
+
+    public static class Container {
+        public BaseClass objectWithType;
+    }
+
+
+    private static final IonValue CONTAINER_WITH_TYPED_OBJECT = asIonValue(
+        "{" +
+        "  objectWithType:type::" +
+        "  {" +
+        "    base:\"" + SUBCLASS_TYPE_NAME + "\"," +
+        "  }" +
+        "}");
+
+    @Test
+    public void testNativeTypeIdsDisabledReadsTypeAnnotationsSuccessfully() throws IOException {
+        IonObjectMapper mapper = new IonObjectMapper();
+        mapper.disable(Feature.USE_NATIVE_TYPE_ID);
+
+        Container containerWithBaseClass = mapper.readValue(CONTAINER_WITH_TYPED_OBJECT, Container.class);
+
+        Assert.assertTrue(containerWithBaseClass.objectWithType instanceof Subclass);
+        Assert.assertEquals(SUBCLASS_TYPE_NAME, ((Subclass) containerWithBaseClass.objectWithType).base);
+    }
+
+    private static IonValue asIonValue(final String ionStr) {
+        return IonSystemBuilder.standard()
+            .build()
+            .singleValue(ionStr);
+    }
+}


### PR DESCRIPTION
This allows the check for native type ids to be disabled while deserializing. I would like to get feedback on this approach.

With the following example, native type ids will not be expected when deserializing.
```
IonObjectMapper mapper = new IonObjectMapper();
mapper.disable(IonParser.Feature.USE_NATIVE_TYPE_ID);
```

The full explanation of the problem this is solving can be found in #270 