### PR TITLE
Add WRITE_MINIMAL_DOUBLES feature to CBORGenerator

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -102,6 +102,19 @@ public class CBORGenerator extends GeneratorBase
          * @since 2.15
          */
         STRINGREF(false),
+
+        /**
+         * Feature that determines whether generator should try to write doubles
+         * as floats: if {@code true}, will write a {@code double} as a 4-byte float if no
+         * precision loss will occur; if {@code false}, will always write a {@code double}
+         * as an 8-byte double.
+         * <p>
+         * Default value is {@code false} meaning that doubles will always be written as
+         * 8-byte values.
+         *
+         * @since 2.15
+         */
+        WRITE_MINIMAL_DOUBLES(false),
         ;
 
         protected final boolean _defaultState;
@@ -176,6 +189,9 @@ public class CBORGenerator extends GeneratorBase
     protected int _formatFeatures;
 
     protected boolean _cfgMinimalInts;
+
+    // @since 2.15
+    protected boolean _cfgMinimalDoubles;
 
     /*
     /**********************************************************
@@ -275,6 +291,7 @@ public class CBORGenerator extends GeneratorBase
         _streamWriteContext = CBORWriteContext.createRootContext(dups);
         _formatFeatures = formatFeatures;
         _cfgMinimalInts = Feature.WRITE_MINIMAL_INTS.enabledIn(formatFeatures);
+        _cfgMinimalDoubles = Feature.WRITE_MINIMAL_DOUBLES.enabledIn(formatFeatures);
         _ioContext = ctxt;
         _out = out;
         _bufferRecyclable = true;
@@ -311,6 +328,7 @@ public class CBORGenerator extends GeneratorBase
         _streamWriteContext = CBORWriteContext.createRootContext(dups);
         _formatFeatures = formatFeatures;
         _cfgMinimalInts = Feature.WRITE_MINIMAL_INTS.enabledIn(formatFeatures);
+        _cfgMinimalDoubles = Feature.WRITE_MINIMAL_DOUBLES.enabledIn(formatFeatures);
         _ioContext = ctxt;
         _out = out;
         _bufferRecyclable = bufferRecyclable;
@@ -413,6 +431,7 @@ public class CBORGenerator extends GeneratorBase
         if (oldState != newState) {
             _formatFeatures = newState;
             _cfgMinimalInts = Feature.WRITE_MINIMAL_INTS.enabledIn(newState);
+            _cfgMinimalDoubles = Feature.WRITE_MINIMAL_DOUBLES.enabledIn(newState);
         }
         return this;
     }
@@ -458,6 +477,8 @@ public class CBORGenerator extends GeneratorBase
         _formatFeatures |= f.getMask();
         if (f == Feature.WRITE_MINIMAL_INTS) {
             _cfgMinimalInts = true;
+        } else if (f == Feature.WRITE_MINIMAL_DOUBLES) {
+            _cfgMinimalDoubles = true;
         }
         return this;
     }
@@ -466,6 +487,8 @@ public class CBORGenerator extends GeneratorBase
         _formatFeatures &= ~f.getMask();
         if (f == Feature.WRITE_MINIMAL_INTS) {
             _cfgMinimalInts = false;
+        } else if (f == Feature.WRITE_MINIMAL_DOUBLES) {
+            _cfgMinimalDoubles = false;
         }
         return this;
     }
@@ -691,8 +714,14 @@ public class CBORGenerator extends GeneratorBase
         // short-cut, do not create child array context etc
         _verifyValueWrite("write int array");
         _writeLengthMarker(PREFIX_TYPE_ARRAY, length);
-        for (int i = offset, end = offset+length; i < end; ++i) {
-            _writeDoubleNoCheck(array[i]);
+        if (_cfgMinimalDoubles) {
+            for (int i = offset, end = offset+length; i < end; ++i) {
+                _writeDoubleMinimal(array[i]);
+            }
+        } else {
+            for (int i = offset, end = offset+length; i < end; ++i) {
+                _writeDoubleNoCheck(array[i]);
+            }
         }
     }
 
@@ -786,8 +815,24 @@ public class CBORGenerator extends GeneratorBase
         _outputBuffer[_outputTail++] = (byte) i;
     }
 
+    private final void _writeFloatNoCheck(float f) throws IOException {
+        _ensureRoomForOutput(5);
+        /*
+         * 17-Apr-2010, tatu: could also use 'floatToIntBits', but it seems more
+         * accurate to use exact representation; and possibly faster. However,
+         * if there are cases where collapsing of NaN was needed (for non-Java
+         * clients), this can be changed
+         */
+        int i = Float.floatToRawIntBits(f);
+        _outputBuffer[_outputTail++] = BYTE_FLOAT32;
+        _outputBuffer[_outputTail++] = (byte) (i >> 24);
+        _outputBuffer[_outputTail++] = (byte) (i >> 16);
+        _outputBuffer[_outputTail++] = (byte) (i >> 8);
+        _outputBuffer[_outputTail++] = (byte) i;
+    }
+
     private final void _writeDoubleNoCheck(double d) throws IOException {
-        _ensureRoomForOutput(11);
+        _ensureRoomForOutput(9);
         // 17-Apr-2010, tatu: could also use 'doubleToIntBits', but it seems
         // more accurate to use exact representation; and possibly faster.
         // However, if there are cases where collapsing of NaN was needed (for
@@ -805,6 +850,15 @@ public class CBORGenerator extends GeneratorBase
         _outputBuffer[_outputTail++] = (byte) (i >> 16);
         _outputBuffer[_outputTail++] = (byte) (i >> 8);
         _outputBuffer[_outputTail++] = (byte) i;
+    }
+
+    private final void _writeDoubleMinimal(double d) throws IOException {
+        float f = (float)d;
+        if (f == d) {
+            _writeFloatNoCheck(f);
+        } else {
+            _writeDoubleNoCheck(d);
+        }
     }
 
     /*
@@ -1178,46 +1232,17 @@ public class CBORGenerator extends GeneratorBase
     @Override
     public void writeNumber(double d) throws IOException {
         _verifyValueWrite("write number");
-        _ensureRoomForOutput(11);
-        /*
-         * 17-Apr-2010, tatu: could also use 'doubleToIntBits', but it seems
-         * more accurate to use exact representation; and possibly faster.
-         * However, if there are cases where collapsing of NaN was needed (for
-         * non-Java clients), this can be changed
-         */
-        long l = Double.doubleToRawLongBits(d);
-        _outputBuffer[_outputTail++] = BYTE_FLOAT64;
-
-        int i = (int) (l >> 32);
-        _outputBuffer[_outputTail++] = (byte) (i >> 24);
-        _outputBuffer[_outputTail++] = (byte) (i >> 16);
-        _outputBuffer[_outputTail++] = (byte) (i >> 8);
-        _outputBuffer[_outputTail++] = (byte) i;
-        i = (int) l;
-        _outputBuffer[_outputTail++] = (byte) (i >> 24);
-        _outputBuffer[_outputTail++] = (byte) (i >> 16);
-        _outputBuffer[_outputTail++] = (byte) (i >> 8);
-        _outputBuffer[_outputTail++] = (byte) i;
+        if (_cfgMinimalDoubles) {
+            _writeDoubleMinimal(d);
+        } else {
+            _writeDoubleNoCheck(d);
+        }
     }
 
     @Override
     public void writeNumber(float f) throws IOException {
-        // Ok, now, we needed token type byte plus 5 data bytes (7 bits each)
-        _ensureRoomForOutput(6);
         _verifyValueWrite("write number");
-
-        /*
-         * 17-Apr-2010, tatu: could also use 'floatToIntBits', but it seems more
-         * accurate to use exact representation; and possibly faster. However,
-         * if there are cases where collapsing of NaN was needed (for non-Java
-         * clients), this can be changed
-         */
-        int i = Float.floatToRawIntBits(f);
-        _outputBuffer[_outputTail++] = BYTE_FLOAT32;
-        _outputBuffer[_outputTail++] = (byte) (i >> 24);
-        _outputBuffer[_outputTail++] = (byte) (i >> 16);
-        _outputBuffer[_outputTail++] = (byte) (i >> 8);
-        _outputBuffer[_outputTail++] = (byte) i;
+        _writeFloatNoCheck(f);
     }
 
     @Override


### PR DESCRIPTION
Enabling WRITE_MINIMAL_DOUBLES works similarly to WRITE_MINIMAL_INTS, choosing to use a smaller data representation (single-precision float) when the conversion will result in no loss of data. This can provide a substantial savings for data that contains many doubles that don't require full precision.

Cleaned up some of the writing code for floats and doubles to avoid code duplication, and reserve the proper amount of space for output for both types.