### PR TITLE
Support base64 strings in `getBinaryValue()` for CBOR and Smile

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -1716,8 +1716,10 @@ public class CBORParser extends ParserBase
         if (_tokenIncomplete) {
             _finishToken();
         }
+        if (_currToken == JsonToken.VALUE_STRING) {
+            return b64variant.decode(_textBuffer.contentsAsString());
+        }
         if (_currToken != JsonToken.VALUE_EMBEDDED_OBJECT ) {
-            // TODO, maybe: support base64 for text?
             _reportError("Current token ("+currentToken()+") not VALUE_EMBEDDED_OBJECT, can not access as binary");
         }
         return _binaryValue;


### PR DESCRIPTION
Adds support for deserializing base64 strings as binary. Elasticsearch returns base64 strings
for binary fields, not native binary.