### PR TITLE
close IOContext

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/AvroGenerator.java
@@ -88,8 +88,6 @@ public class AvroGenerator extends GeneratorBase
     /**********************************************************
      */
 
-    protected final IOContext _ioContext;
-
     /**
      * @since 2.16
      */
@@ -143,8 +141,7 @@ public class AvroGenerator extends GeneratorBase
             ObjectCodec codec, OutputStream output)
         throws IOException
     {
-        super(jsonFeatures, codec);
-        _ioContext = ctxt;
+        super(jsonFeatures, codec, ctxt);
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _formatFeatures = avroFeatures;
         _output = output;
@@ -335,7 +332,6 @@ public class AvroGenerator extends GeneratorBase
     public void close() throws IOException
     {
         if (!isClosed()) {
-            super.close();
             if (isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
                 AvroWriteContext ctxt;
                 while ((ctxt = _avroContext) != null) {
@@ -375,7 +371,7 @@ public class AvroGenerator extends GeneratorBase
             }
             // Internal buffer(s) generator has can now be released as well
             _releaseBuffers();
-            _ioContext.close();
+            super.close();
         }
     }
 

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -1354,34 +1354,37 @@ public class CBORGenerator extends GeneratorBase
 
     @Override
     public void close() throws IOException {
-        // First: let's see that we still have buffers...
-        if ((_outputBuffer != null)
-                && isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
-            while (true) {
-                JsonStreamContext ctxt = getOutputContext();
-                if (ctxt.inArray()) {
-                    writeEndArray();
-                } else if (ctxt.inObject()) {
-                    writeEndObject();
-                } else {
-                    break;
+        if (!isClosed()) {
+            // First: let's see that we still have buffers...
+            if ((_outputBuffer != null)
+                    && isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
+                while (true) {
+                    JsonStreamContext ctxt = getOutputContext();
+                    if (ctxt.inArray()) {
+                        writeEndArray();
+                    } else if (ctxt.inObject()) {
+                        writeEndObject();
+                    } else {
+                        break;
+                    }
                 }
             }
-        }
-        // boolean wasClosed = _closed;
-        super.close();
-        _flushBuffer();
+            // boolean wasClosed = _closed;
+            super.close();
+            _flushBuffer();
 
-        if (_ioContext.isResourceManaged()
-                || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET)) {
-            _out.close();
-        } else if (isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)) {
-            // 14-Jan-2019, tatu: [dataformats-binary#155]: unless prevented via feature
-            // If we can't close it, we should at least flush
-            _out.flush();
+            if (_ioContext.isResourceManaged()
+                    || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET)) {
+                _out.close();
+            } else if (isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)) {
+                // 14-Jan-2019, tatu: [dataformats-binary#155]: unless prevented via feature
+                // If we can't close it, we should at least flush
+                _out.flush();
+            }
+            // Internal buffer(s) generator has can now be released as well
+            _releaseBuffers();
+            _ioContext.close();
         }
-        // Internal buffer(s) generator has can now be released as well
-        _releaseBuffers();
     }
 
     /*

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -178,8 +178,6 @@ public class CBORGenerator extends GeneratorBase
     /**********************************************************
      */
 
-    protected final  IOContext _ioContext;
-
     /**
      * @since 2.16
      */
@@ -288,7 +286,7 @@ public class CBORGenerator extends GeneratorBase
 
     public CBORGenerator(IOContext ctxt, int stdFeatures, int formatFeatures,
             ObjectCodec codec, OutputStream out) {
-        super(stdFeatures, codec, /* Write Context */ null);
+        super(stdFeatures, codec, ctxt, null);
         DupDetector dups = JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION.enabledIn(stdFeatures)
                 ? DupDetector.rootDetector(this)
                 : null;
@@ -297,7 +295,6 @@ public class CBORGenerator extends GeneratorBase
         _formatFeatures = formatFeatures;
         _cfgMinimalInts = Feature.WRITE_MINIMAL_INTS.enabledIn(formatFeatures);
         _cfgMinimalDoubles = Feature.WRITE_MINIMAL_DOUBLES.enabledIn(formatFeatures);
-        _ioContext = ctxt;
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _out = out;
         _bufferRecyclable = true;
@@ -326,7 +323,7 @@ public class CBORGenerator extends GeneratorBase
     public CBORGenerator(IOContext ctxt, int stdFeatures, int formatFeatures,
             ObjectCodec codec, OutputStream out, byte[] outputBuffer,
             int offset, boolean bufferRecyclable) {
-        super(stdFeatures, codec, /* Write Context */ null);
+        super(stdFeatures, codec, ctxt, null);
         DupDetector dups = JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION.enabledIn(stdFeatures)
                 ? DupDetector.rootDetector(this)
                 : null;
@@ -335,7 +332,6 @@ public class CBORGenerator extends GeneratorBase
         _formatFeatures = formatFeatures;
         _cfgMinimalInts = Feature.WRITE_MINIMAL_INTS.enabledIn(formatFeatures);
         _cfgMinimalDoubles = Feature.WRITE_MINIMAL_DOUBLES.enabledIn(formatFeatures);
-        _ioContext = ctxt;
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _out = out;
         _bufferRecyclable = bufferRecyclable;
@@ -1369,8 +1365,6 @@ public class CBORGenerator extends GeneratorBase
                     }
                 }
             }
