### PR TITLE
Upgrade `ion-java` to 1.11.2 and remove handling of exceptions that are no longer leaked

### DIFF
--- a/ion/pom.xml
+++ b/ion/pom.xml
@@ -39,7 +39,7 @@ tree model)
     <dependency>
       <groupId>com.amazon.ion</groupId>
       <artifactId>ion-java</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.2</version>
     </dependency>
 
     <!-- Extends Jackson core, databind -->

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -273,16 +273,7 @@ public class IonParser
             case VALUE_STRING:
                 try {
                     return _reader.stringValue();
-                } catch (IonException
-                    // stringValue() will throw an UnknownSymbolException if we're
-                    // trying to get the text for a symbol id that cannot be resolved.
-                    // stringValue() has an assert statement which could throw an
-                    | AssertionError e
-                    // AssertionError if we're trying to get the text with a symbol
-                    // id less than or equals to 0. This is a bug in ion-java that
-                    // will be fixed by https://github.com/amazon-ion/ion-java/issues/702
-                    // at which point this AssertionError clause should be removed.
-                    ) {
+                } catch (IonException e) {
                     return _reportCorruptContent(e);
                 }
             case VALUE_NUMBER_INT:
@@ -658,12 +649,6 @@ public class IonParser
         } catch (IonException e) {
             return _reportCorruptContent(e);
 
-        } catch (AssertionError e) {
-            // [dataformats-binary#432]: AssertionError if we're trying to get the text
-            //   with a symbol id less than or equals to 0. This is a bug in ion-java that
-            //   will be fixed by https://github.com/amazon-ion/ion-java/issues/702
-            //   at which point this AssertionError clause should be removed.
-            return _reportCorruptContent(e);
         }
         if (type == null) {
             if (_parsingContext.inRoot()) { // EOF?

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/IonFuzz_469_66149_NegArraySizeTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/IonFuzz_469_66149_NegArraySizeTest.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.dataformat.ion.failing;
+package com.fasterxml.jackson.dataformat.ion.fuzz;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -24,7 +24,6 @@ public class IonFuzz_469_66149_NegArraySizeTest
             ION_MAPPER.readTree(doc);
             fail("Should not pass (invalid content)");
         } catch (StreamReadException e) {
-            // May or may not be the exception message to get, change as appropriate
             assertThat(e.getMessage(), Matchers.containsString("Corrupt content to decode"));
         }
     }

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/IonFuzz_471_66141_AssertionErrorTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/IonFuzz_471_66141_AssertionErrorTest.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.dataformat.ion.failing;
+package com.fasterxml.jackson.dataformat.ion.fuzz;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -24,8 +24,7 @@ public class IonFuzz_471_66141_AssertionErrorTest
             ION_MAPPER.readValue(doc, java.util.Date.class);
             fail("Should not pass (invalid content)");
         } catch (StreamReadException e) {
-            // May or may not be the exception message to get, change as appropriate
-            assertThat(e.getMessage(), Matchers.containsString("Corrupt content to decode"));
+            assertThat(e.getMessage(), Matchers.containsString("Corrupt Number value to decode"));
         }
     }
 }

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/IonFuzz_473_66131_AIOOBE_Test.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/fuzz/IonFuzz_473_66131_AIOOBE_Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.dataformat.ion.failing;
+package com.fasterxml.jackson.dataformat.ion.fuzz;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -240,6 +240,8 @@ Tyler Gregg (tgregg@github)
   (2.14.0)
  #468: (ion) Upgrade `ion-java` to 1.11.1 and remove catch clauses for exceptions
   (2.17.0)
+ * ... and countless others, no longer listed here but only in main Release Notes
+   (since he is the official maintainer of the Ion backend)
 
 David Turner (DaveCTurner@github)
  #312: (cbor, smile) Short NUL-only keys incorrectly detected as duplicates

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -49,8 +49,15 @@ Active maintainers:
 #464: (cbor) Unexpected `ArrayIndexOutOfBoundsException` in `CBORParser`
   for corrupt String value
  (fix contributed by Arthur C)
-#468: (ion) Upgrade `ion-java` to 1.11.1 and remove catch clauses for exceptions
-  that are no longer leaked
+#469 (ion) IonReader.newBytes() throwing `NegativeArraySizeException`
+ (contributed by @tgregg)
+#471 (ion) `IonReader` throws `AssertionError` for Timestamp value
+ (contributed by @tgregg)
+#473 (ion) `IonReader.next()` throws `ArrayIndexOutOfBoundsException` for some
+  corrupt content
+ (contributed by @tgregg)
+#482 (ion): Upgrade `ion-java` to 1.11.2 and remove handling of exceptions that
+  are no longer leaked
  (contributed by @tgregg)
 
 2.16.1 (24-Dec-2023)


### PR DESCRIPTION
Closes #469 
Closes #471
Closes #473 

ion-java 1.11.2 release notes: https://github.com/amazon-ion/ion-java/releases/tag/v1.11.2
Maven Central release: https://central.sonatype.com/artifact/com.amazon.ion/ion-java/1.11.2

This should take care of the leaked exceptions identified via fuzzing so far. If we find more we will fix them in subsequent ion-java releases.