### PR TITLE
Don't close IonParser on EOF to be compatible with MappingIterator when source is an empty InputStream

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -676,7 +676,6 @@ public class IonParser
         }
         if (type == null) {
             if (_parsingContext.inRoot()) { // EOF?
-                close();
                 _currToken = null;
             } else {
                 _parsingContext = _parsingContext.getParent();

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/sequence/MappingIteratorTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/sequence/MappingIteratorTest.java
@@ -1,0 +1,50 @@
+package com.fasterxml.jackson.dataformat.ion.sequence;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import org.junit.Test;
+
+public class MappingIteratorTest {
+
+    private static final ObjectMapper MAPPER = new IonObjectMapper();
+
+    @Test
+    public void testReadFromWrite() throws Exception {
+        final Object[] values = new String[]{"1", "2", "3", "4"};
+
+        // write
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (SequenceWriter seq = MAPPER.writer().writeValues(out)) {
+            for (Object value : values) {
+                seq.write(value);
+            }
+        }
+
+        // read
+        final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        try (MappingIterator<Object> it = MAPPER.readerFor(Object.class).readValues(in)) {
+            for (Object value : values) {
+                assertTrue(it.hasNext());
+                assertTrue(it.hasNext()); // should not alter the iterator state
+                assertEquals(value, it.next());
+            }
+            assertFalse(it.hasNext());
+        }
+    }
+
+    @Test
+    public void testReadFromEmpty() throws Exception {
+        final ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        try (MappingIterator<Object> it = MAPPER.readerFor(Object.class).readValues(in)) {
+            assertFalse(it.hasNext());
+        }
+    }
+}


### PR DESCRIPTION
Using a `IonObjectMapper` with a `MappingIterator` to read ION objects fails when the provided `InputStream` is empty, resulting in a "stream closed" exception on the first call on `MappingIterator#hasNextValue()`.

For any reason, [the `ObjectReader` calls `nextToken()` when initializing the `MappingIterator`](https://github.com/FasterXML/jackson-databind/blob/2.18/src/main/java/com/fasterxml/jackson/databind/ObjectReader.java#L2226), and because the `nextToken()` method calls `close()` when the token is `null`, this leads to the exception mentioned above.

During my analysis to understand this error, I was unable to reproduce the "stream closed" exception _(it seems to occur only when wrapping the source `InputStream` within a `BufferedInputStream`)_, but I found a `NullPointerException` under the same conditions.

Here is an extract of the stack trace:
```
java.lang.NullPointerException: Cannot read the array length because "b" is null

	at java.base/java.io.ByteArrayInputStream.read(ByteArrayInputStream.java:175)
	at com.amazon.ion.impl.IonCursorBinary.refill(IonCursorBinary.java:672)
	at com.amazon.ion.impl.IonCursorBinary.fillAt(IonCursorBinary.java:537)
	at com.amazon.ion.impl.IonCursorBinary.slowMakeBufferReady(IonCursorBinary.java:1013)
	at com.amazon.ion.impl.IonCursorBinary.slowNextToken(IonCursorBinary.java:1599)
	at com.amazon.ion.impl.IonCursorBinary.slowOverflowableNextToken(IonCursorBinary.java:1688)
	at com.amazon.ion.impl.IonCursorBinary.slowNextValue(IonCursorBinary.java:1742)
	at com.amazon.ion.impl.IonCursorBinary.nextValue(IonCursorBinary.java:1720)
	at com.amazon.ion.impl.IonReaderContinuableCoreBinary.nextValue(IonReaderContinuableCoreBinary.java:460)
	at com.amazon.ion.impl.IonReaderContinuableApplicationBinary.nextValue(IonReaderContinuableApplicationBinary.java:909)
	at com.amazon.ion.impl.IonReaderContinuableTopLevelBinary.next(IonReaderContinuableTopLevelBinary.java:168)
	at com.fasterxml.jackson.dataformat.ion.IonParser.nextToken(IonParser.java:672)
	at com.fasterxml.jackson.databind.MappingIterator.hasNextValue(MappingIterator.java:246)
```

Everything seems to happen because the `InputStream` is closed on the first call, so I've removed the call to `close()` in `nextToken()`, assuming that the caller will close it.