### PR TITLE
Fixes for 449: Unexpected IOOBE handling

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
@@ -628,6 +628,9 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         final int[] codes = sUtf8UnitLengths;
         do {
             i = inputBuf[inPtr++] & 0xFF;
+            if (inPtr >= inputBuf.length) {
+                throw _constructError("Malformed UTF-8 character at end of short (non-chunked) text segment");
+            }
             switch (codes[i]) {
             case 0:
                 break;

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
@@ -626,13 +626,15 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         }
 
         final int[] codes = sUtf8UnitLengths;
+
         do {
             i = inputBuf[inPtr++] & 0xFF;
-            if (inPtr >= inputBuf.length) {
+            if (inPtr >= end) {
                 throw _constructError("Malformed UTF-8 character at end of short (non-chunked) text segment");
             }
             switch (codes[i]) {
             case 0:
+                outBuf[outPtr++] = (char) i;
                 break;
             case 1:
                 i = ((i & 0x1F) << 6) | (inputBuf[inPtr++] & 0x3F);

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
@@ -614,9 +614,8 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         _inputPtr += len;
         final byte[] inputBuf = _inputBuffer;
 
-        // Let's actually do a tight loop for ASCII first:
         final int end = inPtr + len;
-
+        // Let's actually do a tight loop for ASCII first:
         int i;
         while ((i = inputBuf[inPtr]) >= 0) {
             outBuf[outPtr++] = (char) i;
@@ -626,16 +625,20 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         }
 
         final int[] codes = sUtf8UnitLengths;
-
         do {
             i = inputBuf[inPtr++] & 0xFF;
-            if (inPtr >= end) {
-                throw _constructError("Malformed UTF-8 character at end of short (non-chunked) text segment");
-            }
-            switch (codes[i]) {
-            case 0:
+            final int code = codes[i];
+            if (code == 0) { // still optimized for ASCII
                 outBuf[outPtr++] = (char) i;
-                break;
+                continue;
+            }
+            if ((inPtr + code) > end) {
+                if (code < 4) {
+                    throw _constructError(String.format(
+                            "Malformed %d-byte UTF-8 character at the end of Unicode text block", code));
+                }
+            }
+            switch (code) {
             case 1:
                 i = ((i & 0x1F) << 6) | (inputBuf[inPtr++] & 0x3F);
                 break;
@@ -655,7 +658,7 @@ public class JacksonAvroParserImpl extends AvroParserImpl
                 i = 0xDC00 | (i & 0x3FF);
                 break;
             default: // invalid
-                _reportError("Invalid byte "+Integer.toHexString(i)+" in Unicode text block");
+                _reportError(String.format("Invalid byte 0x2X in Unicode text block", i));
             }
             outBuf[outPtr++] = (char) i;
         } while (inPtr < end);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/fuzz/AvroFuzz449_65618_IOOBETest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/fuzz/AvroFuzz449_65618_IOOBETest.java
@@ -39,7 +39,7 @@ public class AvroFuzz449_65618_IOOBETest extends AvroTestBase
             p.nextToken();
             fail("Should not pass (invalid content)");
         } catch (StreamReadException e) {
-            assertTrue(e.getMessage().contains("Malformed UTF-8 character"));
+            verifyException(e, "Malformed 2-byte UTF-8 character at the end of");
         }
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/fuzz/AvroFuzz449_65618_IOOBETest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/fuzz/AvroFuzz449_65618_IOOBETest.java
@@ -2,19 +2,24 @@ package com.fasterxml.jackson.dataformat.avro.fuzz;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.dataformat.avro.AvroFactory;
-import com.fasterxml.jackson.dataformat.avro.AvroFactoryBuilder;
 import com.fasterxml.jackson.dataformat.avro.AvroMapper;
 import com.fasterxml.jackson.dataformat.avro.AvroParser;
-import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import com.fasterxml.jackson.dataformat.avro.AvroSchema;
+import com.fasterxml.jackson.dataformat.avro.AvroTestBase;
 
 // [dataformats-binary#449]
-public class Fuzz449_65618_IOOBETest
+public class AvroFuzz449_65618_IOOBETest extends AvroTestBase
 {
+    @JsonPropertyOrder({ "name", "value" })
+    static class RootType {
+        public String name;
+        public int value;
+    }
+
     @Test
     public void testFuzz65618IOOBE() throws Exception {
         final AvroFactory factory = AvroFactory.builderWithApacheDecoder().build();
@@ -26,22 +31,15 @@ public class Fuzz449_65618_IOOBETest
             (byte) 122, (byte) 3, (byte) -24
         };
 
+        final AvroSchema schema = mapper.schemaFor(RootType.class);
         try (AvroParser p = factory.createParser(doc)) {
-            AvroSchemaGenerator gen = new AvroSchemaGenerator();
-            mapper.acceptJsonFormatVisitor(RootType.class, gen);
-            p.setSchema(gen.getGeneratedSchema());
-            p.getTextCharacters();
-            p.nextToken();
-            p.nextToken();
+            p.setSchema(schema);
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
             p.nextToken();
             fail("Should not pass (invalid content)");
         } catch (StreamReadException e) {
             assertTrue(e.getMessage().contains("Malformed UTF-8 character"));
         }
-    }
-
-    private class RootType {
-        public String name;
-        public int value;
     }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/fuzz/Fuzz449_65618_IOOBETest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/fuzz/Fuzz449_65618_IOOBETest.java
@@ -1,0 +1,47 @@
+package com.fasterxml.jackson.dataformat.avro.fuzz;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.dataformat.avro.AvroFactory;
+import com.fasterxml.jackson.dataformat.avro.AvroFactoryBuilder;
+import com.fasterxml.jackson.dataformat.avro.AvroMapper;
+import com.fasterxml.jackson.dataformat.avro.AvroParser;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+// [dataformats-binary#449]
+public class Fuzz449_65618_IOOBETest
+{
+    @Test
+    public void testFuzz65618IOOBE() throws Exception {
+        final AvroFactory factory = AvroFactory.builderWithApacheDecoder().build();
+        final AvroMapper mapper = new AvroMapper(factory);
+
+        final byte[] doc = {
+            (byte) 2, (byte) 22, (byte) 36, (byte) 2, (byte) 0,
+            (byte) 0, (byte) 8, (byte) 3, (byte) 3, (byte) 3,
+            (byte) 122, (byte) 3, (byte) -24
+        };
+
+        try (AvroParser p = factory.createParser(doc)) {
+            AvroSchemaGenerator gen = new AvroSchemaGenerator();
+            mapper.acceptJsonFormatVisitor(RootType.class, gen);
+            p.setSchema(gen.getGeneratedSchema());
+            p.getTextCharacters();
+            p.nextToken();
+            p.nextToken();
+            p.nextToken();
+            fail("Should not pass (invalid content)");
+        } catch (StreamReadException e) {
+            assertTrue(e.getMessage().contains("Malformed UTF-8 character"));
+        }
+    }
+
+    private class RootType {
+        public String name;
+        public int value;
+    }
+}

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -295,5 +295,9 @@ Arthur Chan (@arthurscchan)
  * Contributed #432 (ion) More methods from `IonReader` could throw an unexpected
    `AssertionError`
   (2.17.0)
- * Contributed #434 (ion) Unexpected `NullPointerException` thrown from `IonParser::getNumberType()`
+ * Contributed #434: (ion) Unexpected `NullPointerException` thrown from
+  `IonParser::getNumberType()`
+  (2.17.0)
+ * Contributed #449: (avro) `IndexOutOfBoundsException` in `JacksonAvroParserImpl`
+   for invalid input
   (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -31,6 +31,8 @@ Active maintainers:
 #434 (ion) Unexpected `NullPointerException` thrown from `IonParser::getNumberType()`
  (fix contributed by Arthur C)
 #437 (ion) `IonReader.next()` throws NPEs for some invalid content
+#449 (avro) `IndexOutOfBoundsException` in `JacksonAvroParserImpl` for invalid input
+ (fix contributed by Arthur C)
 - (ion) Update `com.amazon.ion:ion-java` to 1.11.0 (from 1.10.5)
 
 2.16.1 (24-Dec-2023)


### PR DESCRIPTION
This PR provides a possible fix for #449 by adding a bound check to avoid unexpected IOOBE from avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java.