### PR TITLE
Fixes wrapping of IonException with StreamReadException

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -508,7 +508,7 @@ public class IonParser
         try {
             type = _reader.next();
         } catch (IonException e) {
-            _constructReadException(e.getMessage(), e);
+            throw _constructReadException(e.getMessage(), e);
         }
         if (type == null) {
             if (_streamReadContext.inRoot()) { // EOF?
@@ -530,7 +530,7 @@ public class IonParser
             // field name symbol cannot be resolved.
             _streamReadContext.setCurrentName(inStruct ? _reader.getFieldName() : null);
         } catch (UnknownSymbolException e) {
-            _constructReadException(e.getMessage(), e);
+            throw _constructReadException(e.getMessage(), e);
         }
         JsonToken t = _tokenFromType(type);
         // and return either field name first


### PR DESCRIPTION
Fixes wrapping of `IonException` with `StreamReadException`.

When [this patch](https://github.com/FasterXML/jackson-dataformats-binary/commit/c3bc484817298ae441d83812ebd256f34aac0c3a) was merged from `2.14` to `master` for #311, the calls to [`wrapError(...)`](https://github.com/FasterXML/jackson-core/blob/4dbffe741d2a8d53b442dd16c5916f313a669d05/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java#L748-L750) were replaced with calls to [`_constructReadException(...)`](https://github.com/FasterXML/jackson-core/blob/115e74413746c910b349a10d5f63d529624c38d1/src/main/java/com/fasterxml/jackson/core/JsonParser.java#L1633-L1635).

However, the behavior of these two methods is not the same—`_wrapError(...)` _throws_ the new exception whereas `_constructReadException(...)` _returns_ the new exception.

This PR adds the necessary `throw`s in front of the calls to `_constructReadException(...)` in `IonParser`.




