### PR TITLE
Update avro to 1.11.3

### DIFF
--- a/avro/pom.xml
+++ b/avro/pom.xml
@@ -47,7 +47,7 @@ abstractions.
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.8.2</version>
+      <version>1.11.3</version>
     </dependency>
 
     <!-- and for testing we need logback -->

--- a/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -338,6 +338,7 @@ public abstract class AvroSchemaHelper
             if (namespace == null) {
                 return name;
             }
+            // Backward compatibility with schemas that use dollar sign for nested classes (Apache Avro before 1.9)
             final int len = namespace.length();
             if (namespace.charAt(len-1) == '$') {
                 return namespace + name;

--- a/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -101,7 +101,8 @@ public abstract class AvroSchemaHelper
         //   NOTE: was reverted in 2.8.8, but is enabled for Jackson 2.9.
         Class<?> enclosing = cls.getEnclosingClass();
         if (enclosing != null) {
-            return enclosing.getName();
+            // Enclosing class may also be nested
+            return enclosing.getName().replace('$', '.');
         }
         Package pkg = cls.getPackage();
         return (pkg == null) ? "" : pkg.getName();
@@ -415,13 +416,25 @@ public abstract class AvroSchemaHelper
             //     Check if this is a nested class
             // 19-Sep-2020, tatu: This is a horrible, horribly inefficient and all-around
             //    wrong mechanism. To be abolished if possible.
-            final String nestedClassName = key.nameWithSeparator('$');
-            try {
-                Class.forName(nestedClassName);
-                return nestedClassName;
-            } catch (ClassNotFoundException e) {
-                // Could not find a nested class, must be a regular class
-                return key.nameWithSeparator('.');
+            // Based on SpecificData::getClass from apache avro
+            // Initially assume that namespace is a Java package
+            StringBuilder sb = new StringBuilder(key.nameWithSeparator('.'));
+            int lastDot = sb.length();
+            while (true) {
+                try {
+                    // Try to resolve the class
+                    String className = sb.toString();
+                    Class.forName(className);
+                    return className;
+                } catch (ClassNotFoundException e) {
+                    // Class does not exist - perhaps last dot is actually a nested class
+                    lastDot = sb.lastIndexOf(".", lastDot);
+                    if (lastDot == -1) {
+                        // No more dots so we are unable to resolve, should we throw an exception?
+                        return key.nameWithSeparator('.');
+                    }
+                    sb.setCharAt(lastDot, '$');
+                }
             }
         }
     }

--- a/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -101,7 +101,7 @@ public abstract class AvroSchemaHelper
         //   NOTE: was reverted in 2.8.8, but is enabled for Jackson 2.9.
         Class<?> enclosing = cls.getEnclosingClass();
         if (enclosing != null) {
-            return enclosing.getName() + "$";
+            return enclosing.getName();
         }
         Package pkg = cls.getPackage();
         return (pkg == null) ? "" : pkg.getName();

--- a/avro/src/test/java/tools/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
@@ -23,6 +23,15 @@ public class AvroNamespaceTest {
     @AvroNamespace("EnumWithAvroNamespaceAnnotation.namespace")
     enum EnumWithAvroNamespaceAnnotation {FOO, BAR;}
 
+    static class Foo {
+        static class Bar {
+            static class ClassWithMultipleNestingLevels {
+            }
+
+            enum EnumWithMultipleNestingLevels {FOO, BAR;}
+        }
+    }
+
     @Test
     public void class_without_AvroNamespace_test() throws Exception {
         // GIVEN
@@ -51,6 +60,21 @@ public class AvroNamespaceTest {
         // THEN
         assertThat(actualSchema.getNamespace())
                 .isEqualTo("ClassWithAvroNamespaceAnnotation.namespace");
+    }
+
+    @Test
+    public void class_with_multiple_nesting_levels_test() throws Exception {
+        // GIVEN
+        AvroMapper mapper = new AvroMapper();
+        AvroSchemaGenerator gen = new AvroSchemaGenerator();
+
+        // WHEN
+        mapper.acceptJsonFormatVisitor(Foo.Bar.ClassWithMultipleNestingLevels.class, gen);
+        Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        // THEN
+        assertThat(actualSchema.getNamespace())
+                .isEqualTo("tools.jackson.dataformat.avro.annotation.AvroNamespaceTest.Foo.Bar");
     }
 
     @Test
@@ -83,4 +107,18 @@ public class AvroNamespaceTest {
                 .isEqualTo("EnumWithAvroNamespaceAnnotation.namespace");
     }
 
+    @Test
+    public void enum_with_multiple_nesting_levels_test() throws Exception {
+        // GIVEN
+        AvroMapper mapper = new AvroMapper();
+        AvroSchemaGenerator gen = new AvroSchemaGenerator();
+
+        // WHEN
+        mapper.acceptJsonFormatVisitor(Foo.Bar.EnumWithMultipleNestingLevels.class, gen);
+        Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        // THEN
+        assertThat(actualSchema.getNamespace())
+                .isEqualTo("tools.jackson.dataformat.avro.annotation.AvroNamespaceTest.Foo.Bar");
+    }
 }

--- a/avro/src/test/java/tools/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
@@ -35,7 +35,7 @@ public class AvroNamespaceTest {
 
         // THEN
         assertThat(actualSchema.getNamespace())
-                .isEqualTo("tools.jackson.dataformat.avro.annotation.AvroNamespaceTest$");
+                .isEqualTo("tools.jackson.dataformat.avro.annotation.AvroNamespaceTest");
     }
 
     @Test
@@ -65,7 +65,7 @@ public class AvroNamespaceTest {
 
         // THEN
         assertThat(actualSchema.getNamespace())
-                .isEqualTo("tools.jackson.dataformat.avro.annotation.AvroNamespaceTest$");
+                .isEqualTo("tools.jackson.dataformat.avro.annotation.AvroNamespaceTest");
     }
 
     @Test

--- a/avro/src/test/java/tools/jackson/dataformat/avro/interop/annotations/AvroAliasTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/interop/annotations/AvroAliasTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AvroAliasTest extends InteropTestBase {
 
-    @AvroAlias(alias = "Employee", space = "tools.jackson.dataformat.avro.AvroTestBase$")
+    @AvroAlias(alias = "Employee", space = "tools.jackson.dataformat.avro.AvroTestBase")
     public static class NewEmployee {
 
         public String name;
@@ -40,7 +40,7 @@ public class AvroAliasTest extends InteropTestBase {
         public AliasedNameEmployee boss;
     }
 
-    @AvroAlias(alias = "Size", space = "tools.jackson.dataformat.avro.AvroTestBase$")
+    @AvroAlias(alias = "Size", space = "tools.jackson.dataformat.avro.AvroTestBase")
     public enum NewSize {
         SMALL,
         LARGE;


### PR DESCRIPTION
Update Apache avro library to 1.11.3.
To make it compatible namespace generation for nested classes had to be changed.
Now dots are used instead of dollar signs as indicator of nesting.
AFAIK dollar sign is not an allowed character in Avro namespace according to the specification and this is why this change was implemented in avro library.
Note that avro library generates namespaces not ending with dollar character since version 1.9, but it actually removes all dollar signs in classes with multiple levels of nesting since 1.11.

See: AVRO-2143 and AVRO-2757
Fixes #167