-            // boolean wasClosed = _closed;
-            super.close();
             _flushBuffer();
 
             if (_ioContext.isResourceManaged()
@@ -1383,7 +1377,7 @@ public class CBORGenerator extends GeneratorBase
             }
             // Internal buffer(s) generator has can now be released as well
             _releaseBuffers();
-            _ioContext.close();
+            super.close();
         }
     }
 

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -700,6 +700,7 @@ public class CBORParser extends ParserMinimalBase
                 // Also, internal buffer(s) can now be released as well
                 _releaseBuffers();
             }
+            _ioContext.close();
         }
     }
 

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
@@ -182,6 +182,7 @@ public class IonGenerator
                     }
                 }
             }
+            _ioContext.close();
         }
     }
 

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonGenerator.java
@@ -109,8 +109,6 @@ public class IonGenerator
     /* Indicates whether the IonGenerator is responsible for closing the underlying IonWriter. */
     protected final boolean _ionWriterIsManaged;
 
-    protected final IOContext _ioContext;
-
     /**
      * @since 2.16
      */
@@ -138,13 +136,12 @@ public class IonGenerator
     public IonGenerator(int jsonFeatures, final int ionFeatures, ObjectCodec codec,
             IonWriter ion, boolean ionWriterIsManaged, IOContext ctxt, Closeable dst)
     {
-        super(jsonFeatures, codec);
+        super(jsonFeatures, codec, ctxt);
         //  Overwrite the writecontext with our own implementation
         _writeContext = IonWriteContext.createRootContext(_writeContext.getDupDetector());
         _formatFeatures = ionFeatures;
         _writer = ion;
         _ionWriterIsManaged = ionWriterIsManaged;
-        _ioContext = ctxt;
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _destination = dst;
     }
@@ -168,8 +165,7 @@ public class IonGenerator
     @Override
     public void close() throws IOException
     {
-        if (!_closed) {
-            _closed = true;
+        if (!isClosed()) {
             if (_ionWriterIsManaged) {
                 _writer.close();
             }
@@ -182,7 +178,7 @@ public class IonGenerator
                     }
                 }
             }
-            _ioContext.close();
+            super.close();
         }
     }
 

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -252,6 +252,7 @@ public class IonParser
                     ((Closeable) src).close();
                 }
             }
+            _ioContext.close();
             _closed = true;
         }
     }

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufGenerator.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufGenerator.java
@@ -370,34 +370,37 @@ public class ProtobufGenerator extends GeneratorBase
     @Override
     public void close() throws IOException
     {
-        super.close();
-        if (isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
-            ProtobufWriteContext ctxt;
-            while ((ctxt = _pbContext) != null) {
-                if (ctxt.inArray()) {
-                    writeEndArray();
-                } else if (ctxt.inObject()) {
-                    writeEndObject();
-                } else {
-                    break;
+        if (!isClosed()) {
+            super.close();
+            if (isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
+                ProtobufWriteContext ctxt;
+                while ((ctxt = _pbContext) != null) {
+                    if (ctxt.inArray()) {
+                        writeEndArray();
+                    } else if (ctxt.inObject()) {
+                        writeEndObject();
+                    } else {
+                        break;
+                    }
                 }
             }
-        }
-        // May need to finalize...
-        if (!_complete) {
-            _complete();
-        }
-        if (_output != null) {
-            if (_ioContext.isResourceManaged() || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET)) {
-                _output.close();
-            } else if (isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)) {
-                // 14-Jan-2019, tatu: [dataformats-binary#155]: unless prevented via feature
-                // If we can't close it, we should at least flush
-                _output.flush();
+            // May need to finalize...
+            if (!_complete) {
+                _complete();
             }
+            if (_output != null) {
+                if (_ioContext.isResourceManaged() || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET)) {
+                    _output.close();
+                } else if (isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)) {
+                    // 14-Jan-2019, tatu: [dataformats-binary#155]: unless prevented via feature
+                    // If we can't close it, we should at least flush
+                    _output.flush();
+                }
+            }
+            // Internal buffer(s) generator has can now be released as well
+            _releaseBuffers();
+            _ioContext.close();
         }
-        // Internal buffer(s) generator has can now be released as well
-        _releaseBuffers();
     }
 
     /*

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufGenerator.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufGenerator.java
@@ -49,8 +49,6 @@ public class ProtobufGenerator extends GeneratorBase
     /**********************************************************
      */
 
