### PR TITLE
Part 1 of doing #393: combine parser/generator side recycler

### DIFF
--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileBufferRecycler.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileBufferRecycler.java
@@ -2,39 +2,66 @@ package com.fasterxml.jackson.dataformat.smile;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.fasterxml.jackson.dataformat.smile.SmileGenerator.SharedStringNode;
+
 /**
  * Simple helper class used for implementing simple reuse system for Smile-specific
  * buffers that are used.
- *
- * @param <T> Type of name entries stored in arrays to recycle
  */
-public class SmileBufferRecycler<T>
+public class SmileBufferRecycler
 {
     public final static int DEFAULT_NAME_BUFFER_LENGTH = 64;
 
     public final static int DEFAULT_STRING_VALUE_BUFFER_LENGTH = 64;
 
-    protected final AtomicReference<T[]> _seenNamesBuffer = new AtomicReference<>();
+    // // // Input side
 
-    protected final AtomicReference<T[]> _seenStringValuesBuffer = new AtomicReference<>();
+    protected final AtomicReference<String[]> _seenNamesReadBuffer = new AtomicReference<>();
+
+    protected final AtomicReference<String[]> _seenStringValuesReadBuffer = new AtomicReference<>();
+
+    // // // Output side
+
+    protected final AtomicReference<SharedStringNode[]> _seenNamesWriteBuffer = new AtomicReference<>();
+
+    protected final AtomicReference<SharedStringNode[]> _seenStringValuesWriteBuffer = new AtomicReference<>();
+
 
     public SmileBufferRecycler() { }
 
-    public T[] allocSeenNamesBuffer()
-    {
-        return _seenNamesBuffer.getAndSet(null);
+    // // // Input side
+    
+    public String[] allocSeenNamesReadBuffer() {
+        return _seenNamesReadBuffer.getAndSet(null);
     }
 
-    public T[] allocSeenStringValuesBuffer()
-    {
-        return _seenStringValuesBuffer.getAndSet(null);
+    public String[] allocSeenStringValuesReadBuffer() {
+        return _seenStringValuesReadBuffer.getAndSet(null);
     }
 
-    public void releaseSeenNamesBuffer(T[] buffer) {
-        _seenNamesBuffer.set(buffer);
+    public void releaseSeenNamesReadBuffer(String[] buffer) {
+        _seenNamesReadBuffer.set(buffer);
     }
 
-    public void releaseSeenStringValuesBuffer(T[] buffer) {
-        _seenStringValuesBuffer.set(buffer);
+    public void releaseSeenStringValuesReadBuffer(String[] buffer) {
+        _seenStringValuesReadBuffer.set(buffer);
+    }
+
+    // // // Output side
+
+    public SharedStringNode[] allocSeenNamesWriteBuffer() {
+        return _seenNamesWriteBuffer.getAndSet(null);
+    }
+
+    public SharedStringNode[] allocSeenStringValuesWriteBuffer() {
+        return _seenStringValuesWriteBuffer.getAndSet(null);
+    }
+
+    public void releaseSeenNamesWriteBuffer(SharedStringNode[] buffer) {
+        _seenNamesWriteBuffer.set(buffer);
+    }
+
+    public void releaseSeenStringValuesWriteBuffer(SharedStringNode[] buffer) {
+        _seenStringValuesWriteBuffer.set(buffer);
     }
 }

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
@@ -130,7 +130,7 @@ public class SmileGenerator
      * Helper class used for keeping track of possibly shareable String
      * references (for field names and/or short String values)
      */
-    protected final static class SharedStringNode
+    public final static class SharedStringNode
     {
         public final String value;
         public final int index;
@@ -201,7 +201,7 @@ public class SmileGenerator
      * Helper object used for low-level recycling of Smile-generator
      * specific buffers.
      */
-    protected final SmileBufferRecycler<SharedStringNode> _smileBufferRecycler;
+    protected final SmileBufferRecycler _smileBufferRecycler;
 
     /*
     /**********************************************************************
@@ -290,8 +290,8 @@ public class SmileGenerator
      * to a buffer recycler used to provide a low-cost
      * buffer recycling for Smile-specific buffers.
      */
-    final protected static ThreadLocal<SoftReference<SmileBufferRecycler<SharedStringNode>>> _smileRecyclerRef
-        = new ThreadLocal<SoftReference<SmileBufferRecycler<SharedStringNode>>>();
+    final protected static ThreadLocal<SoftReference<SmileBufferRecycler>> _smileRecyclerRef
+        = new ThreadLocal<SoftReference<SmileBufferRecycler>>();
 
     /*
     /**********************************************************************
@@ -325,7 +325,7 @@ public class SmileGenerator
             _seenNames = null;
             _seenNameCount = -1;
         } else {
-            _seenNames = _smileBufferRecycler.allocSeenNamesBuffer();
+            _seenNames = _smileBufferRecycler.allocSeenNamesWriteBuffer();
             if (_seenNames == null) {
                 _seenNames = new SharedStringNode[SmileBufferRecycler.DEFAULT_NAME_BUFFER_LENGTH];
             }
@@ -336,7 +336,7 @@ public class SmileGenerator
             _seenStringValues = null;
             _seenStringValueCount = -1;
         } else {
-            _seenStringValues = _smileBufferRecycler.allocSeenStringValuesBuffer();
+            _seenStringValues = _smileBufferRecycler.allocSeenStringValuesWriteBuffer();
             if (_seenStringValues == null) {
                 _seenStringValues = new SharedStringNode[SmileBufferRecycler.DEFAULT_STRING_VALUE_BUFFER_LENGTH];
             }
@@ -372,7 +372,7 @@ public class SmileGenerator
             _seenNames = null;
             _seenNameCount = -1;
         } else {
-            _seenNames = _smileBufferRecycler.allocSeenNamesBuffer();
+            _seenNames = _smileBufferRecycler.allocSeenNamesWriteBuffer();
             if (_seenNames == null) {
                 _seenNames = new SharedStringNode[SmileBufferRecycler.DEFAULT_NAME_BUFFER_LENGTH];
             }
@@ -383,7 +383,7 @@ public class SmileGenerator
             _seenStringValues = null;
             _seenStringValueCount = -1;
         } else {
-            _seenStringValues = _smileBufferRecycler.allocSeenStringValuesBuffer();
+            _seenStringValues = _smileBufferRecycler.allocSeenStringValuesWriteBuffer();
             if (_seenStringValues == null) {
                 _seenStringValues = new SharedStringNode[SmileBufferRecycler.DEFAULT_STRING_VALUE_BUFFER_LENGTH];
             }
@@ -413,14 +413,14 @@ public class SmileGenerator
         _writeBytes(HEADER_BYTE_1, HEADER_BYTE_2, HEADER_BYTE_3, (byte) last);
     }
 
-    protected final static SmileBufferRecycler<SharedStringNode> _smileBufferRecycler()
+    protected final static SmileBufferRecycler _smileBufferRecycler()
     {
-        SoftReference<SmileBufferRecycler<SharedStringNode>> ref = _smileRecyclerRef.get();
-        SmileBufferRecycler<SharedStringNode> br = (ref == null) ? null : ref.get();
+        SoftReference<SmileBufferRecycler> ref = _smileRecyclerRef.get();
+        SmileBufferRecycler br = (ref == null) ? null : ref.get();
 
         if (br == null) {
-            br = new SmileBufferRecycler<SharedStringNode>();
-            _smileRecyclerRef.set(new SoftReference<SmileBufferRecycler<SharedStringNode>>(br));
+            br = new SmileBufferRecycler();
+            _smileRecyclerRef.set(new SoftReference<SmileBufferRecycler>(br));
         }
         return br;
     }
@@ -2638,7 +2638,7 @@ surr1, surr2));
                 if (_seenNameCount > 0) {
                     Arrays.fill(nameBuf, null);
                 }
-                _smileBufferRecycler.releaseSeenNamesBuffer(nameBuf);
+                _smileBufferRecycler.releaseSeenNamesWriteBuffer(nameBuf);
             }
         }
         {
@@ -2651,7 +2651,7 @@ surr1, surr2));
                 if (_seenStringValueCount > 0) {
                     Arrays.fill(valueBuf, null);
                 }
-                _smileBufferRecycler.releaseSeenStringValuesBuffer(valueBuf);
+                _smileBufferRecycler.releaseSeenStringValuesWriteBuffer(valueBuf);
             }
         }
     }

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParser.java
@@ -611,7 +611,7 @@ versionBits));
         int len = oldShared.length;
         String[] newShared;
         if (len == 0) {
-            newShared = _smileBufferRecycler.allocSeenStringValuesBuffer();
+            newShared = _smileBufferRecycler.allocSeenStringValuesReadBuffer();
             if (newShared == null) {
                 newShared = new String[SmileBufferRecycler.DEFAULT_STRING_VALUE_BUFFER_LENGTH];
             }
@@ -1526,7 +1526,7 @@ versionBits));
         int len = oldShared.length;
         String[] newShared;
         if (len == 0) {
-            newShared = _smileBufferRecycler.allocSeenNamesBuffer();
+            newShared = _smileBufferRecycler.allocSeenNamesReadBuffer();
             if (newShared == null) {
                 newShared = new String[SmileBufferRecycler.DEFAULT_NAME_BUFFER_LENGTH];
             }

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBase.java
@@ -248,14 +248,14 @@ public abstract class SmileParserBase extends ParserMinimalBase
      * to a buffer recycler used to provide a low-cost
      * buffer recycling for Smile-specific buffers.
      */
-    protected final static ThreadLocal<SoftReference<SmileBufferRecycler<String>>> _smileRecyclerRef
-        = new ThreadLocal<SoftReference<SmileBufferRecycler<String>>>();
+    protected final static ThreadLocal<SoftReference<SmileBufferRecycler>> _smileRecyclerRef
+        = new ThreadLocal<SoftReference<SmileBufferRecycler>>();
 
     /**
      * Helper object used for low-level recycling of Smile-generator
      * specific buffers.
      */
-    protected final SmileBufferRecycler<String> _smileBufferRecycler;
+    protected final SmileBufferRecycler _smileBufferRecycler;
 
     /*
     /**********************************************************************
@@ -284,14 +284,14 @@ public abstract class SmileParserBase extends ParserMinimalBase
         return _ioContext.streamReadConstraints();
     }
 
-    protected final static SmileBufferRecycler<String> _smileBufferRecycler()
+    protected final static SmileBufferRecycler _smileBufferRecycler()
     {
-        SoftReference<SmileBufferRecycler<String>> ref = _smileRecyclerRef.get();
-        SmileBufferRecycler<String> br = (ref == null) ? null : ref.get();
+        SoftReference<SmileBufferRecycler> ref = _smileRecyclerRef.get();
+        SmileBufferRecycler br = (ref == null) ? null : ref.get();
 
         if (br == null) {
-            br = new SmileBufferRecycler<String>();
-            _smileRecyclerRef.set(new SoftReference<SmileBufferRecycler<String>>(br));
+            br = new SmileBufferRecycler();
+            _smileRecyclerRef.set(new SoftReference<SmileBufferRecycler>(br));
         }
         return br;
     }
@@ -446,7 +446,7 @@ public abstract class SmileParserBase extends ParserMinimalBase
             if (_seenNameCount > 0) {
                 Arrays.fill(nameBuf, 0, _seenNameCount, null);
             }
-            _smileBufferRecycler.releaseSeenNamesBuffer(nameBuf);
+            _smileBufferRecycler.releaseSeenNamesReadBuffer(nameBuf);
         }
         String[] valueBuf = _seenStringValues;
         if (valueBuf != null && valueBuf.length > 0) {
@@ -456,7 +456,7 @@ public abstract class SmileParserBase extends ParserMinimalBase
             if (_seenStringValueCount > 0) {
                 Arrays.fill(valueBuf, 0, _seenStringValueCount, null);
             }
-            _smileBufferRecycler.releaseSeenStringValuesBuffer(valueBuf);
+            _smileBufferRecycler.releaseSeenStringValuesReadBuffer(valueBuf);
         }
         _releaseBuffers2();
     }

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingParserBase.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingParserBase.java
@@ -555,7 +555,7 @@ public abstract class NonBlockingParserBase
         int len = oldShared.length;
         String[] newShared;
         if (len == 0) {
-            newShared = _smileBufferRecycler.allocSeenNamesBuffer();
+            newShared = _smileBufferRecycler.allocSeenNamesReadBuffer();
             if (newShared == null) {
                 newShared = new String[SmileBufferRecycler.DEFAULT_NAME_BUFFER_LENGTH];
             }
@@ -630,7 +630,7 @@ public abstract class NonBlockingParserBase
         int len = oldShared.length;
         String[] newShared;
         if (len == 0) {
-            newShared = _smileBufferRecycler.allocSeenStringValuesBuffer();
+            newShared = _smileBufferRecycler.allocSeenStringValuesReadBuffer();
             if (newShared == null) {
                 newShared = new String[SmileBufferRecycler.DEFAULT_STRING_VALUE_BUFFER_LENGTH];
             }


### PR DESCRIPTION
Basically combines buffers needed by parsers, generators into single `SmileBufferRecycler`, instead of separate parametric instances -- this reduces `ThreadLocal` stored objects by half, but more important will (in part 2) be handled by `SmileFactory` not parser/generator instances.
This in turn will make it possible to figure out a way to override recycler pool handling wrt `jackson-core`. Before that can be designed changes will not result in dramatic gains.

