### PR TITLE
Set StreamReadCapability.EXACT_FLOATS=true

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -420,8 +420,7 @@ public class CBORParser extends ParserMinimalBase
 
     @Override // since 2.12
     public JacksonFeatureSet<StreamReadCapability> getReadCapabilities() {
-        // Defaults are fine
-        return DEFAULT_READ_CAPABILITIES;
+        return DEFAULT_READ_CAPABILITIES.with(StreamReadCapability.EXACT_FLOATS);
     }
 
     /*

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/FloatPrecisionTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/FloatPrecisionTest.java
@@ -1,0 +1,41 @@
+package com.fasterxml.jackson.dataformat.cbor;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertArrayEquals;
+
+
+// for [jackson-core#730]
+public class FloatPrecisionTest extends CBORTestBase
+{
+    // for [jackson-core#730]
+    public void testFloatRoundtrips() throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGenerator gen = cborGenerator(out);
+        gen.writeStartArray();
+
+        gen.writeNumber(Float.MIN_VALUE);
+        gen.writeNumber(0.0f);
+        gen.writeNumber(Float.MAX_VALUE);
+
+        gen.writeNumber(Double.MIN_VALUE);
+        gen.writeNumber(0.0d);
+        gen.writeNumber(Double.MAX_VALUE);
+
+        gen.writeNumber(new BigDecimal("1e999"));
+        gen.writeEndArray();
+        gen.close();
+        byte[] expected = out.toByteArray();
+
+        CBORParser parser = cborParser(expected);
+        ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+        CBORGenerator gen2 = cborGenerator(out2);
+        parser.nextToken();
+        gen2.copyCurrentStructure(parser);
+        gen2.close();
+        byte[] actual = out2.toByteArray();
+        assertArrayEquals(expected, actual);
+    }
+}

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
@@ -319,10 +319,12 @@ public abstract class SmileParserBase extends ParserMinimalBase
         return this;
     }
 
+    protected final static JacksonFeatureSet<StreamReadCapability> SMILE_READ_CAPABILITIES
+        = DEFAULT_READ_CAPABILITIES.with(StreamReadCapability.EXACT_FLOATS);
+
     @Override // since 2.12
     public JacksonFeatureSet<StreamReadCapability> getReadCapabilities() {
-        // Defaults are fine
-        return DEFAULT_READ_CAPABILITIES;
+        return SMILE_READ_CAPABILITIES;
     }
 
     /*

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/FloatPrecisionTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/FloatPrecisionTest.java
@@ -1,0 +1,45 @@
+package com.fasterxml.jackson.dataformat.smile;
+
+import com.fasterxml.jackson.dataformat.smile.BaseTestForSmile;
+import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
+import com.fasterxml.jackson.dataformat.smile.SmileParser;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertArrayEquals;
+
+
+// for [jackson-core#730]
+public class FloatPrecisionTest extends BaseTestForSmile
+{
+    // for [jackson-core#730]
+    public void testFloatRoundtrips() throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SmileGenerator gen = smileGenerator(out, true);
+        gen.writeStartArray();
+
+        gen.writeNumber(Float.MIN_VALUE);
+        gen.writeNumber(0.0f);
+        gen.writeNumber(Float.MAX_VALUE);
+
+        gen.writeNumber(Double.MIN_VALUE);
+        gen.writeNumber(0.0d);
+        gen.writeNumber(Double.MAX_VALUE);
+
+        gen.writeNumber(new BigDecimal("1e999"));
+        gen.writeEndArray();
+        gen.close();
+        byte[] expected = out.toByteArray();
+
+        SmileParser parser = _smileParser(expected);
+        ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+        SmileGenerator gen2 = smileGenerator(out2, true);
+        parser.nextToken();
+        gen2.copyCurrentStructure(parser);
+        gen2.close();
+        byte[] actual = out2.toByteArray();
+        assertArrayEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
This gets the ball rolling setting the `StreamReadCapability.EXACT_FLOATS` flag from https://github.com/FasterXML/jackson-core/pull/733 (issue: https://github.com/FasterXML/jackson-core/issues/730).

- [x] Smile
- [x] CBOR
- [ ] Avro
- [ ] Protobuf
- [ ] Ion

I'm pausing here to take feedback (on both PRs) before proceeding with the last three formats (which I'm slightly less familiar with anyway).