### PR TITLE
remove unused method

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/ProtobufSchemaLoader.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/ProtobufSchemaLoader.java
@@ -183,20 +183,4 @@ public class ProtobufSchemaLoader
         }
         return sb.toString();
     }
-
-    public void _throw(Exception e0) throws IOException
-    {
-        // First, peel it
-        Throwable e = e0;
-        while (e.getCause() != null) {
-            e = e.getCause();
-        }
-        if (e instanceof RuntimeException) {
-            throw (RuntimeException) e;
-        }
-        if (e instanceof IOException){
-            throw (IOException) e;
-        }
-        throw new IOException(e.getMessage(), e);
-    }
 }


### PR DESCRIPTION
I know this method is public but its name starts with an underscore and there is no javadoc - very unlikely any external users use it and the internal code doesn't use it.