### PR TITLE
fix 15 flaky tests

### DIFF
--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/seq/SequenceWriterTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/seq/SequenceWriterTest.java
@@ -9,10 +9,13 @@ import com.fasterxml.jackson.databind.SequenceWriter;
 
 import com.fasterxml.jackson.dataformat.cbor.CBORTestBase;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 public class SequenceWriterTest extends CBORTestBase
 {
     private final ObjectMapper MAPPER = cborMapper();
 
+    @JsonPropertyOrder({ "id", "value"}) 
     static class IdValue {
         public int id, value;
 

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufTestBase.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufTestBase.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufMessage;
 
 import junit.framework.TestCase;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 public abstract class ProtobufTestBase extends TestCase
 {
     /*
@@ -149,6 +151,7 @@ public abstract class ProtobufTestBase extends TestCase
     /**********************************************************
      */
 
+    @JsonPropertyOrder({ "x", "y"})
     static class Point {
         public int x;
         public int y;
@@ -174,6 +177,7 @@ public abstract class ProtobufTestBase extends TestCase
         }
     }
 
+    @JsonPropertyOrder({ "x", "y", "z" })
     static class Point3 {
         public int x, y, z;
 
@@ -277,6 +281,7 @@ public abstract class ProtobufTestBase extends TestCase
         }
     }
     
+    @JsonPropertyOrder({ "topLeft", "bottomRight"})
     static class Box {
         public Point topLeft, bottomRight;
 
@@ -296,6 +301,7 @@ public abstract class ProtobufTestBase extends TestCase
         }
     }
 
+    @JsonPropertyOrder({ "first", "last"})
     static class Name {
         public String first, last;
 

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/WriteBinaryTest.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/WriteBinaryTest.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.dataformat.protobuf.schema.*;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 public class WriteBinaryTest extends ProtobufTestBase
 {
     final protected static String PROTOC_BINARY =
@@ -15,6 +17,7 @@ public class WriteBinaryTest extends ProtobufTestBase
             +"}\n"
     ;
 
+    @JsonPropertyOrder({ "id", "trailer", "data"})
     static class Binary {
         public int id, trailer;
         public byte[] data;

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/seq/SequenceWriterTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/seq/SequenceWriterTest.java
@@ -9,10 +9,13 @@ import com.fasterxml.jackson.databind.SequenceWriter;
 
 import com.fasterxml.jackson.dataformat.smile.BaseTestForSmile;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 public class SequenceWriterTest extends BaseTestForSmile
 {
     private final ObjectMapper MAPPER = smileMapper();
 
+    @JsonPropertyOrder({ "id", "value"})
     static class IdValue {
         public int id, value;
 


### PR DESCRIPTION
Fix 15 flaky tests using java annotation. A ﬂaky test is an analysis of web application code that fails to produce the same result each time the same analysis is run. Flaky tests are detected by nondex (https://github.com/TestingResearchIllinois/NonDex) which is tool developped by the research group led by professor Darko at UIUC.

com.fasterxml.jackson.dataformat.cbor.seq.SequenceWriterTest#testSimpleSeqWrite
com.fasterxml.jackson.dataformat.smile.seq.SequenceWriterTest#testSimpleSeqWrite
com.fasterxml.jackson.dataformat.protobuf.NextXxxParsingTeskt#testNextInt
com.fasterxml.jackson.dataformat.protobuf.WriteArrayTest#testPointArrayPacked            
com.fasterxml.jackson.dataformat.protobuf.WriteArrayTest#testPointArraySparse 
com.fasterxml.jackson.dataformat.protobuf.WriteSimpleTest#testWritePointInt              
com.fasterxml.jackson.dataformat.protobuf.ReadSimpleTest#testReadPointInt                
com.fasterxml.jackson.dataformat.protobuf.ReadSimpleTest#testReadPointLong               
com.fasterxml.jackson.dataformat.protobuf.ReadSimpleTest#testStringArrayWithName         
com.fasterxml.jackson.dataformat.protobuf.WriteBinaryTest#testSimpleBinary               
com.fasterxml.jackson.dataformat.protobuf.WriteSimpleTest#testWriteCoord                 
com.fasterxml.jackson.dataformat.protobuf.WriteStringsTest#testSimpleShort               
com.fasterxml.jackson.dataformat.protobuf.WriteStringsTest#testSimpleLongAscii  
com.fasterxml.jackson.dataformat.protobuf.WriteStringsTest#testSimpleLongTwoByteUTF8     
com.fasterxml.jackson.dataformat.protobuf.WriteStringsTest#testSimpleLongThreeByteUTF8