-    protected final IOContext _ioContext;
-
     /**
      * @since 2.16
      */
@@ -142,8 +140,7 @@ public class ProtobufGenerator extends GeneratorBase
             ObjectCodec codec, OutputStream output)
         throws IOException
     {
-        super(jsonFeatures, codec, BOGUS_WRITE_CONTEXT);
-        _ioContext = ctxt;
+        super(jsonFeatures, codec, ctxt, BOGUS_WRITE_CONTEXT);
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _output = output;
         _pbContext = _rootContext = ProtobufWriteContext.createNullContext();
@@ -371,7 +368,6 @@ public class ProtobufGenerator extends GeneratorBase
     public void close() throws IOException
     {
         if (!isClosed()) {
-            super.close();
             if (isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
                 ProtobufWriteContext ctxt;
                 while ((ctxt = _pbContext) != null) {
@@ -399,7 +395,7 @@ public class ProtobufGenerator extends GeneratorBase
             }
             // Internal buffer(s) generator has can now be released as well
             _releaseBuffers();
-            _ioContext.close();
+            super.close();
         }
     }
 

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -444,6 +444,7 @@ public class ProtobufParser extends ParserMinimalBase
                 // Also, internal buffer(s) can now be released as well
                 _releaseBuffers();
             }
+            _ioContext.close();
         }
     }
 

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
@@ -183,8 +183,6 @@ public class SmileGenerator
     /**********************************************************
      */
 
-    protected final IOContext _ioContext;
-
     /**
      * @since 2.16
      */
@@ -304,14 +302,13 @@ public class SmileGenerator
     public SmileGenerator(IOContext ctxt, int stdFeatures, int smileFeatures,
             ObjectCodec codec, OutputStream out)
     {
-        super(stdFeatures, codec, /*WriteContext*/ null);
+        super(stdFeatures, codec, ctxt, null);
         DupDetector dups = JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION.enabledIn(stdFeatures)
                 ? DupDetector.rootDetector(this)
                 : null;
                 // NOTE: we passed `null` for default write context
         _streamWriteContext = SmileWriteContext.createRootContext(dups);
         _formatFeatures = smileFeatures;
-        _ioContext = ctxt;
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _smileBufferRecycler = _smileBufferRecycler();
         _out = out;
@@ -351,14 +348,13 @@ public class SmileGenerator
             ObjectCodec codec, OutputStream out, byte[] outputBuffer, int offset,
             boolean bufferRecyclable)
     {
-        super(stdFeatures, codec, null);
+        super(stdFeatures, codec, ctxt, null);
         DupDetector dups = JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION.enabledIn(stdFeatures)
                 ? DupDetector.rootDetector(this)
                 : null;
                 // NOTE: we passed `null` for default write context
         _streamWriteContext = SmileWriteContext.createRootContext(dups);
         _formatFeatures = smileFeatures;
-        _ioContext = ctxt;
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         _smileBufferRecycler = _smileBufferRecycler();
         _out = out;
@@ -1902,10 +1898,8 @@ public class SmileGenerator
                     }
                 }
             }
-            boolean wasClosed = _closed;
-            super.close();
 
-            if (!wasClosed && isEnabled(Feature.WRITE_END_MARKER)) {
+            if (isEnabled(Feature.WRITE_END_MARKER)) {
                 _writeByte(BYTE_MARKER_END_OF_CONTENT);
             }
             _flushBuffer();
@@ -1919,7 +1913,7 @@ public class SmileGenerator
             }
             // Internal buffer(s) generator has can now be released as well
             _releaseBuffers();
-            _ioContext.close();
+            super.close();
         }
     }
 

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
@@ -421,6 +421,7 @@ public abstract class SmileParserBase extends ParserMinimalBase
                 // Also, internal buffer(s) can now be released as well
                 _releaseBuffers();
             }
+            _ioContext.close();
         }
     }
 


### PR DESCRIPTION
need to close the IOContext now (part of the BufferRecycler changes in v2.16)

follow up to https://github.com/FasterXML/jackson-dataformats-binary/commit/d041c71762504a7cde11e37e53b38c9dd9851373