### PR TITLE
[Avro] Ease future customization by unifying place where a new visitor is created.

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/ArrayVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/ArrayVisitor.java
@@ -19,16 +19,16 @@ public class ArrayVisitor
     implements SchemaBuilder
 {
     protected final JavaType _type;
-    
-    protected final DefinedSchemas _schemas;
+
+    protected final VisitorFormatWrapperImpl _visitorWrapper;
 
     protected Schema _elementSchema;
-    
-    public ArrayVisitor(SerializerProvider p, JavaType type, DefinedSchemas schemas)
+
+    public ArrayVisitor(SerializerProvider p, JavaType type, VisitorFormatWrapperImpl visitorWrapper)
     {
         super(p);
         _type = type;
-        _schemas = schemas;
+        _visitorWrapper = visitorWrapper;
     }
 
     @Override
@@ -53,7 +53,7 @@ public class ArrayVisitor
     public void itemsFormat(JsonFormatVisitable visitable, JavaType type)
             throws JsonMappingException
     {
-        VisitorFormatWrapperImpl wrapper = new VisitorFormatWrapperImpl(_schemas, getProvider());
+        VisitorFormatWrapperImpl wrapper = _visitorWrapper.createVisitorWrapper();
         visitable.acceptJsonFormatVisitor(wrapper, type);
         _elementSchema = wrapper.getAvroSchema();
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/ArrayVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/ArrayVisitor.java
@@ -53,7 +53,7 @@ public class ArrayVisitor
     public void itemsFormat(JsonFormatVisitable visitable, JavaType type)
             throws JsonMappingException
     {
-        VisitorFormatWrapperImpl wrapper = _visitorWrapper.createVisitorWrapper();
+        VisitorFormatWrapperImpl wrapper = _visitorWrapper.createChildWrapper();
         visitable.acceptJsonFormatVisitor(wrapper, type);
         _elementSchema = wrapper.getAvroSchema();
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
@@ -14,17 +14,17 @@ public class MapVisitor extends JsonMapFormatVisitor.Base
 {
     protected final JavaType _type;
 
-    protected final DefinedSchemas _schemas;
-    
+    protected final VisitorFormatWrapperImpl _visitorWrapper;
+
     protected Schema _valueSchema;
 
     protected JavaType _keyType;
 
-    public MapVisitor(SerializerProvider p, JavaType type, DefinedSchemas schemas)
+    public MapVisitor(SerializerProvider p, JavaType type, VisitorFormatWrapperImpl visitorWrapper)
     {
         super(p);
         _type = type;
-        _schemas = schemas;
+        _visitorWrapper = visitorWrapper;
     }
 
     @Override
@@ -57,8 +57,8 @@ public class MapVisitor extends JsonMapFormatVisitor.Base
     public void valueFormat(JsonFormatVisitable handler, JavaType valueType)
         throws JsonMappingException
     {
-        VisitorFormatWrapperImpl wrapper = new VisitorFormatWrapperImpl(_schemas, getProvider());
-        handler.acceptJsonFormatVisitor(wrapper, valueType);
-        _valueSchema = wrapper.getAvroSchema();
+        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+        handler.acceptJsonFormatVisitor(visitorWrapper, valueType);
+        _valueSchema = visitorWrapper.getAvroSchema();
     }
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/MapVisitor.java
@@ -57,7 +57,7 @@ public class MapVisitor extends JsonMapFormatVisitor.Base
     public void valueFormat(JsonFormatVisitable handler, JavaType valueType)
         throws JsonMappingException
     {
-        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createChildWrapper();
         handler.acceptJsonFormatVisitor(visitorWrapper, valueType);
         _valueSchema = visitorWrapper.getAvroSchema();
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -23,7 +23,7 @@ public class RecordVisitor
 {
     protected final JavaType _type;
 
-    protected final DefinedSchemas _schemas;
+    protected final VisitorFormatWrapperImpl _visitorWrapper;
 
     /**
      * Tracks if the schema for this record has been overridden (by an annotation or other means), and calls to the {@code property} and
@@ -35,11 +35,11 @@ public class RecordVisitor
 
     protected List<Schema.Field> _fields = new ArrayList<Schema.Field>();
 
-    public RecordVisitor(SerializerProvider p, JavaType type, DefinedSchemas schemas)
+    public RecordVisitor(SerializerProvider p, JavaType type, VisitorFormatWrapperImpl visitorWrapper)
     {
         super(p);
         _type = type;
-        _schemas = schemas;
+        _visitorWrapper = visitorWrapper;
         // Check if the schema for this record is overridden
         BeanDescription bean = getProvider().getConfig().introspectDirectClassAnnotations(_type);
         List<NamedType> subTypes = getProvider().getAnnotationIntrospector().findSubtypes(bean.getClassInfo());
@@ -52,7 +52,7 @@ public class RecordVisitor
             try {
                 for (NamedType subType : subTypes) {
                     JsonSerializer<?> ser = getProvider().findValueSerializer(subType.getType());
-                    VisitorFormatWrapperImpl visitor = new VisitorFormatWrapperImpl(_schemas, getProvider());
+                    VisitorFormatWrapperImpl visitor = _visitorWrapper.createVisitorWrapper();
                     ser.acceptJsonFormatVisitor(visitor, getProvider().getTypeFactory().constructType(subType.getType()));
                     unionSchemas.add(visitor.getAvroSchema());
                 }
@@ -69,7 +69,7 @@ public class RecordVisitor
                 _avroSchema.addProp(meta.key(), meta.value());
             }
         }
-        schemas.addSchema(type, _avroSchema);
+        _visitorWrapper.getSchemas().addSchema(type, _avroSchema);
     }
 
     @Override
@@ -103,9 +103,9 @@ public class RecordVisitor
         if (_overridden) {
             return;
         }
-        VisitorFormatWrapperImpl wrapper = new VisitorFormatWrapperImpl(_schemas, getProvider());
-        handler.acceptJsonFormatVisitor(wrapper, type);
-        Schema schema = wrapper.getAvroSchema();
+        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+        handler.acceptJsonFormatVisitor(visitorWrapper, type);
+        Schema schema = visitorWrapper.getAvroSchema();
         _fields.add(new Schema.Field(name, schema, null, (Object) null));
     }
 
@@ -124,9 +124,9 @@ public class RecordVisitor
         if (_overridden) {
             return;
         }
-        VisitorFormatWrapperImpl wrapper = new VisitorFormatWrapperImpl(_schemas, getProvider());
-        handler.acceptJsonFormatVisitor(wrapper, type);
-        Schema schema = wrapper.getAvroSchema();
+        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+        handler.acceptJsonFormatVisitor(visitorWrapper, type);
+        Schema schema = visitorWrapper.getAvroSchema();
         if (!type.isPrimitive()) {
             schema = AvroSchemaHelper.unionWithNull(schema);
         }
@@ -170,9 +170,9 @@ public class RecordVisitor
                     }
                     ser = prov.findValueSerializer(prop.getType(), prop);
                 }
-                VisitorFormatWrapperImpl visitor = new VisitorFormatWrapperImpl(_schemas, prov);
-                ser.acceptJsonFormatVisitor(visitor, prop.getType());
-                writerSchema = visitor.getAvroSchema();
+                VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+                ser.acceptJsonFormatVisitor(visitorWrapper, prop.getType());
+                writerSchema = visitorWrapper.getAvroSchema();
             }
 
             /* 23-Nov-2012, tatu: Actually let's also assume that primitive type values

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -52,7 +52,7 @@ public class RecordVisitor
             try {
                 for (NamedType subType : subTypes) {
                     JsonSerializer<?> ser = getProvider().findValueSerializer(subType.getType());
-                    VisitorFormatWrapperImpl visitor = _visitorWrapper.createVisitorWrapper();
+                    VisitorFormatWrapperImpl visitor = _visitorWrapper.createChildWrapper();
                     ser.acceptJsonFormatVisitor(visitor, getProvider().getTypeFactory().constructType(subType.getType()));
                     unionSchemas.add(visitor.getAvroSchema());
                 }
@@ -103,7 +103,7 @@ public class RecordVisitor
         if (_overridden) {
             return;
         }
-        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createChildWrapper();
         handler.acceptJsonFormatVisitor(visitorWrapper, type);
         Schema schema = visitorWrapper.getAvroSchema();
         _fields.add(new Schema.Field(name, schema, null, (Object) null));
@@ -124,7 +124,7 @@ public class RecordVisitor
         if (_overridden) {
             return;
         }
-        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+        VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createChildWrapper();
         handler.acceptJsonFormatVisitor(visitorWrapper, type);
         Schema schema = visitorWrapper.getAvroSchema();
         if (!type.isPrimitive()) {
@@ -170,7 +170,7 @@ public class RecordVisitor
                     }
                     ser = prov.findValueSerializer(prop.getType(), prop);
                 }
-                VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createVisitorWrapper();
+                VisitorFormatWrapperImpl visitorWrapper = _visitorWrapper.createChildWrapper();
                 ser.acceptJsonFormatVisitor(visitorWrapper, prop.getType());
                 writerSchema = visitorWrapper.getAvroSchema();
             }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
@@ -49,6 +49,10 @@ public class VisitorFormatWrapperImpl
         _provider = p;
     }
 
+    protected VisitorFormatWrapperImpl createVisitorWrapper() {
+        return new VisitorFormatWrapperImpl(_schemas, _provider);
+    }
+
     @Override
     public SerializerProvider getProvider() {
         return _provider;
@@ -58,6 +62,10 @@ public class VisitorFormatWrapperImpl
     public void setProvider(SerializerProvider provider) {
         _schemas.setProvider(provider);
         _provider = provider;
+    }
+
+    protected DefinedSchemas getSchemas() {
+        return _schemas;
     }
 
     /*
@@ -95,14 +103,14 @@ public class VisitorFormatWrapperImpl
             _valueSchema = s;
             return null;
         }
-        RecordVisitor v = new RecordVisitor(_provider, type, _schemas);
+        RecordVisitor v = new RecordVisitor(_provider, type, this);
         _builder = v;
         return v;
     }
 
     @Override
     public JsonMapFormatVisitor expectMapFormat(JavaType mapType) {
-        MapVisitor v = new MapVisitor(_provider, mapType, _schemas);
+        MapVisitor v = new MapVisitor(_provider, mapType, this);
         _builder = v;
         return v;
     }
@@ -122,7 +130,7 @@ public class VisitorFormatWrapperImpl
                 return null;
             }
         }
-        ArrayVisitor v = new ArrayVisitor(_provider, convertedType, _schemas);
+        ArrayVisitor v = new ArrayVisitor(_provider, convertedType, this);
         _builder = v;
         return v;
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
@@ -49,7 +49,7 @@ public class VisitorFormatWrapperImpl
         _provider = p;
     }
 
-    protected VisitorFormatWrapperImpl createVisitorWrapper() {
+    protected VisitorFormatWrapperImpl createChildWrapper() {
         return new VisitorFormatWrapperImpl(_schemas, _provider);
     }
 


### PR DESCRIPTION
To ease customization by a user I suggest to add protected method `AvroFormatVisitorWrapper` (ex `VisitorFormatWrapperImpl`) createVisitorWrapper() into `AvroFormatVisitorWrapperwhich` creates and returns a new instance of visitor wrapper. This method would be used on each place where new visitor instance is created in ArrayVisitor, MapVisitor and RecordVisitor.

    By having this in place it is easier to add / modify existing functionality by a user. He just needs to extend existing visitor wrapper and override particular method (just ask me how I know it).

    ```
    protected AvroFormatVisitorWrapper createVisitorFormatWrapperImpl() {
        return new AvroFormatVisitorWrapper(_schemas, _provider);
    }
    ```

