### PR TITLE
[Avro] Generate logicalType switch

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/AvroJavaTimeModule.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/AvroJavaTimeModule.java
@@ -21,8 +21,8 @@ import java.time.ZonedDateTime;
 /**
  * A module that installs a collection of serializers and deserializers for java.time classes.
  *
- * This module is to be used either:
- *   - Instead of Java 8 date/time module (com.fasterxml.jackson.datatype.jsr310.JavaTimeModule) or
+ * AvroJavaTimeModule module is to be used either as:
+ *   - replacement of Java 8 date/time module (com.fasterxml.jackson.datatype.jsr310.JavaTimeModule) or
  *   - to override Java 8 date/time module and for that, module must be registered AFTER Java 8 date/time module.
  */
 public class AvroJavaTimeModule extends SimpleModule {

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroInstantSerializer.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroInstantSerializer.java
@@ -24,8 +24,8 @@ import java.util.function.Function;
  * Please note that time zone information gets lost in this process. Upon reading a value back, we can only
  * reconstruct the instant, but not the original representation.
  *
- * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.DateTimeVisitor} it aims to produce
- * Avro schema with type long and logicalType timestamp-millis:
+ * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator#enableLogicalTypes()}
+ * it aims to produce Avro schema with type long and logicalType timestamp-millis:
  * {
  *   "type" : "long",
  *   "logicalType" : "timestamp-millis"

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroLocalDateSerializer.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroLocalDateSerializer.java
@@ -18,8 +18,8 @@ import java.time.LocalDate;
  * Serialized value represents number of days from the unix epoch, 1 January 1970 with no reference
  * to a particular time zone or time of day.
  *
- * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.DateTimeVisitor} it aims to produce
- * Avro schema with type int and logicalType date:
+ * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator#enableLogicalTypes()}
+ * it aims to produce Avro schema with type int and logicalType date:
  * {
  *   "type" : "int",
  *   "logicalType" : "date"

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroLocalDateTimeSerializer.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroLocalDateTimeSerializer.java
@@ -20,8 +20,8 @@ import java.time.ZoneOffset;
  * Serialized value represents timestamp in a local timezone, regardless of what specific time zone
  * is considered local, with a precision of one millisecond from 1 January 1970 00:00:00.000.
  *
- * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.DateTimeVisitor} it aims to produce
- * Avro schema with type long and logicalType local-timestamp-millis:
+ * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator#enableLogicalTypes()}
+ * it aims to produce Avro schema with type long and logicalType local-timestamp-millis:
  * {
  *   "type" : "long",
  *   "logicalType" : "local-timestamp-millis"

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroLocalTimeSerializer.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/jsr310/ser/AvroLocalTimeSerializer.java
@@ -18,9 +18,9 @@ import java.time.LocalTime;
  * Serialized value represents time of day, with no reference to a particular calendar,
  * time zone or date, where the int stores the number of milliseconds after midnight, 00:00:00.000.
  *
- * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.DateTimeVisitor} it aims to produce
- * Avro schema with type int and logicalType time-millis:
- *  {
+ * Note: In combination with {@link com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator#enableLogicalTypes()}
+ * it aims to produce Avro schema with type int and logicalType time-millis:
+ * {
  *   "type" : "int",
  *   "logicalType" : "time-millis"
  * }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/DateTimeVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/DateTimeVisitor.java
@@ -39,7 +39,8 @@ public class DateTimeVisitor extends JsonIntegerFormatVisitor.Base
 
         Schema schema = AvroSchemaHelper.numericAvroSchema(_type);
         if (_hint != null) {
-            String logicalType = logicalType(_hint);
+            String logicalType = getLogicalType(schema.getType(), _hint);
+
             if (logicalType != null) {
                 schema.addProp(LogicalType.LOGICAL_TYPE_PROP, logicalType);
             } else {
@@ -49,26 +50,26 @@ public class DateTimeVisitor extends JsonIntegerFormatVisitor.Base
         return schema;
     }
 
-    private String logicalType(JavaType hint) {
+    private String getLogicalType(Schema.Type avroType, JavaType hint) {
         Class<?> clazz = hint.getRawClass();
 
-        if (OffsetDateTime.class.isAssignableFrom(clazz)) {
+        if (OffsetDateTime.class.isAssignableFrom(clazz) && Schema.Type.LONG == avroType) {
             return TIMESTAMP_MILLIS;
         }
-        if (ZonedDateTime.class.isAssignableFrom(clazz)) {
+        if (ZonedDateTime.class.isAssignableFrom(clazz) && Schema.Type.LONG == avroType) {
             return TIMESTAMP_MILLIS;
         }
-        if (Instant.class.isAssignableFrom(clazz)) {
+        if (Instant.class.isAssignableFrom(clazz) && Schema.Type.LONG == avroType) {
             return TIMESTAMP_MILLIS;
         }
 
-        if (LocalDate.class.isAssignableFrom(clazz)) {
+        if (LocalDate.class.isAssignableFrom(clazz) && Schema.Type.INT == avroType) {
             return DATE;
         }
-        if (LocalTime.class.isAssignableFrom(clazz)) {
+        if (LocalTime.class.isAssignableFrom(clazz) && Schema.Type.INT == avroType) {
             return TIME_MILLIS;
         }
-        if (LocalDateTime.class.isAssignableFrom(clazz)) {
+        if (LocalDateTime.class.isAssignableFrom(clazz) && Schema.Type.LONG == avroType) {
             return LOCAL_TIMESTAMP_MILLIS;
         }
 

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
@@ -27,6 +27,8 @@ public class VisitorFormatWrapperImpl
 
     protected final DefinedSchemas _schemas;
 
+    protected boolean _logicalTypesEnabled = false;
+
     /**
      * Visitor used for resolving actual Schema, if structured type
      * (or one with complex configuration)
@@ -49,8 +51,21 @@ public class VisitorFormatWrapperImpl
         _provider = p;
     }
 
+
+    protected VisitorFormatWrapperImpl(VisitorFormatWrapperImpl src) {
+        this._schemas = src._schemas;
+        this._provider = src._provider;
+        this._logicalTypesEnabled = src._logicalTypesEnabled;
+    }
+
+    /**
+     * Creates new {@link VisitorFormatWrapperImpl} instance with shared schemas,
+     * serialization provider and same configuration.
+     *
+     * @return new instance with shared properties and configuration.
+     */
     protected VisitorFormatWrapperImpl createChildWrapper() {
-        return new VisitorFormatWrapperImpl(_schemas, _provider);
+        return new VisitorFormatWrapperImpl(this);
     }
 
     @Override
@@ -83,6 +98,24 @@ public class VisitorFormatWrapperImpl
                     +": no schema generated");
         }
         return _builder.builtAvroSchema();
+    }
+
+    /**
+     * Enables Avro schema with Logical Types generation.
+     */
+    public void enableLogicalTypes() {
+        _logicalTypesEnabled = true;
+    }
+
+    /**
+     * Disables Avro schema with Logical Types generation.
+     */
+    public void disableLogicalTypes() {
+        _logicalTypesEnabled = false;
+    }
+
+    public boolean isLogicalTypesEnabled() {
+        return _logicalTypesEnabled;
     }
 
     /*
@@ -166,7 +199,7 @@ public class VisitorFormatWrapperImpl
             return null;
         }
 
-        if (_isDateTimeType(type)) {
+        if (isLogicalTypesEnabled() && _isDateTimeType(type)) {
             DateTimeVisitor v = new DateTimeVisitor(type);
             _builder = v;
             return v;

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/jsr310/AvroJavaTimeModule_schemaCreationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/jsr310/AvroJavaTimeModule_schemaCreationTest.java
@@ -55,6 +55,7 @@ public class AvroJavaTimeModule_schemaCreationTest {
                 .addModule(new AvroJavaTimeModule())
                 .build();
         AvroSchemaGenerator gen = new AvroSchemaGenerator();
+        gen.enableLogicalTypes();
 
         // WHEN
         mapper.acceptJsonFormatVisitor(testClass, gen);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/DateTimeVisitor_builtAvroSchemaTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/DateTimeVisitor_builtAvroSchemaTest.java
@@ -1,0 +1,100 @@
+package com.fasterxml.jackson.dataformat.avro.schema;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class DateTimeVisitor_builtAvroSchemaTest {
+
+    private static final TypeFactory TYPE_FACTORY = TypeFactory.defaultInstance();
+
+    @Parameter(0)
+    public Class testClass;
+
+    @Parameter(1)
+    public JsonParser.NumberType givenNumberType;
+
+    @Parameter(2)
+    public Schema.Type expectedAvroType;
+
+    @Parameter(3)
+    public String expectedLogicalType;
+
+    @Parameters(name = "With {0} and number type {1}")
+    public static Collection testData() {
+        return Arrays.asList(new Object[][]{
+                // Java type  | given number type, | expected Avro type | expected logicalType
+                {
+                        Instant.class,
+                        JsonParser.NumberType.LONG,
+                        Schema.Type.LONG,
+                        "timestamp-millis"},
+                {
+                        OffsetDateTime.class,
+                        JsonParser.NumberType.LONG,
+                        Schema.Type.LONG,
+                        "timestamp-millis"},
+                {
+                        ZonedDateTime.class,
+                        JsonParser.NumberType.LONG,
+                        Schema.Type.LONG,
+                        "timestamp-millis"},
+                {
+                        LocalDateTime.class,
+                        JsonParser.NumberType.LONG,
+                        Schema.Type.LONG,
+                        "local-timestamp-millis"},
+                {
+                        LocalDate.class,
+                        JsonParser.NumberType.INT,
+                        Schema.Type.INT,
+                        "date"},
+                {
+                        LocalTime.class,
+                        JsonParser.NumberType.INT,
+                        Schema.Type.INT,
+                        "time-millis"},
+        });
+    }
+
+    @Test
+    public void builtAvroSchemaTest() {
+        // GIVEN
+        DateTimeVisitor dateTimeVisitor = new DateTimeVisitor(TYPE_FACTORY.constructSimpleType(testClass, null));
+        dateTimeVisitor.numberType(givenNumberType);
+
+        // WHEN
+        Schema actualSchema = dateTimeVisitor.builtAvroSchema();
+
+        System.out.println(testClass.getName() + " schema:\n" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getType()).isEqualTo(expectedAvroType);
+        assertThat(actualSchema.getProp(LogicalType.LOGICAL_TYPE_PROP)).isEqualTo(expectedLogicalType);
+        /**
+         * Having logicalType and java-class is not valid according to
+         * {@link LogicalType#validate(Schema)}
+         */
+        assertThat(actualSchema.getProp(SpecificData.CLASS_PROP)).isNull();
+    }
+
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl_createChildWrapperTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl_createChildWrapperTest.java
@@ -1,0 +1,28 @@
+package com.fasterxml.jackson.dataformat.avro.schema;
+
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class VisitorFormatWrapperImpl_createChildWrapperTest {
+
+    @Test
+    public void test () {
+        // GIVEN
+        SerializerProvider serializerProvider = new DefaultSerializerProvider.Impl();
+        DefinedSchemas schemas = new DefinedSchemas();
+
+        VisitorFormatWrapperImpl src = new VisitorFormatWrapperImpl(schemas, serializerProvider);
+        src.enableLogicalTypes();
+
+        // WHEN
+        VisitorFormatWrapperImpl actual = src.createChildWrapper();
+
+        // THEN
+        // All settings are inherited from parent visitor wrapper.
+        Assertions.assertThat(actual.getSchemas()).isEqualTo(schemas);
+        Assertions.assertThat(actual.getProvider()).isEqualTo(serializerProvider);
+        Assertions.assertThat(actual.isLogicalTypesEnabled()).isTrue();
+    }
+}


### PR DESCRIPTION
Switch to enable / disable generation of Avro logical types.
Logical types generation is disabled by default - I this it more sensitive that way.

BTW: This PR is build upon #292. It is better to start with that one first.

Closes #290.
