### PR TITLE
Update avro to 1.11.3 (backport to 2.18 branch)

### DIFF
--- a/avro/pom.xml
+++ b/avro/pom.xml
@@ -47,7 +47,7 @@ abstractions.
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.8.2</version>
+      <version>1.11.3</version>
     </dependency>
 
     <!-- and for testing we need logback -->

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -108,6 +108,7 @@ public abstract class AvroSchemaHelper
         //   NOTE: was reverted in 2.8.8, but is enabled for Jackson 2.9.
         Class<?> enclosing = cls.getEnclosingClass();
         if (enclosing != null) {
+            // 23-Aug-2024: Changed as per [dataformats-binary#167] 
             // Enclosing class may also be nested
             return enclosing.getName().replace('$', '.');
         }
@@ -352,7 +353,8 @@ public abstract class AvroSchemaHelper
             if (namespace == null) {
                 return name;
             }
-            // Backward compatibility with schemas that use dollar sign for nested classes (Apache Avro before 1.9)
+            // 23-Aug-2024: [dataformats-binary#167] Still needed for backwards-compatibility
+            // with schemas that use dollar sign for nested classes (Apache Avro before 1.9)
             final int len = namespace.length();
             if (namespace.charAt(len-1) == '$') {
                 return namespace + name;
@@ -443,8 +445,8 @@ public abstract class AvroSchemaHelper
             //     Check if this is a nested class
             // 19-Sep-2020, tatu: This is a horrible, horribly inefficient and all-around
             //    wrong mechanism. To be abolished if possible.
-            // Based on SpecificData::getClass from apache avro
-            // Initially assume that namespace is a Java package
+            // 23-Aug-2024:[dataformats-binary#167] Based on SpecificData::getClass
+            //   from Apache Avro. Initially assume that namespace is a Java package
             StringBuilder sb = new StringBuilder(key.nameWithSeparator('.'));
             int lastDot = sb.length();
             while (true) {

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -108,7 +108,7 @@ public abstract class AvroSchemaHelper
         //   NOTE: was reverted in 2.8.8, but is enabled for Jackson 2.9.
         Class<?> enclosing = cls.getEnclosingClass();
         if (enclosing != null) {
-            return enclosing.getName() + "$";
+            return enclosing.getName();
         }
         Package pkg = cls.getPackage();
         return (pkg == null) ? "" : pkg.getName();
@@ -351,6 +351,7 @@ public abstract class AvroSchemaHelper
             if (namespace == null) {
                 return name;
             }
+            // Backward compatibility with schemas that use dollar sign for nested classes (Apache Avro before 1.9)
             final int len = namespace.length();
             if (namespace.charAt(len-1) == '$') {
                 return namespace + name;

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
@@ -35,7 +35,7 @@ public class AvroNamespaceTest {
 
         // THEN
         assertThat(actualSchema.getNamespace())
-                .isEqualTo("com.fasterxml.jackson.dataformat.avro.annotation.AvroNamespaceTest$");
+                .isEqualTo("com.fasterxml.jackson.dataformat.avro.annotation.AvroNamespaceTest");
     }
 
     @Test
@@ -65,7 +65,7 @@ public class AvroNamespaceTest {
 
         // THEN
         assertThat(actualSchema.getNamespace())
-                .isEqualTo("com.fasterxml.jackson.dataformat.avro.annotation.AvroNamespaceTest$");
+                .isEqualTo("com.fasterxml.jackson.dataformat.avro.annotation.AvroNamespaceTest");
     }
 
     @Test

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/annotation/AvroNamespaceTest.java
@@ -23,6 +23,15 @@ public class AvroNamespaceTest {
     @AvroNamespace("EnumWithAvroNamespaceAnnotation.namespace")
     enum EnumWithAvroNamespaceAnnotation {FOO, BAR;}
 
+    static class Foo {
+        static class Bar {
+            static class ClassWithMultipleNestingLevels {
+            }
+
+            enum EnumWithMultipleNestingLevels {FOO, BAR;}
+        }
+    }
+
     @Test
     public void class_without_AvroNamespace_test() throws Exception {
         // GIVEN
@@ -51,6 +60,21 @@ public class AvroNamespaceTest {
         // THEN
         assertThat(actualSchema.getNamespace())
                 .isEqualTo("ClassWithAvroNamespaceAnnotation.namespace");
+    }
+
+    @Test
+    public void class_with_multiple_nesting_levels_test() throws Exception {
+        // GIVEN
+        AvroMapper mapper = new AvroMapper();
+        AvroSchemaGenerator gen = new AvroSchemaGenerator();
+
+        // WHEN
+        mapper.acceptJsonFormatVisitor(Foo.Bar.ClassWithMultipleNestingLevels.class, gen);
+        Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        // THEN
+        assertThat(actualSchema.getNamespace())
+                .isEqualTo("com.fasterxml.jackson.dataformat.avro.annotation.AvroNamespaceTest.Foo.Bar");
     }
 
     @Test
@@ -83,4 +107,18 @@ public class AvroNamespaceTest {
                 .isEqualTo("EnumWithAvroNamespaceAnnotation.namespace");
     }
 
+    @Test
+    public void enum_with_multiple_nesting_levels_test() throws Exception {
+        // GIVEN
+        AvroMapper mapper = new AvroMapper();
+        AvroSchemaGenerator gen = new AvroSchemaGenerator();
+
+        // WHEN
+        mapper.acceptJsonFormatVisitor(Foo.Bar.EnumWithMultipleNestingLevels.class, gen);
+        Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        // THEN
+        assertThat(actualSchema.getNamespace())
+                .isEqualTo("com.fasterxml.jackson.dataformat.avro.annotation.AvroNamespaceTest.Foo.Bar");
+    }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroAliasTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/interop/annotations/AvroAliasTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AvroAliasTest extends InteropTestBase {
 
-    @AvroAlias(alias = "Employee", space = "com.fasterxml.jackson.dataformat.avro.AvroTestBase$")
+    @AvroAlias(alias = "Employee", space = "com.fasterxml.jackson.dataformat.avro.AvroTestBase")
     public static class NewEmployee {
 
         public String name;
@@ -40,7 +40,7 @@ public class AvroAliasTest extends InteropTestBase {
         public AliasedNameEmployee boss;
     }
 
-    @AvroAlias(alias = "Size", space = "com.fasterxml.jackson.dataformat.avro.AvroTestBase$")
+    @AvroAlias(alias = "Size", space = "com.fasterxml.jackson.dataformat.avro.AvroTestBase")
     public enum NewSize {
         SMALL,
         LARGE;

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -328,6 +328,10 @@ Yoann Vernageau (@yvrng)
    when source is an empty `InputStream`
   (2.17.1)
 
+Rafał Harabień (@rafalh)
+ * Contributed fix for #167: (avro) Incompatibility with Avro >=1.9.0 (upgrade to Avro 1.11.3)
+  (2.18.0)
+
 PJ Fanning (@pjfanning)
  * Contributed #484: (protobuf) Rework synchronization in `ProtobufMapper`
   (2.18.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,9 @@ Active maintainers:
 
 2.18.0 (not yet released)
 
+#167: (avro) Incompatibility with Avro >=1.9.0 (upgrade to Avro 1.11.3)
+ (reported by @Sage-Pierce)
+ (fix contributed by Rafał H)
 #484: (protobuf) Rework synchronization in `ProtobufMapper`
  (contributed by @pjfanning)
 #494: (avro) Avro Schema generation: allow mapping Java Enum properties to


### PR DESCRIPTION
Update Apache avro library to 1.11.3.
To make it compatible namespace generation for nested classes had to be changed.
Now dots are used instead of dollar signs as indicator of nesting.
AFAIK dollar sign is not an allowed character in Avro namespace according to the specification and this is why this change was implemented in avro library.
Note that avro library generates namespaces not ending with dollar character since version 1.9, but it actually removes all dollar signs in classes with multiple levels of nesting since 1.11.

See: AVRO-2143 and AVRO-2757
Fixes https://github.com/FasterXML/jackson-dataformats-binary/issues/167

Compatibility:
* over-the-wire protocol should be compatible
* reading schemas from older versions should work
* schemas generated after this change for classes with no nesting are unchanged
* schemas generated after this change for classes with one nesting level are readable by Jackson 2.11+ (commit c5705492)
* schemas generated after this change for classes with multiple nesting levels will not be readable by older Jackson versions