### PR TITLE
Rework synchronization in `ProtobufMapper`

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufMapper.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufMapper.java
@@ -203,7 +203,7 @@ public class ProtobufMapper extends ObjectMapper
             try {
                 l = _descriptorLoader;
                 if (l == null) {
-                    l = _descriptorLoader = DescriptorLoader.construct(this);
+                    _descriptorLoader = l = DescriptorLoader.construct(this);
                 }
             } finally {
                 _lock.unlock();

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufMapper.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufMapper.java
@@ -22,8 +22,6 @@ public class ProtobufMapper extends ObjectMapper
 {
     private static final long serialVersionUID = 1L;
 
-    private final ReentrantLock _lock = new ReentrantLock();
-
     /**
      * Base implementation for "Vanilla" {@link ObjectMapper}, used with
      * Protobuf backend.
@@ -46,6 +44,9 @@ public class ProtobufMapper extends ObjectMapper
      * @since 2.9
      */
     protected volatile DescriptorLoader _descriptorLoader;
+
+    // @since 2.18
+    private final ReentrantLock _descriptorLock = new ReentrantLock();
 
     /*
     /**********************************************************
@@ -199,14 +200,14 @@ public class ProtobufMapper extends ObjectMapper
     {
         DescriptorLoader l = _descriptorLoader;
         if (l == null) {
-            _lock.lock();
+            _descriptorLock.lock();
             try {
                 l = _descriptorLoader;
                 if (l == null) {
                     _descriptorLoader = l = DescriptorLoader.construct(this);
                 }
             } finally {
-                _lock.unlock();
+                _descriptorLock.unlock();
             }
         }
         return l;

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -319,3 +319,7 @@ Thomas de Lange (@thomasdelange5)
  * Contributed fix for #428: (ion) `IonParser.getIntValue()` fails or does not handle
    value overflow checks
   (2.17.0)
+
+PJ Fanning (pjfanning@github)
+ * Contributed #484: Rework synchronization in `ProtobufMapper`
+  (2.18.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,8 @@ Active maintainers:
 
 2.18.0 (not yet released)
 
-No changes since 2.17.
+#484: (protobuf) Rework synchronization in `ProtobufMapper`
+ (contributed by @pjfanning)
 
 2.17.0 (12-Mar-2024)
 


### PR DESCRIPTION
* also marked the variable as volatile as this is something that is often done when you have concurrent access
* the new code tries a little harder not to create multiple DescriptorLoaders. The old code could have queued up multiple threads where l was null and then each got the synchronization lock in turn and then created a fresh DescriptorLoader.