### PR TITLE
add tests for large nums

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -888,6 +888,7 @@ public class CBORParser extends ParserMinimalBase
         if (_binaryValue.length == 0) {
             _numberBigInt = BigInteger.ZERO;
         } else {
+            _ioContext.streamReadConstraints().validateIntegerLength(_binaryValue.length);
             BigInteger nr = new BigInteger(_binaryValue);
             if (neg) {
                 nr = nr.negate();

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -2140,8 +2140,10 @@ public class CBORParser extends ParserMinimalBase
         if ((_numTypesValid & (NR_DOUBLE | NR_FLOAT)) != 0) {
             // Let's parse from String representation, to avoid rounding errors that
             //non-decimal floating operations would incur
+            final String text = getText();
+            this.streamReadConstraints().validateFPLength(text.length());
             _numberBigDecimal = NumberInput.parseBigDecimal(
-                    getText(), isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
+                    text, isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
         } else if ((_numTypesValid & NR_BIGINT) != 0) {
             _numberBigDecimal = new BigDecimal(_numberBigInt);
         } else if ((_numTypesValid & NR_LONG) != 0) {

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -388,6 +388,11 @@ public class CBORParser extends ParserMinimalBase
     }
 
     @Override
+    public StreamReadConstraints streamReadConstraints() {
+        return _ioContext.streamReadConstraints();
+    }
+
+    @Override
     public ObjectCodec getCodec() {
         return _objectCodec;
     }

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/ParserNumbersTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/ParserNumbersTest.java
@@ -5,16 +5,9 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
-import com.fasterxml.jackson.dataformat.cbor.CBORConstants;
-import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
-import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
-import com.fasterxml.jackson.dataformat.cbor.CBORParser;
-import com.fasterxml.jackson.dataformat.cbor.CBORTestBase;
+import com.fasterxml.jackson.dataformat.cbor.*;
 import com.fasterxml.jackson.dataformat.cbor.testutil.ThrottledInputStream;
 
 @SuppressWarnings("resource")
@@ -363,7 +356,7 @@ public class ParserNumbersTest extends CBORTestBase
     }
 
     public void testVeryBigDecimalType() throws IOException {
-        final int len = 1200;
+        final int len = 10000;
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < len; i++) {
             sb.append(1);
@@ -376,6 +369,31 @@ public class ParserNumbersTest extends CBORTestBase
 
         final byte[] b = out.toByteArray();
         try (CBORParser parser = cborParser(b)) {
+            try {
+                parser.nextToken();
+                fail("expected NumberFormatException");
+            } catch (NumberFormatException nfe) {
+                assertEquals("Number length (4153) exceeds the maximum length (1000)", nfe.getMessage());
+            }
+        }
+    }
+
+    public void testVeryBigDecimalWithUnlimitedNumLength() throws IOException {
+        final int len = 10000;
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < len; i++) {
+            sb.append(1);
+        }
+        final BigDecimal NR = new BigDecimal(sb.toString());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGenerator generator = cborGenerator(out);
+        generator.writeNumber(NR);
+        generator.close();
+
+        final byte[] b = out.toByteArray();
+        CBORFactoryBuilder f = cborFactoryBuilder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build());
+        try (CBORParser parser = cborParser(f.build(), b)) {
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, parser.nextToken());
             assertEquals(NumberType.BIG_DECIMAL, parser.getNumberType());
             assertEquals(NR, parser.getDecimalValue());

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/ParserNumbersTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/ParserNumbersTest.java
@@ -361,4 +361,26 @@ public class ParserNumbersTest extends CBORTestBase
             assertNull(parser.nextToken());
         }
     }
+
+    public void testVeryBigDecimalType() throws IOException {
+        final int len = 1200;
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < len; i++) {
+            sb.append(1);
+        }
+        final BigDecimal NR = new BigDecimal(sb.toString());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGenerator generator = cborGenerator(out);
+        generator.writeNumber(NR);
+        generator.close();
+
+        final byte[] b = out.toByteArray();
+        try (CBORParser parser = cborParser(b)) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, parser.nextToken());
+            assertEquals(NumberType.BIG_DECIMAL, parser.getNumberType());
+            assertEquals(NR, parser.getDecimalValue());
+            assertEquals(NR.doubleValue(), parser.getDoubleValue());
+            assertNull(parser.nextToken());
+        }
+    }
 }

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -172,6 +172,11 @@ public class IonParser
     }
 
     @Override
