### PR TITLE
Fixes for #424: Add null checking and wrap NPE

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -332,56 +332,48 @@ public class IonParser
 
     @Override
     public BigInteger getBigIntegerValue() throws IOException {
-        NumberType nt = getNumberType();
-        if (nt == null) {
-            throw _constructError("Wrong number type: BigInteger not found.", null);
-        }
+        _verifyIsNumberToken();
         return _reader.bigIntegerValue();
     }
 
     @Override
     public BigDecimal getDecimalValue() throws IOException {
-        NumberType nt = getNumberType();
-        if (nt == null) {
-            throw _constructError("Wrong number type: BigDecimal not found.", null);
-        }
+        _verifyIsNumberToken();
         return _reader.bigDecimalValue();
     }
 
     @Override
     public double getDoubleValue() throws IOException {
-        NumberType nt = getNumberType();
-        if (nt == null) {
-            throw _constructError("Wrong number type: Double not found.", null);
-        }
+        _verifyIsNumberToken();
         return _reader.doubleValue();
     }
 
     @Override
     public float getFloatValue() throws IOException {
-        NumberType nt = getNumberType();
-        if (nt == null) {
-            throw _constructError("Wrong number type: Float not found.", null);
-        }
+        _verifyIsNumberToken();
         return (float) _reader.doubleValue();
     }
 
     @Override
     public int getIntValue() throws IOException {
-        NumberType nt = getNumberType();
-        if (nt == null) {
-            throw _constructError("Wrong number type: Int not found.", null);
-        }
+        _verifyIsNumberToken();
         return _reader.intValue();
     }
 
     @Override
     public long getLongValue() throws IOException {
-        NumberType nt = getNumberType();
-        if (nt == null) {
-            throw _constructError("Wrong number type: Long not found.", null);
-        }
+        _verifyIsNumberToken();
         return _reader.longValue();
+    }
+
+    // @since 2.17
+    private void _verifyIsNumberToken() throws IOException
+    {
+        if (_currToken != JsonToken.VALUE_NUMBER_INT && _currToken != JsonToken.VALUE_NUMBER_FLOAT) {
+            // Same as `ParserBase._parseNumericValue()` exception:
+            _reportError("Current token (%s) not numeric, can not use numeric value accessors",
+                    _currToken);
+        }
     }
 
     @Override

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -286,6 +286,13 @@ public class IonParser
                         msg = "UNKNOWN ROOT CAUSE";
                     }
                     throw _constructError("Internal `IonReader` error: "+msg, e);
+                } catch (NullPointerException e) {
+                    // NullPointerException could be thrown on invalid data
+                    String msg = e.getMessage();
+                    if (msg == null) {
+                        msg = "UNKNOWN ROOT CAUSE";
+                    }
+                    throw _constructError("Internal `IonReader` error: "+msg, e);
                 }
             case VALUE_NUMBER_INT:
             case VALUE_NUMBER_FLOAT:
@@ -331,31 +338,55 @@ public class IonParser
 
     @Override
     public BigInteger getBigIntegerValue() throws IOException {
+        NumberType nt = getNumberType();
+        if (nt == null) {
+            throw _constructError("Wrong number type: BigInteger not found.", null);
+        }
         return _reader.bigIntegerValue();
     }
 
     @Override
     public BigDecimal getDecimalValue() throws IOException {
+        NumberType nt = getNumberType();
+        if (nt == null) {
+            throw _constructError("Wrong number type: BigDecimal not found.", null);
+        }
         return _reader.bigDecimalValue();
     }
 
     @Override
     public double getDoubleValue() throws IOException {
+        NumberType nt = getNumberType();
+        if (nt == null) {
+            throw _constructError("Wrong number type: Double not found.", null);
+        }
         return _reader.doubleValue();
     }
 
     @Override
     public float getFloatValue() throws IOException {
+        NumberType nt = getNumberType();
+        if (nt == null) {
+            throw _constructError("Wrong number type: Float not found.", null);
+        }
         return (float) _reader.doubleValue();
     }
 
     @Override
     public int getIntValue() throws IOException {
+        NumberType nt = getNumberType();
+        if (nt == null) {
+            throw _constructError("Wrong number type: Int not found.", null);
+        }
         return _reader.intValue();
     }
 
     @Override
     public long getLongValue() throws IOException {
+        NumberType nt = getNumberType();
+        if (nt == null) {
+            throw _constructError("Wrong number type: Long not found.", null);
+        }
         return _reader.longValue();
     }
 

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -278,16 +278,10 @@ public class IonParser
                     // trying to get the text for a symbol id that cannot be resolved.
                     // stringValue() has an assert statement which could throw an
                     throw _constructError(e.getMessage(), e);
