### PR TITLE
check added to prevent IonValue null deserialization to fail when bean has a missing property

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
@@ -17,6 +17,7 @@ package com.fasterxml.jackson.dataformat.ion.ionvalue;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -58,11 +59,14 @@ class IonValueDeserializer extends JsonDeserializer<IonValue> {
     @Override
     public IonValue getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         try {
-            Object embeddedObj = ctxt.getParser().getEmbeddedObject();
-            if (embeddedObj instanceof IonValue) {
-                IonValue iv = (IonValue) embeddedObj;
-                if (iv.isNullValue()) {
-                    return iv;
+            final JsonParser parser = ctxt.getParser();
+            if (parser != null && parser.getCurrentToken() != JsonToken.END_OBJECT) {
+                final Object embeddedObj = parser.getEmbeddedObject();
+                if (embeddedObj instanceof IonValue) {
+                    IonValue iv = (IonValue) embeddedObj;
+                    if (iv.isNullValue()) {
+                        return iv;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR aims to resolve the issue https://github.com/FasterXML/jackson-dataformats-binary/issues/317
This is a duplicate of https://github.com/FasterXML/jackson-dataformats-binary/pull/320 which was created over 2.14. 
This PR is created using 2.13 branch as base.

Changes:

- Do not call getEmbeddedObject when current token is END_OBJECT
- Add unit test case exposing the issue