### PR TITLE
Improve error message in AvroAliasTest

### DIFF
--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroAliasTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroAliasTest.java
@@ -66,7 +66,7 @@ public class AvroAliasTest extends InteropTestBase {
         SchemaCompatibility.SchemaPairCompatibility compatibility =
             SchemaCompatibility.checkReaderWriterCompatibility(newSchema, oldSchema);
         //
-        assertThat(compatibility.getType()).isEqualTo(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
+        checkSchemaIsCompatible(compatibility);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class AvroAliasTest extends InteropTestBase {
         SchemaCompatibility.SchemaPairCompatibility compatibility =
             SchemaCompatibility.checkReaderWriterCompatibility(newSchema, oldSchema);
         //
-        assertThat(compatibility.getType()).isEqualTo(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
+        checkSchemaIsCompatible(compatibility);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class AvroAliasTest extends InteropTestBase {
         SchemaCompatibility.SchemaPairCompatibility compatibility =
             SchemaCompatibility.checkReaderWriterCompatibility(newSchema, oldSchema);
         //
-        assertThat(compatibility.getType()).isEqualTo(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
+        checkSchemaIsCompatible(compatibility);
     }
 
     @Test
@@ -134,8 +134,14 @@ public class AvroAliasTest extends InteropTestBase {
         SchemaCompatibility.SchemaPairCompatibility forwardsCompatibility =
             SchemaCompatibility.checkReaderWriterCompatibility(newSchema, oldSchema);
         //
-        assertThat(backwardsCompatibility.getType()).isEqualTo(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
-        assertThat(forwardsCompatibility.getType()).isEqualTo(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
+        checkSchemaIsCompatible(backwardsCompatibility);
+        checkSchemaIsCompatible(forwardsCompatibility);
+    }
+
+    private void checkSchemaIsCompatible(SchemaCompatibility.SchemaPairCompatibility compatibility) {
+        assertThat(compatibility.getType())
+            .withFailMessage("Expected schema to be compatible but was not. Reason:\n%s", compatibility.getDescription())
+            .isEqualTo(SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE);
     }
 
 }


### PR DESCRIPTION
it gives the reason of schema incompatibility when the schema is expected to be compatible. It can help investigation on #167

difference of output when test is faling (for isntance when upgrading avro dependency to 1.9):
current main branch;
```
[[1;31mERROR[m] [1;31m  AvroAliasTest.testAliasedRecordForwardsCompatible:69 expected:<[]COMPATIBLE> but was:<[IN]COMPATIBLE>
```

with this Pull Request:
```
[[1;31mERROR[m] [1;31m  AvroAliasTest.testAliasedRecordForwardsCompatible:69->checkSchemaIsCompatible:119 Expected schema to be compatible but was not. Reason:
Data encoded using writer schema:
{
  "type" : "record",
  "name" : "Employee",
  "namespace" : "com.fasterxml.jackson.dataformat.avro.AvroTestBase",
  "fields" : [ {
    "name" : "name",
    "type" : "string"
  }, {
    "name" : "age",
    "type" : "int"
  }, {
    "name" : "emails",
    "type" : {
      "type" : "array",
      "items" : "string",
      "java-class" : "[Ljava.lang.String;"
    }
  }, {
    "name" : "boss",
    "type" : "Employee"
  } ]
}
will or may fail to decode using reader schema:
{
  "type" : "record",
  "name" : "NewEmployee",
  "namespace" : "com.fasterxml.jackson.dataformat.avro.interop.annotations.AvroAliasTest",
  "fields" : [ {
    "name" : "name",
    "type" : "string"
  }, {
    "name" : "age",
    "type" : "int"
  }, {
    "name" : "emails",
    "type" : {
      "type" : "array",
      "items" : "string",
      "java-class" : "[Ljava.lang.String;"
    }
  }, {
    "name" : "boss",
    "type" : "NewEmployee"
  } ],
  "aliases" : [ "com.fasterxml.jackson.dataformat.avro.AvroTestBase$.Employee" ]
}
```

