### PR TITLE
[Avro] write enums as string

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaGenerator.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaGenerator.java
@@ -31,4 +31,17 @@ public class AvroSchemaGenerator extends VisitorFormatWrapperImpl
         super.disableLogicalTypes();
         return this;
     }
+
+    @Override
+    public AvroSchemaGenerator enableWriteEnumAsString() {
+        super.enableWriteEnumAsString();
+        return this;
+    }
+
+    @Override
+    public AvroSchemaGenerator disableWriteEnumAsString() {
+        super.disableWriteEnumAsString();
+        return this;
+    }
+
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/EnumVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/EnumVisitor.java
@@ -1,0 +1,45 @@
+package com.fasterxml.jackson.dataformat.avro.schema;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
+
+import org.apache.avro.Schema;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+public class EnumVisitor extends JsonStringFormatVisitor.Base
+    implements SchemaBuilder
+{
+    protected final SerializerProvider _provider;
+    protected final JavaType _type;
+    protected final DefinedSchemas _schemas;
+
+    protected Set<String> _enums;
+
+    public EnumVisitor(SerializerProvider provider, DefinedSchemas schemas, JavaType t) {
+        _schemas = schemas;
+        _type = t;
+        _provider = provider;
+    }
+
+    @Override
+    public void enumTypes(Set<String> enums) {
+        _enums = enums;
+    }
+
+    @Override
+    public Schema builtAvroSchema() {
+        if (_enums == null) {
+        	throw new IllegalStateException("Possible enum values cannot be null");
+        }
+
+        BeanDescription bean = _provider.getConfig().introspectClassAnnotations(_type);
+        Schema schema = AvroSchemaHelper.createEnumSchema(bean, new ArrayList<>(_enums));
+        _schemas.addSchema(_type, schema);
+        return schema;
+    }
+
+}

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/EnumVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/EnumVisitor.java
@@ -10,6 +10,12 @@ import org.apache.avro.Schema;
 import java.util.ArrayList;
 import java.util.Set;
 
