### PR TITLE
Fix issue 464: Add multiple checking condition to avoid IOOBE

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -2374,6 +2374,20 @@ public class CBORParser extends ParserMinimalBase
         // Let's actually do a tight loop for ASCII first:
         final int end = inPtr + len;
 
+        // If the provided len is malformed, the end value
+        // could be larger than the length of inputBuf.
+        // This could cause the following while loop
+        // not returning in the correct location,
+        // result in ArrayIndexOutOfBoundsException
+        // It could also throw AIOOBE if the inPtr
+        // already pointing to the end of inputBuf
+        // and no more data is left in inputBuf.
+        // It will also be a problem if end is
+        // negative when provided len is negative.
+        if ((end <= 0) || (end >= inputBuf.length) || (inPtr >= inputBuf.length)) {
+            throw _constructReadException("Requested length too long.");
+        }
+
         int i;
         while ((i = inputBuf[inPtr]) >= 0) {
             outBuf[outPtr++] = (char) i;

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/fuzz/CBORFuzz464_65722_IOOBETest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/fuzz/CBORFuzz464_65722_IOOBETest.java
@@ -1,0 +1,31 @@
+package com.fasterxml.jackson.dataformat.cbor.fuzz;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.exc.StreamReadException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.fasterxml.jackson.dataformat.cbor.CBORTestBase;
+
+public class CBORFuzz464_65722_IOOBETest extends CBORTestBase
+{
+    private final ObjectMapper MAPPER = cborMapper();
+
+    public void testInvalidText() throws Exception
+    {
+        final byte[] input = {
+            (byte)-60, (byte)-49, (byte)122, (byte)127, (byte)-1,
+            (byte)-1, (byte)-1, (byte)15, (byte)110
+        };
+        try (JsonParser p = MAPPER.createParser(input)) {
+            try {
+                p.nextToken();
+                p.getTextLength();
+                fail("Should not reach here (invalid input)");
+            } catch (StreamReadException e) {
+                verifyException(e, "Requested length too long.");
+            }
+        }
+    }
+}

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/fuzz/CBORFuzz464_65722_IOOBETest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/fuzz/CBORFuzz464_65722_IOOBETest.java
@@ -20,11 +20,12 @@ public class CBORFuzz464_65722_IOOBETest extends CBORTestBase
         };
         try (JsonParser p = MAPPER.createParser(input)) {
             try {
-                p.nextToken();
+                assertToken(JsonToken.VALUE_STRING, p.nextToken());
+                // oddly enough `getText()` didn't do it but this:
                 p.getTextLength();
                 fail("Should not reach here (invalid input)");
             } catch (StreamReadException e) {
-                verifyException(e, "Requested length too long.");
+                verifyException(e, "Unexpected end-of-input in VALUE_STRING");
             }
         }
     }

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -307,3 +307,6 @@ Arthur Chan (@arthurscchan)
   (2.17.0)
  * Contributed #460: (protobuf) Unexpected `NullPointerException` in `ProtobufParser.currentName()`
   (2.17.0)
+ * Contributed #464: (cbor) Unexpected `ArrayIndexOutOfBoundsException` in `CBORParser`
+   for corrupt String value
+  (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -40,6 +40,9 @@ Active maintainers:
 #460: (protobuf) Unexpected `NullPointerException` in `ProtobufParser.currentName()`
  (fix contributed by Arthur C)
 #462: (protobuf) `ProtobufParser.currentName()` returns wrong value at root level
+#464: (cbor) Unexpected `ArrayIndexOutOfBoundsException` in `CBORParser`
+  for corrupt String value
+ (fix contributed by Arthur C)
 - (ion) Update `com.amazon.ion:ion-java` to 1.11.0 (from 1.10.5)
 
 2.16.1 (24-Dec-2023)


### PR DESCRIPTION
This PR provides a suggested fix for #464 by adding multiple checking conditions for the array index and buffer length in the `CBORParser::_finishShortText()` method to avoid malformed length value (negative value or value too large) causing infinite while loop and result in AIOOBE.