### PR TITLE
Wrap possible AssertionError from Ion class

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -274,8 +274,11 @@ public class IonParser
                 try {
                     // stringValue() will throw an UnknownSymbolException if we're
                     // trying to get the text for a symbol id that cannot be resolved.
+                    // stringValue() has an assert statement which could throw an
+                    // AssertionError if we're trying to get the text with a symbol
+                    // id less than or equals to 0.
                     return _reader.stringValue();
-                } catch (UnknownSymbolException e) {
+                } catch (UnknownSymbolException | AssertionError e) {
                     throw _constructError(e.getMessage(), e);
                 }
             case VALUE_NUMBER_INT:

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz64721InvalidIonTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz64721InvalidIonTest.java
@@ -1,0 +1,27 @@
+package com.fasterxml.jackson.dataformat.ion.fuzz;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.dataformat.ion.*;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("resource")
+public class Fuzz64721InvalidIonTest
+{
+    @Test(expected = JsonParseException.class)
+    public void testFuzz64721AssertionException() throws IOException {
+       IonFactory f = IonFactory
+                          .builderForBinaryWriters()
+                          .enable(IonParser.Feature.USE_NATIVE_TYPE_ID)
+                          .build();
+       IonObjectMapper mapper = IonObjectMapper.builder(f).build();
+       mapper.readValue("$0/", EnumFuzz.class);
+    }
+
+    private static enum EnumFuzz {
+        A, B, C, D, E;
+    }
+}


### PR DESCRIPTION
This PR fixes #417 by wrapping the unexpected AssertionError with the general JsonParseException to avoid throwing AssertionError directly to the users when invalid input is provided.