-                } catch (AssertionError e) {
+                } catch (AssertionError | NullPointerException e) {
                     // AssertionError if we're trying to get the text with a symbol
                     // id less than or equals to 0.
-                    String msg = e.getMessage();
-                    if (msg == null) {
-                        msg = "UNKNOWN ROOT CAUSE";
-                    }
-                    throw _constructError("Internal `IonReader` error: "+msg, e);
-                } catch (NullPointerException e) {
-                    // NullPointerException could be thrown on invalid data
+                    // NullPointerException may also be thrown on invalid data
                     String msg = e.getMessage();
                     if (msg == null) {
                         msg = "UNKNOWN ROOT CAUSE";

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz424_65065_65126NPETest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz424_65065_65126NPETest.java
@@ -1,0 +1,48 @@
+package com.fasterxml.jackson.dataformat.ion.fuzz;
+
+import java.io.ByteArrayInputStream;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.dataformat.ion.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+// [dataformats-binary#424]
+public class Fuzz424_65065_65126NPETest
+{
+    @Test
+    public void testFuzz65065() throws Exception {
+       IonFactory f = IonFactory
+                          .builderForBinaryWriters()
+                          .build();
+
+       IonObjectMapper mapper = IonObjectMapper.builder(f).build();
+
+       try {
+           byte[] bytes = {(byte) -32, (byte) 1, (byte) 0, (byte) -22, (byte) 123, (byte) -112};
+           mapper.readTree(f.createParser(new ByteArrayInputStream(bytes)));
+           fail("Should not pass (invalid content)");
+       } catch (StreamReadException e) {
+           assertThat(e.getMessage(), Matchers.containsString("UNKNOWN ROOT CAUSE"));
+       }
+    }
+
+    @Test
+    public void testFuzz65126() throws Exception {
+       IonFactory f = IonFactory
+                          .builderForBinaryWriters()
+                          .build();
+
+       try {
+           byte[] bytes = {(byte) 1, (byte) 0};
+           f.createParser(bytes).getDecimalValue();
+           fail("Should not pass (invalid content)");
+       } catch (StreamReadException e) {
+           assertThat(e.getMessage(), Matchers.containsString("Wrong number type"));
+       }
+    }
+}

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz424_65065_65126NPETest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz424_65065_65126NPETest.java
@@ -27,7 +27,7 @@ public class Fuzz424_65065_65126NPETest
            mapper.readTree(f.createParser(new ByteArrayInputStream(bytes)));
            fail("Should not pass (invalid content)");
        } catch (StreamReadException e) {
-           assertThat(e.getMessage(), Matchers.containsString("UNKNOWN ROOT CAUSE"));
+           assertThat(e.getMessage(), Matchers.containsString("Internal `IonReader` error"));
        }
     }
 

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz424_65065_65126NPETest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/Fuzz424_65065_65126NPETest.java
@@ -42,7 +42,7 @@ public class Fuzz424_65065_65126NPETest
            f.createParser(bytes).getDecimalValue();
            fail("Should not pass (invalid content)");
        } catch (StreamReadException e) {
-           assertThat(e.getMessage(), Matchers.containsString("Wrong number type"));
+           assertThat(e.getMessage(), Matchers.containsString("Current token (null) not numeric"));
        }
     }
 }

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -287,3 +287,6 @@ Arthur Chan (@arthurscchan)
  (2.17.0)
  * Contributed #420: (ion) `IndexOutOfBoundsException` thrown by `IonReader` implementations
  (2.17.0)
+ * Contributed #424: (ion) `IonReader` throws `NullPointerException` for unchecked
+   invalid data
+ (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -22,6 +22,8 @@ Active maintainers:
 #420: (ion) `IndexOutOfBoundsException` thrown by `IonReader` implementations
   are not handled 
  (contributed by Arthur C)
+#424: (ion) `IonReader` throws `NullPointerException` for unchecked invalid data
+ (contributed by Arthur C)
 -(ion) Update `com.amazon.ion:ion-java` to 1.11.0 (from 1.10.5)
 
 2.16.0 (15-Nov-2023)


### PR DESCRIPTION
This PR provides a fixes for #424 by adding some null checking and wrap possible NPE in `IonParser`.