### PR TITLE
Fix getNullValue of IonValueDeserializer. 

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
@@ -63,7 +63,8 @@ class IonValueDeserializer extends JsonDeserializer<IonValue> {
             final JsonParser parser = ctxt.getParser();
             if (parser != null && parser.getCurrentToken() != JsonToken.END_OBJECT) {
                 final Object embeddedObj = parser.getEmbeddedObject();
-                if ((embeddedObj instanceof IonValue) && !(embeddedObj instanceof IonNull)) {
+                if ((embeddedObj instanceof IonValue)
+                    && ( (parser.getTypeId() != null) || !(embeddedObj instanceof IonNull))) {
                     final IonValue iv = (IonValue) embeddedObj;
                     if (iv.isNullValue()) {
                         return iv;

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
@@ -14,6 +14,8 @@
 
 package com.fasterxml.jackson.dataformat.ion.ionvalue;
 
+import com.amazon.ion.IonNull;
+import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -58,11 +60,14 @@ class IonValueDeserializer extends JsonDeserializer<IonValue> {
     @Override
     public IonValue getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         try {
-            Object embeddedObj = ctxt.getParser().getEmbeddedObject();
-            if (embeddedObj instanceof IonValue) {
-                IonValue iv = (IonValue) embeddedObj;
-                if (iv.isNullValue()) {
-                    return iv;
+            final JsonParser parser = ctxt.getParser();
+            if (parser != null && parser.getCurrentToken() != JsonToken.END_OBJECT) {
+                final Object embeddedObj = parser.getEmbeddedObject();
+                if ((embeddedObj instanceof IonValue) && !(embeddedObj instanceof IonNull)) {
+                    final IonValue iv = (IonValue) embeddedObj;
+                    if (iv.isNullValue()) {
+                        return iv;
+                    }
                 }
             }
 

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
@@ -116,17 +116,30 @@ public class IonValueDeserializerTest {
         IonValueData source = new IonValueData();
         source.put("a", null); // Serialized to IonNull, deserialized back to java null
         source.put("b", ion("null.bool"));
+        source.put("ba", ion("foo::null.bool"));
         source.put("c", ion("null.int"));
+        source.put("ca", ion("foo::null.int"));
         source.put("d", ion("null.float"));
+        source.put("da", ion("foo::null.float"));
         source.put("e", ion("null.decimal"));
+        source.put("ea", ion("foo::null.decimal"));
         source.put("f", ion("null.timestamp"));
+        source.put("fa", ion("foo::null.timestamp"));
         source.put("g", ion("null.string"));
+        source.put("ga", ion("foo::null.string"));
         source.put("h", ion("null.symbol"));
+        source.put("ha", ion("foo::null.symbol"));
         source.put("i", ion("null.blob"));
+        source.put("ia", ion("foo::null.blob"));
         source.put("j", ion("null.clob"));
+        source.put("ja", ion("foo::null.clob"));
         source.put("k", ion("null.struct"));
+        source.put("ka", ion("foo::null.struct"));
         source.put("l", ion("null.list"));
+        source.put("la", ion("foo::null.list"));
         source.put("m", ion("null.sexp"));
+        source.put("ma", ion("foo::null.sexp"));
+        source.put("maa", ion("'com.foo.Bar'::null.sexp"));
 
         IonValue data = ION_VALUE_MAPPER.writeValueAsIonValue(source);
         IonValueData result = ION_VALUE_MAPPER.readValue(data, IonValueData.class);
@@ -135,7 +148,21 @@ public class IonValueDeserializerTest {
     }
 
     @Test
-    public void shouldBeAbleToDeserializeIonNullToJavaNull() throws Exception {
+    public void shouldBeAbleToDeserializeAnnotatedIonNull() throws Exception {
+        IonValueData source = new IonValueData();
+        source.put("a", ion("foo::null"));
+        source.put("aa", ion("'com.foo.Bar'::null"));
+        source.put("b", ion("foo::null.null"));
+        source.put("ba", ion("'com.foo.Bar'::null.null"));
+
+        IonValue data = ION_VALUE_MAPPER.writeValueAsIonValue(source);
+        IonValueData result = ION_VALUE_MAPPER.readValue(data, IonValueData.class);
+
+        assertEquals(source, result);
+    }
+
+    @Test
+    public void shouldBeAbleToDeserializeUnannotatedIonNullToJavaNull() throws Exception {
         IonValueData source = new IonValueData();
         source.put("a", null);
         source.put("b", ion("null"));

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
@@ -113,11 +113,25 @@ public class IonValueDeserializerTest {
 
     @Test
     public void shouldBeAbleToDeserializeNullValue() throws Exception {
-        IonValue ion = SYSTEM.newNull();
+        IonValueData source = new IonValueData();
+        source.put("a", null); // Serialized to IonNull, deserialized back to java null
+        source.put("b", ion("null.bool"));
+        source.put("c", ion("null.int"));
+        source.put("d", ion("null.float"));
+        source.put("e", ion("null.decimal"));
+        source.put("f", ion("null.timestamp"));
+        source.put("g", ion("null.string"));
+        source.put("h", ion("null.symbol"));
+        source.put("i", ion("null.blob"));
+        source.put("j", ion("null.clob"));
+        source.put("k", ion("null.struct"));
+        source.put("l", ion("null.list"));
+        source.put("m", ion("null.sexp"));
 
-        IonValue data = ION_VALUE_MAPPER.readValue(ion, IonValue.class);
+        IonValue data = ION_VALUE_MAPPER.writeValueAsIonValue(source);
+        IonValueData result = ION_VALUE_MAPPER.readValue(data, IonValueData.class);
 
-        assertEquals(ion, data);
+        assertEquals(source, result);
     }
 
     @Test

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
@@ -135,6 +135,24 @@ public class IonValueDeserializerTest {
     }
 
     @Test
+    public void shouldBeAbleToDeserializeIonNullToJavaNull() throws Exception {
+        IonValueData source = new IonValueData();
+        source.put("a", null);
+        source.put("b", ion("null"));
+        source.put("c", ion("null.null"));
+
+        IonValue data = ION_VALUE_MAPPER.writeValueAsIonValue(source);
+        IonValueData result = ION_VALUE_MAPPER.readValue(data, IonValueData.class);
+
+        IonValueData expected = new IonValueData();
+        expected.put("a", null);
+        expected.put("b", null);
+        expected.put("c", null);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
     public void shouldBeAbleToDeserializeAnnotatedNullStruct() throws Exception {
         IonValue ion = ion("foo::null.struct");
 


### PR DESCRIPTION
This PR aims to resolve the issues https://github.com/FasterXML/jackson-dataformats-binary/issues/317 and https://github.com/FasterXML/jackson-dataformats-binary/issues/318

Changes:
1. Do not call getEmbeddedObject when current token is END_OBJECT
2. Make sure java nulls are deserialized correctly
3. Update unit test case with nulls