### PR TITLE
Ensure `IonReader` instances created within `IonFactory` are always resource-managed

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonFactory.java
@@ -360,14 +360,17 @@ public class IonFactory extends JsonFactory
         throws IOException
     {
         IonReader ion = _system.newReader(in);
-        return new IonParser(ion, _system, ctxt, getCodec(), _ionParserFeatures);
+        return new IonParser(ion, _system,
+                _createContext(_createContentReference(ion), true), getCodec(), _ionParserFeatures);
     }
 
     @Override
     protected JsonParser _createParser(Reader r, IOContext ctxt)
         throws IOException
     {
-        return new IonParser(_system.newReader(r), _system, ctxt, getCodec(), _ionParserFeatures);
+        IonReader ion = _system.newReader(r);
+        return new IonParser(ion, _system,
+                _createContext(_createContentReference(ion), true), getCodec(), _ionParserFeatures);
     }
 
     @Override
@@ -381,7 +384,9 @@ public class IonFactory extends JsonFactory
     protected JsonParser _createParser(byte[] data, int offset, int len, IOContext ctxt)
         throws IOException
     {
-        return new IonParser(_system.newReader(data, offset, len), _system, ctxt, getCodec(), _ionParserFeatures);
+        IonReader ion = _system.newReader(data, offset, len);
+        return new IonParser(ion, _system,
+                _createContext(_createContentReference(ion), true), getCodec(), _ionParserFeatures);
     }
 
     @Override

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonFactoryTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/IonFactoryTest.java
@@ -1,0 +1,71 @@
+package com.fasterxml.jackson.dataformat.ion;
+
+import com.amazon.ion.IonReader;
+import com.fasterxml.jackson.core.JsonParser;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IonFactoryTest {
+
+    // 4-byte Ion 1.0 IVM followed by int 0.
+    private static final byte[] BINARY_INT_0 = new byte[] {(byte) 0xE0, 0x01, 0x00, (byte) 0xEA, 0x20};
+    private static final String TEXT_INT_0 = "0";
+
+    @Test
+    public void byteArrayIsManaged() throws Throwable {
+        assertResourceManaged(true, parser(f -> f.createParser(BINARY_INT_0)));
+    }
+
+    @Test
+    public void charArrayIsManaged() throws Throwable {
+        assertResourceManaged(true, parser(f -> f.createParser(TEXT_INT_0.toCharArray())));
+    }
+
+    @Test
+    public void readerIsManaged() throws Throwable {
+        assertResourceManaged(true, parser(f -> f.createParser(new StringReader(TEXT_INT_0))));
+    }
+
+    @Test
+    public void inputStreamIsManaged() throws Throwable {
+        assertResourceManaged(true, parser(f -> f.createParser(new ByteArrayInputStream(BINARY_INT_0))));
+    }
+
+    @Test
+    public void ionValueIsManaged() throws Throwable {
+        assertResourceManaged(true, parser(f -> f.createParser(f.getIonSystem().newInt(0))));
+    }
+
+    @Test
+    public void ionReaderIsNotManaged() throws Throwable {
+        // When the user provides an IonReader, it is not resource-managed, meaning that the user retains the
+        // responsibility to close it. In all other cases, the IonReader is created internally, is resource-managed,
+        // and is closed automatically in IonParser.close().
+        assertResourceManaged(false, parser(f -> f.createParser(f.getIonSystem().newReader(BINARY_INT_0))));
+    }
+
+    private void assertResourceManaged(boolean expectResourceManaged, ThrowingSupplier<IonParser> supplier)
+        throws Throwable {
+        IonParser parser = supplier.get();
+        assertEquals(expectResourceManaged, parser._ioContext.isResourceManaged());
+        assertTrue(IonReader.class.isAssignableFrom(parser._ioContext.contentReference().getRawContent().getClass()));
+        parser.close();
+    }
+
+    private interface ThrowingFunction<T, R> {
+        R apply(T t) throws Throwable;
+    }
+
+    private interface ThrowingSupplier<T> {
+        T get() throws Throwable;
+    }
+
+    private static ThrowingSupplier<IonParser> parser(ThrowingFunction<IonFactory, JsonParser> f) {
+        return () -> (IonParser) f.apply(new IonFactory());
+    }
+}


### PR DESCRIPTION
This is intended to fix the memory leak issue described in #306, superseding that pull request.

This solution ensures that `IonReader` instances created by `IonFactory` are marked as "resource-managed", meaning that they are closed during `IonParser.close()`. Closing an `IonReader` causes it to close any resources it creates (e.g. a `GZIPInputStream`, as was the case in the original PR).

Note: `IonFactory`/`IonParser` currently ignores the `StreamReadFeature.AUTO_CLOSE_SOURCE` feature, which allows users to opt-in to disabling closure of resources (e.g. an `InputStream`) provided by the user. Before this change, user-provided `InputStream`s and `Reader`s would not be closed by `IonParser.close()` because the `IonReader` created to wrap the resources was never closed. Now that that `IonReader` is closed, those user-provided resources will be closed transitively via `IonReader.close()`. Although this is technically a behavioral change, it seems unlikely to be harmful, as resuming parsing of a partially-consumed stream of Ion data without any context is only possible in specific circumstances. It seems far more likely that current users are either 1) manually closing these resources, in which case this change leads to a redundant close (not harmful in the `InputStream`/`Reader` implementations I'm aware of), or 2) forgetting to close these resources, which may leak memory, depending on the implementation. Option 2) is even more likely for users used to `JsonFactory`, where `AUTO_CLOSE_SOURCE` is (as far as I can tell) on by default. Therefore, I conclude that the benefits of this change outweigh the risks; however, I'm open to other opinions.

This solution isn't very aesthetically-pleasing, as it discards and replaces the `IOContext` passed in by the `JsonFactory` superclass. This amounts to one redundant `IOContext` instantiation per `createParser` call. This could probably be avoided, but it would require a larger refactor.

The included unit test verifies that `IonReader`s are always marked as resource-managed except when provided directly by the user. The test assumes correct behavior of `IonParser.close()`; namely, that resource-managed resources that are `Closeable` will be closed. Before this fix, the `BYTE_ARRAY`, `CHAR_ARRAY`, `READER`, and `INPUT_STREAM` cases failed.