+    public StreamReadConstraints streamReadConstraints() {
+        return _ioContext.streamReadConstraints();
+    }
+
+    @Override
     public void setCodec(ObjectCodec c) {
         _objectCodec = c;
     }

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -1811,8 +1811,10 @@ public class ProtobufParser extends ParserMinimalBase
         if ((_numTypesValid & (NR_DOUBLE | NR_FLOAT)) != 0) {
             // Let's parse from String representation, to avoid rounding errors that
             //non-decimal floating operations would incur
+            final String text = getText();
+            this.streamReadConstraints().validateFPLength(text.length());
             _numberBigDecimal = NumberInput.parseBigDecimal(
-                    getText(), isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
+                    text, isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
         } else if ((_numTypesValid & NR_BIGINT) != 0) {
             _numberBigDecimal = new BigDecimal(_numberBigInt);
         } else if ((_numTypesValid & NR_LONG) != 0) {

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -312,6 +312,11 @@ public class ProtobufParser extends ParserMinimalBase
         _tokenInputCol = -1;
     }
 
+    @Override
+    public StreamReadConstraints streamReadConstraints() {
+        return _ioContext.streamReadConstraints();
+    }
+
     public void setSchema(ProtobufSchema schema)
     {
         if (_schema == schema) {

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParser.java
@@ -2245,11 +2245,12 @@ versionBits));
     
     private final void _finishBigInteger() throws IOException
     {
-        byte[] raw = _read7BitBinaryWithLength();
+        final byte[] raw = _read7BitBinaryWithLength();
         // [dataformats-binary#257]: 0-length special case to handle
         if (raw.length == 0) {
             _numberBigInt = BigInteger.ZERO;
         } else {
+            _ioContext.streamReadConstraints().validateIntegerLength(raw.length);
             _numberBigInt = new BigInteger(raw);
         }
         _numTypesValid = NR_BIGINT;
@@ -2291,12 +2292,13 @@ versionBits));
 	
     private final void _finishBigDecimal() throws IOException
     {
-        int scale = SmileUtil.zigzagDecode(_readUnsignedVInt());
-        byte[] raw = _read7BitBinaryWithLength();
+        final int scale = SmileUtil.zigzagDecode(_readUnsignedVInt());
+        final byte[] raw = _read7BitBinaryWithLength();
         // [dataformats-binary#257]: 0-length special case to handle
         if (raw.length == 0) {
             _numberBigDecimal = BigDecimal.ZERO;
         } else {
+            _ioContext.streamReadConstraints().validateFPLength(raw.length);
             BigInteger unscaledValue = new BigInteger(raw);
             _numberBigDecimal = new BigDecimal(unscaledValue, scale);
         }

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
@@ -750,8 +750,10 @@ public abstract class SmileParserBase extends ParserMinimalBase
         if ((_numTypesValid & (NR_DOUBLE | NR_FLOAT)) != 0) {
             // Let's parse from String representation, to avoid rounding errors that
             //non-decimal floating operations would incur
+            final String text = getText();
+            this.streamReadConstraints().validateFPLength(text.length());
             _numberBigDecimal = NumberInput.parseBigDecimal(
-                    getText(), isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
+                    text, isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
         } else if ((_numTypesValid & NR_BIGINT) != 0) {
             _numberBigDecimal = new BigDecimal(_numberBigInt);
         } else if ((_numTypesValid & NR_LONG) != 0) {

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
@@ -273,6 +273,11 @@ public abstract class SmileParserBase extends ParserMinimalBase
         _smileBufferRecycler = _smileBufferRecycler();
     }
 
+    @Override
+    public StreamReadConstraints streamReadConstraints() {
+        return _ioContext.streamReadConstraints();
+    }
+
     protected final static SmileBufferRecycler<String> _smileBufferRecycler()
     {
         SoftReference<SmileBufferRecycler<String>> ref = _smileRecyclerRef.get();

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
@@ -1290,7 +1290,9 @@ public class NonBlockingByteArrayParser
     private final JsonToken _finishBigIntBody() throws IOException
     {
         if (_decode7BitEncoded()) { // got it all!
-            _numberBigInt = new BigInteger(_byteArrayBuilder.toByteArray());
+            final byte[] array = _byteArrayBuilder.toByteArray();
+            _ioContext.streamReadConstraints().validateIntegerLength(array.length);
+            _numberBigInt = new BigInteger(array);
             _numberType = NumberType.BIG_INTEGER;
             _numTypesValid = NR_BIGINT;
             return _valueComplete(JsonToken.VALUE_NUMBER_INT);
@@ -1436,8 +1438,10 @@ public class NonBlockingByteArrayParser
     {
         if (_decode7BitEncoded()) { // got it all!
             // note: scale value is signed, needs zigzag, so:
-            int scale = SmileUtil.zigzagDecode((int) _pending64);
-            BigInteger bigInt = new BigInteger(_byteArrayBuilder.toByteArray());
+            final int scale = SmileUtil.zigzagDecode((int) _pending64);
+            final byte[] array = _byteArrayBuilder.toByteArray();
+            _ioContext.streamReadConstraints().validateFPLength(array.length);
+            BigInteger bigInt = new BigInteger(array);
             _numberBigDecimal = new BigDecimal(bigInt, scale);
             _numberType = NumberType.BIG_DECIMAL;
             _numTypesValid = NR_BIGDECIMAL;

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/parse/NumberParsingTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/parse/NumberParsingTest.java
@@ -378,6 +378,30 @@ public class NumberParsingTest
         p.close();
     }
 
+    public void testVeryBigDecimal() throws IOException
+    {
+        final int len = 1200;
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < len; i++) {
+            sb.append(1);
+        }
+        final BigDecimal value = new BigDecimal(sb.toString());
+        ByteArrayOutputStream bo = new ByteArrayOutputStream();
+        SmileGenerator g = smileGenerator(bo, false);
+        g.writeNumber(value);
+        g.close();
+        byte[] data = bo.toByteArray();
+        assertEquals(575, data.length);
+
+        try (SmileParser p = _smileParser(data)) {
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(JsonParser.NumberType.BIG_DECIMAL, p.getNumberType());
+            assertEquals(value, p.getDecimalValue());
+            assertFalse(p.isNaN());
+            assertEquals(value, p.getNumberValue());
+        }
+    }
+
     public void testMixedAccessForInts() throws IOException
     {
         ByteArrayOutputStream bo = new ByteArrayOutputStream();

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/parse/NumberParsingTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/parse/NumberParsingTest.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.dataformat.smile.BaseTestForSmile;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import com.fasterxml.jackson.dataformat.smile.SmileParser;
 
@@ -380,7 +381,7 @@ public class NumberParsingTest
 
     public void testVeryBigDecimal() throws IOException
     {
-        final int len = 1200;
+        final int len = 10000;
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < len; i++) {
             sb.append(1);
@@ -391,9 +392,39 @@ public class NumberParsingTest
         g.writeNumber(value);
         g.close();
         byte[] data = bo.toByteArray();
-        assertEquals(575, data.length);
 
         try (SmileParser p = _smileParser(data)) {
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            try {
+                p.getNumberType();
+                fail("expected NumberFormatException");
+            } catch (NumberFormatException nfe) {
+                assertEquals("Number length (4153) exceeds the maximum length (1000)", nfe.getMessage());
+            }
+        }
+    }
+
+    public void testVeryBigDecimalWithUnlimitedNumLength() throws IOException
+    {
+        final int len = 10000;
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < len; i++) {
+            sb.append(1);
+        }
+        final BigDecimal value = new BigDecimal(sb.toString());
+        ByteArrayOutputStream bo = new ByteArrayOutputStream();
+        SmileGenerator g = smileGenerator(bo, false);
+        g.writeNumber(value);
+        g.close();
+        byte[] data = bo.toByteArray();
+
+        SmileFactory f = SmileFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build())
+                .configure(SmileParser.Feature.REQUIRE_HEADER, false)
+                .configure(SmileGenerator.Feature.WRITE_HEADER, false)
+                .configure(SmileGenerator.Feature.WRITE_END_MARKER, false)
+                .build();
+        try (SmileParser p = _smileParser(f, data)) {
             assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(JsonParser.NumberType.BIG_DECIMAL, p.getNumberType());
             assertEquals(value, p.getDecimalValue());


### PR DESCRIPTION
These tests succeed despite the the large nums.
This is because the numbers are represented in binary form and the text length checks do not get invoked.
The question is whether we want to check the num lengths when we parse the binary nums.