### PR TITLE
Add `logback-test.xml` to `test/resources` in the Avro Module

### DIFF
--- a/avro/src/test/resources/logback-test.xml
+++ b/avro/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<configuration>
+    <root level="WARN">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
In versions 2.15 and above, the `logback-test.xml` file was being included as part of the release artifact because it was packaged in the `main/resources` folder instead of the `test/resources` folder. By moving the config file to the test resources folder, it will keep the test output reasonable while not impacting any logback applications which pull in this module as a dependency.

This pull request is in response to the discussion in #379