### PR TITLE
core#1015 non-blocking smile parser respects CANONICALIZE_FIELD_NAMES

### DIFF
--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileFactory.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileFactory.java
@@ -414,7 +414,7 @@ public class SmileFactory extends JsonFactory
         IOContext ctxt = _createContext(null, false);
         // 13-Mar-2021, tatu: [dataformats-binary#252] Leave async parser with
         //   always-canonicalizing, for now (2.13) -- to be improved in future
-        ByteQuadsCanonicalizer can = _byteSymbolCanonicalizer.makeChild(_factoryFeatures);
+        ByteQuadsCanonicalizer can = _byteSymbolCanonicalizer.makeChildOrPlaceholder(_factoryFeatures);
         return new NonBlockingByteArrayParser(ctxt, _parserFeatures, _smileParserFeatures, can);
     }
 

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingParserBase.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingParserBase.java
@@ -531,6 +531,10 @@ public abstract class NonBlockingParserBase
 
     protected final String _addDecodedToSymbols(int len, String name) throws IOException
     {
+        // 5-May-2023, ckozak: [core#1015] respect CANONICALIZE_FIELD_NAMES factory config.
+        if (!_symbolsCanonical) {
+            return name;
+        }
         if (len < 5) {
             return _symbols.addName(name, _quad1);
         }

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/SmileFactoryPropertiesTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/SmileFactoryPropertiesTest.java
@@ -5,6 +5,7 @@ import java.io.*;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.io.ContentReference;
+import com.fasterxml.jackson.dataformat.smile.async.NonBlockingByteArrayParser;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -151,6 +152,20 @@ public class SmileFactoryPropertiesTest extends BaseTestForSmile
         g.writeStartArray();
         g.writeEndArray();
         g.close();
+    }
+
+    public void testCanonicalization() throws Exception
+    {
+        try (NonBlockingByteArrayParser parser = new SmileFactory()
+                .createNonBlockingByteArrayParser()) {
+            assertTrue(parser._symbolsCanonical);
+        }
+        try (NonBlockingByteArrayParser parser = SmileFactory.builder()
+                .disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES)
+                .build()
+                .createNonBlockingByteArrayParser()) {
+            assertFalse(parser._symbolsCanonical);
+        }
     }
 
     /*


### PR DESCRIPTION
see https://github.com/FasterXML/jackson-core/issues/1015
and https://github.com/FasterXML/jackson-core/pull/1016