+/**
+ * Specific visitor for Java Enum types that are to be exposed as
+ * Avro Enums. Used unless Java Enums are to be mapped to Avro Strings.
+ *
+ * @since 2.18
+ */
 public class EnumVisitor extends JsonStringFormatVisitor.Base
     implements SchemaBuilder
 {

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/EnumVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/EnumVisitor.java
@@ -33,7 +33,7 @@ public class EnumVisitor extends JsonStringFormatVisitor.Base
     @Override
     public Schema builtAvroSchema() {
         if (_enums == null) {
-        	throw new IllegalStateException("Possible enum values cannot be null");
+            throw new IllegalStateException("Possible enum values cannot be null");
         }
 
         BeanDescription bean = _provider.getConfig().introspectClassAnnotations(_type);
@@ -41,5 +41,4 @@ public class EnumVisitor extends JsonStringFormatVisitor.Base
         _schemas.addSchema(_type, schema);
         return schema;
     }
-
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/StringVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/StringVisitor.java
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.dataformat.avro.schema;
 
-import java.util.ArrayList;
 import java.util.Set;
 
 import org.apache.avro.Schema;
@@ -18,13 +17,9 @@ public class StringVisitor extends JsonStringFormatVisitor.Base
 {
     protected final SerializerProvider _provider;
     protected final JavaType _type;
-    protected final DefinedSchemas _schemas;
 
-    protected Set<String> _enums;
-
-    public StringVisitor(SerializerProvider provider, DefinedSchemas schemas, JavaType t) {
-        _schemas = schemas;
-        _type = t;
+    public StringVisitor(SerializerProvider provider, JavaType type) {
+        _type = type;
         _provider = provider;
     }
 
@@ -35,7 +30,7 @@ public class StringVisitor extends JsonStringFormatVisitor.Base
 
     @Override
     public void enumTypes(Set<String> enums) {
-        _enums = enums;
+    	// Do nothing
     }
 
     @Override
@@ -50,11 +45,6 @@ public class StringVisitor extends JsonStringFormatVisitor.Base
             return AvroSchemaHelper.createUUIDSchema();
         }
         BeanDescription bean = _provider.getConfig().introspectClassAnnotations(_type);
-        if (_enums != null) {
-            Schema s = AvroSchemaHelper.createEnumSchema(bean, new ArrayList<>(_enums));
-            _schemas.addSchema(_type, s);
-            return s;
-        }
         Schema schema = Schema.create(Schema.Type.STRING);
         // Stringable classes need to include the type
         if (AvroSchemaHelper.isStringable(bean.getClassInfo()) && !_type.hasRawClass(String.class)) {

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import com.fasterxml.jackson.dataformat.avro.AvroSchema;
+
 import org.apache.avro.Schema;
 
 import java.time.temporal.Temporal;
@@ -177,7 +178,14 @@ public class VisitorFormatWrapperImpl
             _valueSchema = s;
             return null;
         }
-        StringVisitor v = new StringVisitor(_provider, _schemas, type);
+
+        if (Enum.class.isAssignableFrom(type.getRawClass())) {
+        	EnumVisitor v = new EnumVisitor(_provider, _schemas, type);
+            _builder = v;
+            return v;
+        }
+
+        StringVisitor v = new StringVisitor(_provider, type);
         _builder = v;
         return v;
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
@@ -1,25 +1,18 @@
 package com.fasterxml.jackson.dataformat.avro.schema;
 
+import java.time.temporal.Temporal;
+
 import com.fasterxml.jackson.core.JsonGenerator;
+
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonAnyFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonArrayFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonBooleanFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonMapFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNullFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
+
 import com.fasterxml.jackson.dataformat.avro.AvroSchema;
 
 import org.apache.avro.Schema;
-
-import java.time.temporal.Temporal;
 
 public class VisitorFormatWrapperImpl
     implements JsonFormatVisitorWrapper
@@ -111,6 +104,8 @@ public class VisitorFormatWrapperImpl
 
     /**
      * Enables Avro schema with Logical Types generation.
+     *
+     * @since 2.13
      */
     public VisitorFormatWrapperImpl enableLogicalTypes() {
         _logicalTypesEnabled = true;
@@ -119,6 +114,8 @@ public class VisitorFormatWrapperImpl
 
     /**
      * Disables Avro schema with Logical Types generation.
+     *
+     * @since 2.13
      */
     public VisitorFormatWrapperImpl disableLogicalTypes() {
         _logicalTypesEnabled = false;
@@ -131,6 +128,8 @@ public class VisitorFormatWrapperImpl
 
     /**
      * Enable Java enum to Avro string mapping.
+     *
+     * @since 2.18
      */
     public VisitorFormatWrapperImpl enableWriteEnumAsString() {
     	_writeEnumAsString = true;
@@ -139,12 +138,15 @@ public class VisitorFormatWrapperImpl
 
     /**
      * Disable Java enum to Avro string mapping.
+     *
+     * @since 2.18
      */
     public VisitorFormatWrapperImpl disableWriteEnumAsString() {
         _writeEnumAsString = false;
         return this;
     }
 
+    // @since 2.18
     public boolean isWriteEnumAsStringEnabled() {
         return _writeEnumAsString;
     }
@@ -204,8 +206,10 @@ public class VisitorFormatWrapperImpl
             return null;
         }
 
-        if (Enum.class.isAssignableFrom(type.getRawClass()) && !isWriteEnumAsStringEnabled()) {
-        	EnumVisitor v = new EnumVisitor(_provider, _schemas, type);
+        // 06-Jun-2024: [dataformats-binary#494] Enums may be exposed either
+        //   as native Avro Enums, or as Avro Strings:
+        if (type.isEnumType() && !isWriteEnumAsStringEnabled()) {
+            EnumVisitor v = new EnumVisitor(_provider, _schemas, type);
             _builder = v;
             return v;
         }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/VisitorFormatWrapperImpl.java
@@ -34,6 +34,11 @@ public class VisitorFormatWrapperImpl
     protected boolean _logicalTypesEnabled = false;
 
     /**
+     * @since 2.18
+     */
+    protected boolean _writeEnumAsString = false;
+
+    /**
      * Visitor used for resolving actual Schema, if structured type
      * (or one with complex configuration)
      */
@@ -124,6 +129,26 @@ public class VisitorFormatWrapperImpl
         return _logicalTypesEnabled;
     }
 
+    /**
+     * Enable Java enum to Avro string mapping.
+     */
+    public VisitorFormatWrapperImpl enableWriteEnumAsString() {
+    	_writeEnumAsString = true;
+        return this;
+    }
+
+    /**
+     * Disable Java enum to Avro string mapping.
+     */
+    public VisitorFormatWrapperImpl disableWriteEnumAsString() {
+        _writeEnumAsString = false;
+        return this;
+    }
+
+    public boolean isWriteEnumAsStringEnabled() {
+        return _writeEnumAsString;
+    }
+
     /*
     /**********************************************************************
     /* Callbacks
@@ -179,7 +204,7 @@ public class VisitorFormatWrapperImpl
             return null;
         }
 
-        if (Enum.class.isAssignableFrom(type.getRawClass())) {
+        if (Enum.class.isAssignableFrom(type.getRawClass()) && !isWriteEnumAsStringEnabled()) {
         	EnumVisitor v = new EnumVisitor(_provider, _schemas, type);
             _builder = v;
             return v;

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/EnumTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/EnumTest.java
@@ -2,13 +2,22 @@ package com.fasterxml.jackson.dataformat.avro;
 
 public class EnumTest extends AvroTestBase
 {
-    protected final static String ENUM_SCHEMA_JSON = "{\n"
+    // gender as Avro enum
+	protected final static String ENUM_SCHEMA_JSON = "{\n"
             +"\"type\": \"record\",\n"
             +"\"name\": \"Employee\",\n"
             +"\"fields\": [\n"
             +" {\"name\": \"gender\", \"type\": { \"type\" : \"enum\","
             +" \"name\": \"Gender\", \"symbols\": [\"M\",\"F\"] }"
             +"}\n"
+            +"]}";
+
+    // gender as Avro string
+    protected final static String STRING_SCHEMA_JSON = "{"
+            +" \"type\": \"record\", "
+            +" \"name\": \"Employee\", "
+            +" \"fields\": ["
+            +" {\"name\": \"gender\", \"type\": \"string\"}"
             +"]}";
 
     protected enum Gender { M, F; }
@@ -23,7 +32,7 @@ public class EnumTest extends AvroTestBase
 
     private final AvroMapper MAPPER = newMapper();
 
-    public void testSimple() throws Exception
+    public void test_avroSchemaWithEnum_fromEnumValueToEnumValue() throws Exception
     {
         AvroSchema schema = MAPPER.schemaFrom(ENUM_SCHEMA_JSON);
         Employee input = new Employee();
@@ -40,7 +49,7 @@ public class EnumTest extends AvroTestBase
         assertEquals(Gender.F, output.gender);
     }
 
-    public void testEnumValueAsString() throws Exception
+    public void test_avroSchemaWithEnum_fromStringValueToEnumValue() throws Exception
     {
         AvroSchema schema = MAPPER.schemaFrom(ENUM_SCHEMA_JSON);
         EmployeeStr input = new EmployeeStr();
@@ -56,4 +65,42 @@ public class EnumTest extends AvroTestBase
         assertNotNull(output);
         assertEquals(Gender.F, output.gender);
     }
+
+    public void test_avroSchemaWithString_fromEnumValueToEnumValue() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFrom(STRING_SCHEMA_JSON);
+        Employee input = new Employee();
+        input.gender = Gender.F;
+
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(input);
+        assertNotNull(bytes);
+        // FIXME What is expected bytes length?
+//        assertEquals(1, bytes.length); // measured to be current exp size
+
+        // and then back
+        Employee output = MAPPER.readerFor(Employee.class).with(schema)
+                .readValue(bytes);
+        assertNotNull(output);
+        assertEquals(Gender.F, output.gender);
+    }
+
+    // Not sure this test makes sense
+    public void test_avroSchemaWithString_fromStringValueToEnumValue() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFrom(STRING_SCHEMA_JSON);
+        EmployeeStr input = new EmployeeStr();
+        input.gender = "F";
+
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(input);
+        assertNotNull(bytes);
+        // FIXME What is expected bytes length?
+//        assertEquals(1, bytes.length); // measured to be current exp size
+
+        // and then back
+        Employee output = MAPPER.readerFor(Employee.class).with(schema)
+                .readValue(bytes);
+        assertNotNull(output);
+        assertEquals(Gender.F, output.gender);
+    }
+
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/Enum_schemaCreationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/Enum_schemaCreationTest.java
@@ -1,0 +1,56 @@
+package com.fasterxml.jackson.dataformat.avro.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.dataformat.avro.AvroMapper;
+import com.fasterxml.jackson.dataformat.avro.AvroTestBase;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
+import org.junit.Test;
+
+public class Enum_schemaCreationTest extends AvroTestBase {
+
+    static enum NumbersEnum {
+    	ONE, TWO, THREE
+    }
+
+    private final AvroMapper MAPPER = newMapper();
+
+    @Test
+    public void testJavaEnumToAvroEnum_test() throws JsonMappingException {
+        // GIVEN
+        AvroSchemaGenerator gen = new AvroSchemaGenerator();
+
+        // WHEN
+        MAPPER.acceptJsonFormatVisitor(NumbersEnum.class , gen);
+        Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        System.out.println("schema:\n" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getType()).isEqualTo( Schema.Type.ENUM);
+        assertThat(actualSchema.getEnumSymbols()).containsExactlyInAnyOrder("ONE", "TWO", "THREE");
+    }
+
+    @Test
+    public void testJavaEnumToAvroString_test() throws JsonMappingException {
+        // GIVEN
+        AvroSchemaGenerator gen = new AvroSchemaGenerator()
+        		.enableWriteEnumAsString();
+
+        // WHEN
+        MAPPER.acceptJsonFormatVisitor(NumbersEnum.class , gen);
+        Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        System.out.println("schema:\n" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getType()).isEqualTo( Schema.Type.STRING);
+
+        // When type is stringable then java-class property is addded.
+        assertThat(actualSchema.getProp(SpecificData.CLASS_PROP)).isNotEmpty();
+    }
+
+}

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -222,6 +222,9 @@ Michal Foksa (MichalFoksa@github)
 * Contributed #310: (avro) Avro schema generation: allow override namespace with new
   `@AvroNamespace` annotation
  (2.14.0)
+* Contributed #494: Avro Schema generation: allow mapping Java Enum properties to
+  Avro String values
+ (2.18.0)
 
 Hunter Herman (hherman1@github)
 
@@ -325,6 +328,11 @@ Yoann Vernageau (@yvrng)
    when source is an empty `InputStream`
   (2.17.1)
 
-PJ Fanning (pjfanning@github)
+PJ Fanning (@pjfanning)
  * Contributed #484: Rework synchronization in `ProtobufMapper`
+  (2.18.0)
+
+Joachim Lous (@jlous)
+ * Requested #494: Avro Schema generation: allow mapping Java Enum properties to
+   Avro String values
   (2.18.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,10 @@ Active maintainers:
 
 #484: (protobuf) Rework synchronization in `ProtobufMapper`
  (contributed by @pjfanning)
+#494: Avro Schema generation: allow mapping Java Enum properties to
+  Avro String values
+ (requested by Joachim L)
+ (contributed by Michal F)
 
 2.17.1 (04-May-2024)
 


### PR DESCRIPTION
New switch added `enableWriteEnumAsString()` to enable Java enum to Avro string mapping at schema generation.

Fixes #494 