### PR TITLE
[AVRO] Support of Avro logical type `Decimal`.

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/annotation/AvroDecimal.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/annotation/AvroDecimal.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Decimal {
+public @interface AvroDecimal {
 
     /**
      * Maximum precision of decimals stored in this type.

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/annotation/Decimal.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/annotation/Decimal.java
@@ -1,0 +1,34 @@
+package com.fasterxml.jackson.dataformat.avro.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Instructs the {@link com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator AvroSchemaGenerator}
+ * to declare the annotated property's logical type as "decimal" ({@link org.apache.avro.LogicalTypes.Decimal}).
+ * By default, the Avro type is "bytes" ({@link org.apache.avro.Schema.Type#BYTES}), unless the field is also
+ * annotated with {@link com.fasterxml.jackson.dataformat.avro.AvroFixedSize}, in which case the Avro type
+ * will be "fixed" ({@link org.apache.avro.Schema.Type#FIXED}).
+ * <p>
+ * This annotation is only used during Avro schema generation and does not affect data serialization
+ * or deserialization.
+ *
+ * @since 2.19
+ */
+@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Decimal {
+
+    /**
+     * Maximum precision of decimals stored in this type.
+     */
+    int precision();
+
+    /**
+     * Scale must be zero or a positive integer less than or equal to the precision.
+     */
+    int scale() default 0;
+
+}

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/annotation/Decimal.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/annotation/Decimal.java
@@ -6,7 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Instructs the {@link com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator AvroSchemaGenerator}
+ * When generate logical types is enabled, annotation instructs the
+ * {@link com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator AvroSchemaGenerator}
  * to declare the annotated property's logical type as "decimal" ({@link org.apache.avro.LogicalTypes.Decimal}).
  * By default, the Avro type is "bytes" ({@link org.apache.avro.Schema.Type#BYTES}), unless the field is also
  * annotated with {@link com.fasterxml.jackson.dataformat.avro.AvroFixedSize}, in which case the Avro type
@@ -29,6 +30,6 @@ public @interface Decimal {
     /**
      * Scale must be zero or a positive integer less than or equal to the precision.
      */
-    int scale() default 0;
+    int scale();
 
 }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroParserImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroParserImpl.java
@@ -583,6 +583,34 @@ public abstract class AvroParserImpl
 
     /*
     /**********************************************************
+    /* Methods for AvroReadContext implementations: decimals
+    /**********************************************************
+     */
+
+    public JsonToken decodeBytesDecimal(int scale) throws IOException {
+        decodeBytes();
+        _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
+        _numTypesValid = NR_BIGDECIMAL;
+        return JsonToken.VALUE_NUMBER_FLOAT;
+    }
+
+    public void skipBytesDecimal() throws IOException {
+        skipBytes();
+    }
+
+    public JsonToken decodeFixedDecimal(int scale, int size) throws IOException {
+        decodeFixed(size);
+        _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
+        _numTypesValid = NR_BIGDECIMAL;
+        return JsonToken.VALUE_NUMBER_FLOAT;
+    }
+
+    public void skipFixedDecimal(int size) throws IOException {
+        skipFixed(size);
+    }
+
+    /*
+    /**********************************************************
     /* Methods for AvroReadContext impls, other
     /**********************************************************
      */

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroParserImpl.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroParserImpl.java
@@ -587,6 +587,7 @@ public abstract class AvroParserImpl
     /**********************************************************
      */
 
+    // @since 2.19
     public JsonToken decodeBytesDecimal(int scale) throws IOException {
         decodeBytes();
         _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
@@ -594,10 +595,12 @@ public abstract class AvroParserImpl
         return JsonToken.VALUE_NUMBER_FLOAT;
     }
 
+    // @since 2.19
     public void skipBytesDecimal() throws IOException {
         skipBytes();
     }
 
+    // @since 2.19
     public JsonToken decodeFixedDecimal(int scale, int size) throws IOException {
         decodeFixed(size);
         _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
@@ -605,6 +608,7 @@ public abstract class AvroParserImpl
         return JsonToken.VALUE_NUMBER_FLOAT;
     }
 
+    // @since 2.19
     public void skipFixedDecimal(int size) throws IOException {
         skipFixed(size);
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroReaderFactory.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.dataformat.avro.deser;
 import java.io.IOException;
 import java.util.*;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 
 import com.fasterxml.jackson.dataformat.avro.deser.ScalarDecoder.*;
@@ -56,12 +57,18 @@ public abstract class AvroReaderFactory
         case BOOLEAN:
             return READER_BOOLEAN;
         case BYTES:
+            if (type.getLogicalType() instanceof LogicalTypes.Decimal) {
+                return new BytesDecimalReader(((LogicalTypes.Decimal) type.getLogicalType()).getScale());
+            }
             return READER_BYTES;
         case DOUBLE:
             return READER_DOUBLE;
         case ENUM:
             return new EnumDecoder(AvroSchemaHelper.getFullName(type), type.getEnumSymbols());
         case FIXED:
+            if (type.getLogicalType() instanceof LogicalTypes.Decimal) {
+                return new  FixedDecimalReader(((LogicalTypes.Decimal) type.getLogicalType()).getScale(), type.getFixedSize());
+            }
             return new FixedDecoder(type.getFixedSize(), AvroSchemaHelper.getFullName(type));
         case FLOAT:
             return READER_FLOAT;

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.dataformat.avro.deser;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonToken;
@@ -543,6 +544,102 @@ public abstract class ScalarDecoder
             @Override
             public void skipValue(AvroParserImpl parser) throws IOException {
                 parser.skipFixed(_size);
+            }
+        }
+    }
+
+    protected final static class FixedDecimalReader extends ScalarDecoder {
+        private final int _scale;
+        private final int _size;
+
+        public FixedDecimalReader(int scale, int size) {
+            _scale = scale;
+            _size = size;
+        }
+
+        @Override
+        public JsonToken decodeValue(AvroParserImpl parser) throws IOException {
+            return parser.decodeFixedDecimal(_scale, _size);
+        }
+
+        @Override
+        protected void skipValue(AvroParserImpl parser) throws IOException {
+            parser.skipFixedDecimal(_size);
+        }
+
+        @Override
+        public String getTypeId() {
+            return AvroSchemaHelper.getTypeId(BigDecimal.class);
+        }
+
+        @Override
+        public AvroFieldReader asFieldReader(String name, boolean skipper) {
+            return new FR(name, skipper, getTypeId(), _scale, _size);
+        }
+
+        private final static class FR extends AvroFieldReader {
+            private final int _scale;
+            private final int _size;
+            public FR(String name, boolean skipper, String typeId, int scale, int size) {
+                super(name, skipper, typeId);
+                _scale = scale;
+                _size = size;
+            }
+
+            @Override
+            public JsonToken readValue(AvroReadContext parent, AvroParserImpl parser) throws IOException {
+                return parser.decodeFixedDecimal(_scale, _size);
+            }
+
+            @Override
+            public void skipValue(AvroParserImpl parser) throws IOException {
+                parser.skipFixedDecimal(_size);
+            }
+        }
+    }
+
+    protected final static class BytesDecimalReader extends ScalarDecoder {
+        private final int _scale;
+
+        public BytesDecimalReader(int scale) {
+            _scale = scale;
+        }
+
+        @Override
+        public JsonToken decodeValue(AvroParserImpl parser) throws IOException {
+            return parser.decodeBytesDecimal(_scale);
+        }
+
+        @Override
+        protected void skipValue(AvroParserImpl parser) throws IOException {
+            parser.skipBytesDecimal();
+        }
+
+        @Override
+        public String getTypeId() {
+            return AvroSchemaHelper.getTypeId(BigDecimal.class);
+        }
+
+        @Override
+        public AvroFieldReader asFieldReader(String name, boolean skipper) {
+            return new FR(name, skipper, getTypeId(), _scale);
+        }
+
+        private final static class FR extends AvroFieldReader {
+            private final int _scale;
+            public FR(String name, boolean skipper, String typeId, int scale) {
+                super(name, skipper, typeId);
+                _scale = scale;
+            }
+
+            @Override
+            public JsonToken readValue(AvroReadContext parent, AvroParserImpl parser) throws IOException {
+                return parser.decodeBytesDecimal(_scale);
+            }
+
+            @Override
+            public void skipValue(AvroParserImpl parser) throws IOException {
+                parser.skipFloat();
             }
         }
     }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/ScalarDecoder.java
@@ -548,6 +548,9 @@ public abstract class ScalarDecoder
         }
     }
 
+    /**
+     * @since 2.19
+     */
     protected final static class FixedDecimalReader extends ScalarDecoder {
         private final int _scale;
         private final int _size;
@@ -598,6 +601,9 @@ public abstract class ScalarDecoder
         }
     }
 
+    /**
+     * @since 2.19
+     */
     protected final static class BytesDecimalReader extends ScalarDecoder {
         private final int _scale;
 

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.dataformat.avro.AvroFixedSize;
-import com.fasterxml.jackson.dataformat.avro.annotation.Decimal;
+import com.fasterxml.jackson.dataformat.avro.annotation.AvroDecimal;
 import com.fasterxml.jackson.dataformat.avro.ser.CustomEncodingSerializer;
 
 public class RecordVisitor
@@ -155,12 +155,12 @@ public class RecordVisitor
                 writerSchema = Schema.createFixed(fixedSize.typeName(), null, fixedSize.typeNamespace(), fixedSize.size());
             }
             if (_visitorWrapper.isLogicalTypesEnabled()) {
-                Decimal decimal = prop.getAnnotation(Decimal.class);
-                if (decimal != null) {
+                AvroDecimal avroDecimal = prop.getAnnotation(AvroDecimal.class);
+                if (avroDecimal != null) {
                     if (writerSchema == null) {
                         writerSchema = Schema.create(Type.BYTES);
                     }
-                    writerSchema = LogicalTypes.decimal(decimal.precision(), decimal.scale())
+                    writerSchema = LogicalTypes.decimal(avroDecimal.precision(), avroDecimal.scale())
                             .addToSchema(writerSchema);
                 }
             }

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
+import org.apache.avro.Conversions.DecimalConversion;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericData;
@@ -26,6 +27,8 @@ public class NonBSGenericDatumWriter<D>
     private final static Class<?> CLS_STRING = String.class;
     private final static Class<?> CLS_BIG_DECIMAL = BigDecimal.class;
     private final static Class<?> CLS_BIG_INTEGER = BigInteger.class;
+
+    private final static DecimalConversion BIG_DECIMAL_CONVERSION = new DecimalConversion();
 
     public NonBSGenericDatumWriter(Schema root) {
 	super(root);
@@ -97,6 +100,11 @@ public class NonBSGenericDatumWriter<D>
                 super.writeWithoutConversion(schema, ByteBuffer.wrap((byte[]) datum), out);
                 return;
             }
+            if (datum.getClass() == CLS_BIG_DECIMAL) {
+                super.writeWithoutConversion(schema, BIG_DECIMAL_CONVERSION.toBytes(
+                        (BigDecimal) datum, schema, schema.getLogicalType()), out);
+                return;
+            }
             break;
         case FIXED:
             // One more mismatch to fix
@@ -109,6 +117,11 @@ public class NonBSGenericDatumWriter<D>
             */
             if (datum instanceof byte[]) {
                 super.writeWithoutConversion(schema, new GenericData.Fixed(schema, (byte[]) datum), out);
+                return;
+            }
+            if (datum.getClass() == CLS_BIG_DECIMAL) {
+                super.writeWithoutConversion(schema, BIG_DECIMAL_CONVERSION.toFixed(
+                        (BigDecimal) datum, schema, schema.getLogicalType()), out);
                 return;
             }
             break;

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
@@ -28,6 +28,7 @@ public class NonBSGenericDatumWriter<D>
     private final static Class<?> CLS_BIG_DECIMAL = BigDecimal.class;
     private final static Class<?> CLS_BIG_INTEGER = BigInteger.class;
 
+    // @since 2.19
     private final static DecimalConversion BIG_DECIMAL_CONVERSION = new DecimalConversion();
 
     public NonBSGenericDatumWriter(Schema root) {

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
@@ -2,11 +2,85 @@ package com.fasterxml.jackson.dataformat.avro;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.dataformat.avro.annotation.Decimal;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.junit.Test;
 
 import java.math.BigDecimal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class BigDecimalTest extends AvroTestBase
 {
+    private static final AvroMapper MAPPER = new AvroMapper();
+
+    static class BigDecimalWithDecimalAnnotationToBytesWrapper {
+        @JsonProperty(required = true) // field is made required only to have simpler avro schema
+        @Decimal(precision = 10, scale = 2)
+        public BigDecimal bigDecimalValue;
+
+        public BigDecimalWithDecimalAnnotationToBytesWrapper(BigDecimal bigDecimalValue) {
+            this.bigDecimalValue = bigDecimalValue;
+        }
+    }
+
+    @Test
+    public void testSchemaCreationOnBigDecimalWithDecimalAnnotationToBytes() throws JsonMappingException {
+        // GIVEN
+        AvroSchemaGenerator gen = new AvroSchemaGenerator()
+                .enableLogicalTypes();
+
+        // WHEN
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationToBytesWrapper.class, gen);
+        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        System.out.println(BigDecimalWithDecimalAnnotationToBytesWrapper.class.getSimpleName() + " schema:\n" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
+
+        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
+        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.BYTES);
+        assertThat(bigDecimalValue.getLogicalType()).isEqualTo(LogicalTypes.decimal(10, 2));
+        assertThat(bigDecimalValue.getProp("java-class")).isNull();
+    }
+
+    static class BigDecimalWithDecimalAnnotationToFixedWrapper {
+        @JsonProperty(required = true) // field is made required only to have simpler avro schema
+        @AvroFixedSize(typeName = "BigDecimalWithDecimalAnnotationToFixedWrapper", size = 10)
+        @Decimal(precision = 6, scale = 3)
+        public BigDecimal bigDecimalValue;
+
+        public BigDecimalWithDecimalAnnotationToFixedWrapper(BigDecimal bigDecimalValue) {
+            this.bigDecimalValue = bigDecimalValue;
+        }
+    }
+
+    @Test
+    public void testSchemaCreationOnBigDecimalWithDecimalAnnotationToFixed() throws JsonMappingException {
+        // GIVEN
+        AvroSchemaGenerator gen = new AvroSchemaGenerator()
+                .enableLogicalTypes();
+
+        // WHEN
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationToFixedWrapper.class, gen);
+        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        System.out.println(BigDecimalWithDecimalAnnotationToFixedWrapper.class.getSimpleName() + " schema:\n" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
+
+        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
+        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.FIXED);
+        assertThat(bigDecimalValue.getFixedSize()).isEqualTo(10);
+        assertThat(bigDecimalValue.getLogicalType()).isEqualTo(LogicalTypes.decimal(6, 3));
+                assertThat(bigDecimalValue.getProp("java-class")).isNull();
+    }
+
     public static class NamedAmount {
         public final String name;
         public final BigDecimal amount;
@@ -20,13 +94,12 @@ public class BigDecimalTest extends AvroTestBase
     }
 
     public void testSerializeBigDecimal() throws Exception {
-        AvroMapper mapper = newMapper();
-        AvroSchema schema = mapper.schemaFor(NamedAmount.class);
+        AvroSchema schema = MAPPER.schemaFor(NamedAmount.class);
 
-        byte[] bytes = mapper.writer(schema)
+        byte[] bytes = MAPPER.writer(schema)
                 .writeValueAsBytes(new NamedAmount("peter", 42.0));
 
-        NamedAmount result = mapper.reader(schema).forType(NamedAmount.class).readValue(bytes);
+        NamedAmount result = MAPPER.reader(schema).forType(NamedAmount.class).readValue(bytes);
 
         assertEquals("peter", result.name);
         assertEquals(BigDecimal.valueOf(42.0), result.amount);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
@@ -146,8 +146,8 @@ public class BigDecimalTest extends AvroTestBase {
                 .readValue(bytes);
 
         // THEN
-        assertEquals(BigDecimal.valueOf(42.2), result.bigDecimalValue);
-        assertEquals("peter", result.name);
+        assertThat(result.bigDecimalValue).isEqualTo(BigDecimal.valueOf(42.2));
+        assertThat(result.name).isEqualTo("peter");
     }
 
     public void testSerialization_toBytesWithLogicalTypeDecimal() throws Exception {
@@ -186,8 +186,8 @@ public class BigDecimalTest extends AvroTestBase {
 
         // THEN
         // Because scale of decimal logical type is 2, result is with 2 decimal places
-        assertEquals(new BigDecimal("42.20"), result.bigDecimalValue);
-        assertEquals("peter", result.name);
+        assertThat(result.bigDecimalValue).isEqualTo(new BigDecimal("42.20"));
+        assertThat(result.name).isEqualTo("peter");
     }
 
     public void testSerialization_toFixedWithLogicalTypeDecimal() throws Exception {
@@ -229,8 +229,8 @@ public class BigDecimalTest extends AvroTestBase {
 
         // THEN
         // Because scale of decimal logical type is 2, result is with 2 decimal places
-        assertEquals(new BigDecimal("42.20"), result.bigDecimalValue);
-        assertEquals("peter", result.name);
+        assertThat(result.bigDecimalValue).isEqualTo(new BigDecimal("42.20"));
+        assertThat(result.name).isEqualTo("peter");
     }
 
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
@@ -135,12 +135,21 @@ public class BigDecimalTest extends AvroTestBase {
 
         AvroSchema schema = MAPPER.schemaFrom(schemaString);
 
-        // WHEN
-        // serialize
+        // WHEN - serialize
         byte[] bytes = MAPPER.writer(schema)
                 .writeValueAsBytes(new BigDecimalAndName(BigDecimal.valueOf(42.2), "peter"));
 
-        // deserialize
+        // THEN
+        assertThat(bytes).isEqualTo(new byte[]{
+                // bigDecimalValue
+                0x08, // -> 4 dec - bigDecimalValue property string value length
+                0x34, 0x32, 0x2E, 0x32, // -> "42.2" in ASCII
+                // name
+                0x0A, // -> 5 dec - name property string length
+                0x70, 0x65, 0x74, 0x65, 0x72 // -> "peter" in ASCII
+        });
+
+        // WHEN - deserialize
         BigDecimalAndName result = MAPPER.reader(schema)
                 .forType(BigDecimalAndName.class)
                 .readValue(bytes);
@@ -172,14 +181,24 @@ public class BigDecimalTest extends AvroTestBase {
 
         AvroSchema schema = MAPPER.schemaFrom(schemaString);
 
-        // WHEN
-        // serialize
+        // WHEN - serialize
         byte[] bytes = MAPPER.writer(schema)
                 .writeValueAsBytes(new BigDecimalAndName(
                         new BigDecimal("42.2"),
                         "peter"));
+        // THEN
+        assertThat(bytes).isEqualTo(new byte[]{
+                // bigDecimalValue
+                0x02, // -> 1 dec - second bigDecimalValue property type (bytes)
+                0x04, // -> 2 dec - bigDecimalValue property bytes length
+                0x10, 0x7C, // -> 0x107C -> 4220 dec - it is 42.2 value in scale 2.
+                // name
+                0x02, // 1 dec - second name property type (string)
+                0x0A, // -> 5 dec - name property string length
+                0x70, 0x65, 0x74, 0x65, 0x72 // -> "peter" in ASCII
+        });
 
-        // deserialize
+        // WHEN - deserialize
         BigDecimalAndName result = MAPPER.reader(schema)
                 .forType(BigDecimalAndName.class)
                 .readValue(bytes);
@@ -215,14 +234,25 @@ public class BigDecimalTest extends AvroTestBase {
 
         AvroSchema schema = MAPPER.schemaFrom(schemaString);
 
-        // WHEN
-        // serialize
+        // WHEN - serialize
         byte[] bytes = MAPPER.writer(schema)
                 .writeValueAsBytes(new BigDecimalAndName(
                         new BigDecimal("42.2"),
                         "peter"));
 
-        // deserialize
+        // THEN
+        assertThat(bytes).isEqualTo(new byte[]{
+                // bigDecimalValue
+                0x02, // -> 1 dec - second bigDecimalValue property type (bytes)
+                // 10 bytes long fixed value
+                0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x10 ,0x7C, // -> 0x107C -> 4220 dec - it is 42.2 value in scale 2.
+                // name
+                0x02, // 1 dec - second name property type (string)
+                0x0A, // -> 5 dec - name property string length
+                0x70, 0x65, 0x74, 0x65, 0x72 // -> "peter" in ASCII
+        });
+
+        // WHEN - deserialize
         BigDecimalAndName result = MAPPER.reader(schema)
                 .forType(BigDecimalAndName.class)
                 .readValue(bytes);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_schemaCreationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_schemaCreationTest.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.dataformat.avro;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.dataformat.avro.annotation.Decimal;
+import com.fasterxml.jackson.dataformat.avro.annotation.AvroDecimal;
 import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -15,29 +15,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BigDecimal_schemaCreationTest extends AvroTestBase {
     private static final AvroMapper MAPPER = new AvroMapper();
 
-    static class BigDecimalWithDecimalAnnotationWrapper {
+    static class BigDecimalWithAvroDecimalAnnotationWrapper {
         @JsonProperty(required = true) // field is required to have simpler avro schema
-        @Decimal(precision = 10, scale = 2)
+        @AvroDecimal(precision = 10, scale = 2)
         public final BigDecimal bigDecimalValue;
 
-        public BigDecimalWithDecimalAnnotationWrapper(BigDecimal bigDecimalValue) {
+        public BigDecimalWithAvroDecimalAnnotationWrapper(BigDecimal bigDecimalValue) {
             this.bigDecimalValue = bigDecimalValue;
         }
     }
 
     @Test
-    public void testSchemaCreation_withLogicalTypesDisabled_onBigDecimalWithDecimalAnnotation() throws JsonMappingException {
+    public void testSchemaCreation_withLogicalTypesDisabled_onBigDecimalWithAvroDecimalAnnotation() throws JsonMappingException {
         // GIVEN
         AvroSchemaGenerator gen = new AvroSchemaGenerator()
                 .disableLogicalTypes();
 
         // WHEN
-        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationWrapper.class, gen);
-        // actualSchema = MAPPER.schemaFor(BigDecimalWithDecimalAnnotationWrapper.class) would be enough in this case
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithAvroDecimalAnnotationWrapper.class, gen);
+        // actualSchema = MAPPER.schemaFor(BigDecimalWithAvroDecimalAnnotationWrapper.class) would be enough in this case
         // because logical types are disabled by default.
         final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
 
-        System.out.println(BigDecimalWithDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
+        System.out.println(BigDecimalWithAvroDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
@@ -48,16 +48,16 @@ public class BigDecimal_schemaCreationTest extends AvroTestBase {
     }
 
     @Test
-    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithDecimalAnnotation() throws JsonMappingException {
+    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithAvroDecimalAnnotation() throws JsonMappingException {
         // GIVEN
         AvroSchemaGenerator gen = new AvroSchemaGenerator()
                 .enableLogicalTypes();
 
         // WHEN
-        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationWrapper.class, gen);
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithAvroDecimalAnnotationWrapper.class, gen);
         final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
 
-        System.out.println(BigDecimalWithDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
+        System.out.println(BigDecimalWithAvroDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
@@ -67,28 +67,28 @@ public class BigDecimal_schemaCreationTest extends AvroTestBase {
         assertThat(bigDecimalValue.getProp("java-class")).isNull();
     }
 
-    static class BigDecimalWithDecimalAnnotationToFixedWrapper {
+    static class BigDecimalWithAvroDecimalAnnotationToFixedWrapper {
         @JsonProperty(required = true) // field is required to have simpler avro schema
-        @AvroFixedSize(typeName = "BigDecimalWithDecimalAnnotationToFixedWrapper", size = 10)
-        @Decimal(precision = 6, scale = 3)
+        @AvroFixedSize(typeName = "BigDecimalWithAvroDecimalAnnotationToFixedWrapper", size = 10)
+        @AvroDecimal(precision = 6, scale = 3)
         public final BigDecimal bigDecimalValue;
 
-        public BigDecimalWithDecimalAnnotationToFixedWrapper(BigDecimal bigDecimalValue) {
+        public BigDecimalWithAvroDecimalAnnotationToFixedWrapper(BigDecimal bigDecimalValue) {
             this.bigDecimalValue = bigDecimalValue;
         }
     }
 
     @Test
-    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithDecimalAnnotationToFixed() throws JsonMappingException {
+    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithAvroDecimalAnnotationToFixed() throws JsonMappingException {
         // GIVEN
         AvroSchemaGenerator gen = new AvroSchemaGenerator()
                 .enableLogicalTypes();
 
         // WHEN
-        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationToFixedWrapper.class, gen);
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithAvroDecimalAnnotationToFixedWrapper.class, gen);
         final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
 
-        System.out.println(BigDecimalWithDecimalAnnotationToFixedWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
+        System.out.println(BigDecimalWithAvroDecimalAnnotationToFixedWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_schemaCreationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_schemaCreationTest.java
@@ -1,0 +1,102 @@
+package com.fasterxml.jackson.dataformat.avro;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.dataformat.avro.annotation.Decimal;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BigDecimal_schemaCreationTest extends AvroTestBase {
+    private static final AvroMapper MAPPER = new AvroMapper();
+
+    static class BigDecimalWithDecimalAnnotationWrapper {
+        @JsonProperty(required = true) // field is required to have simpler avro schema
+        @Decimal(precision = 10, scale = 2)
+        public final BigDecimal bigDecimalValue;
+
+        public BigDecimalWithDecimalAnnotationWrapper(BigDecimal bigDecimalValue) {
+            this.bigDecimalValue = bigDecimalValue;
+        }
+    }
+
+    @Test
+    public void testSchemaCreation_withLogicalTypesDisabled_onBigDecimalWithDecimalAnnotation() throws JsonMappingException {
+        // GIVEN
+        AvroSchemaGenerator gen = new AvroSchemaGenerator()
+                .disableLogicalTypes();
+
+        // WHEN
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationWrapper.class, gen);
+        // actualSchema = MAPPER.schemaFor(BigDecimalWithDecimalAnnotationWrapper.class) would be enough in this case
+        // because logical types are disabled by default.
+        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        System.out.println(BigDecimalWithDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
+        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
+        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.STRING);
+        assertThat(bigDecimalValue.getLogicalType()).isNull();
+        assertThat(bigDecimalValue.getProp("java-class")).isEqualTo("java.math.BigDecimal");
+    }
+
+    @Test
+    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithDecimalAnnotation() throws JsonMappingException {
+        // GIVEN
+        AvroSchemaGenerator gen = new AvroSchemaGenerator()
+                .enableLogicalTypes();
+
+        // WHEN
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationWrapper.class, gen);
+        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        System.out.println(BigDecimalWithDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
+        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
+        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.BYTES);
+        assertThat(bigDecimalValue.getLogicalType()).isEqualTo(LogicalTypes.decimal(10, 2));
+        assertThat(bigDecimalValue.getProp("java-class")).isNull();
+    }
+
+    static class BigDecimalWithDecimalAnnotationToFixedWrapper {
+        @JsonProperty(required = true) // field is required to have simpler avro schema
+        @AvroFixedSize(typeName = "BigDecimalWithDecimalAnnotationToFixedWrapper", size = 10)
+        @Decimal(precision = 6, scale = 3)
+        public final BigDecimal bigDecimalValue;
+
+        public BigDecimalWithDecimalAnnotationToFixedWrapper(BigDecimal bigDecimalValue) {
+            this.bigDecimalValue = bigDecimalValue;
+        }
+    }
+
+    @Test
+    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithDecimalAnnotationToFixed() throws JsonMappingException {
+        // GIVEN
+        AvroSchemaGenerator gen = new AvroSchemaGenerator()
+                .enableLogicalTypes();
+
+        // WHEN
+        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationToFixedWrapper.class, gen);
+        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
+
+        System.out.println(BigDecimalWithDecimalAnnotationToFixedWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
+
+        // THEN
+        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
+
+        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
+        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.FIXED);
+        assertThat(bigDecimalValue.getFixedSize()).isEqualTo(10);
+        assertThat(bigDecimalValue.getLogicalType()).isEqualTo(LogicalTypes.decimal(6, 3));
+        assertThat(bigDecimalValue.getProp("java-class")).isNull();
+    }
+}

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_serialization_and_deserializationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_serialization_and_deserializationTest.java
@@ -2,104 +2,13 @@ package com.fasterxml.jackson.dataformat.avro;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.dataformat.avro.annotation.Decimal;
-import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
-import org.apache.avro.LogicalTypes;
-import org.apache.avro.Schema;
-import org.junit.Test;
 
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BigDecimalTest extends AvroTestBase {
+public class BigDecimal_serialization_and_deserializationTest extends AvroTestBase {
     private static final AvroMapper MAPPER = new AvroMapper();
-
-    static class BigDecimalWithDecimalAnnotationWrapper {
-        @JsonProperty(required = true) // field is required to have simpler avro schema
-        @Decimal(precision = 10, scale = 2)
-        public final BigDecimal bigDecimalValue;
-
-        public BigDecimalWithDecimalAnnotationWrapper(BigDecimal bigDecimalValue) {
-            this.bigDecimalValue = bigDecimalValue;
-        }
-    }
-
-    @Test
-    public void testSchemaCreation_withLogicalTypesDisabled_onBigDecimalWithDecimalAnnotation() throws JsonMappingException {
-        // GIVEN
-        AvroSchemaGenerator gen = new AvroSchemaGenerator()
-                .disableLogicalTypes();
-
-        // WHEN
-        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationWrapper.class, gen);
-        // actualSchema = MAPPER.schemaFor(BigDecimalWithDecimalAnnotationWrapper.class) would be enough in this case
-        // because logical types are disabled by default.
-        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
-
-        System.out.println(BigDecimalWithDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
-
-        // THEN
-        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
-        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
-        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.STRING);
-        assertThat(bigDecimalValue.getLogicalType()).isNull();
-        assertThat(bigDecimalValue.getProp("java-class")).isEqualTo("java.math.BigDecimal");
-    }
-
-    @Test
-    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithDecimalAnnotation() throws JsonMappingException {
-        // GIVEN
-        AvroSchemaGenerator gen = new AvroSchemaGenerator()
-                .enableLogicalTypes();
-
-        // WHEN
-        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationWrapper.class, gen);
-        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
-
-        System.out.println(BigDecimalWithDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
-
-        // THEN
-        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
-        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
-        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.BYTES);
-        assertThat(bigDecimalValue.getLogicalType()).isEqualTo(LogicalTypes.decimal(10, 2));
-        assertThat(bigDecimalValue.getProp("java-class")).isNull();
-    }
-
-    static class BigDecimalWithDecimalAnnotationToFixedWrapper {
-        @JsonProperty(required = true) // field is required to have simpler avro schema
-        @AvroFixedSize(typeName = "BigDecimalWithDecimalAnnotationToFixedWrapper", size = 10)
-        @Decimal(precision = 6, scale = 3)
-        public final BigDecimal bigDecimalValue;
-
-        public BigDecimalWithDecimalAnnotationToFixedWrapper(BigDecimal bigDecimalValue) {
-            this.bigDecimalValue = bigDecimalValue;
-        }
-    }
-
-    @Test
-    public void testSchemaCreation_withLogicalTypesEnabled_onBigDecimalWithDecimalAnnotationToFixed() throws JsonMappingException {
-        // GIVEN
-        AvroSchemaGenerator gen = new AvroSchemaGenerator()
-                .enableLogicalTypes();
-
-        // WHEN
-        MAPPER.acceptJsonFormatVisitor(BigDecimalWithDecimalAnnotationToFixedWrapper.class, gen);
-        final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
-
-        System.out.println(BigDecimalWithDecimalAnnotationToFixedWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
-
-        // THEN
-        assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
-
-        Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
-        assertThat(bigDecimalValue.getType()).isEqualTo(Schema.Type.FIXED);
-        assertThat(bigDecimalValue.getFixedSize()).isEqualTo(10);
-        assertThat(bigDecimalValue.getLogicalType()).isEqualTo(LogicalTypes.decimal(6, 3));
-        assertThat(bigDecimalValue.getProp("java-class")).isNull();
-    }
 
     static class BigDecimalAndName {
         public final BigDecimal bigDecimalValue;

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -219,12 +219,17 @@ Michal Foksa (MichalFoksa@github)
  (2.13.0)
 * Contributed #290: (avro) Generate logicalType switch
  (2.13.0)
+* Contributed fix for #308: (avro) Incorrect serialization for `LogicalType.Decimal`
+  (Java `BigDecimal`)
 * Contributed #310: (avro) Avro schema generation: allow override namespace with new
   `@AvroNamespace` annotation
  (2.14.0)
 * Contributed #494: Avro Schema generation: allow mapping Java Enum properties to
   Avro String values
  (2.18.0)
+* Contributed fix for #535: (avro) AvroSchemaGenerator: logicalType(s) never set
+  for non-date classes
+ (2.19.0)
 * Contributed #536: (avro) Add Logical Type support for `java.util.UUID`
  (2.19.0)
 
@@ -357,3 +362,13 @@ Robert Noack (@mr-robert)
 Knut Wannheden (@knutwannheden)
  * Contributed #518: Should not read past end for CBOR string values
   (2.18.1)
+
+Idan Sheinberg (@sheinbergon)
+ * Reported #308: (avro) Incorrect serialization for `LogicalType.Decimal` (Java
+   `BigDecimal`)
+  (2.19.0)
+
+Cormac Redmond (@credmond)
+ * Reported #535: (avro) AvroSchemaGenerator: logicalType(s) never set for
+   non-Date classes
+  (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,12 @@ Active maintainers:
 
 2.19.0 (not yet released)
 
+#308: (avro) Incorrect serialization for `LogicalType.Decimal` (Java `BigDecimal`)
+ (reported by Idan S)
+ (fix contributed by Michal F)
+#535: (avro) AvroSchemaGenerator: logicalType(s) never set for non-date classes
+ (reported by Cormac R)
+ (fix contributed by Michal F)
 #536: (avro) Add Logical Type support for `java.util.UUID`
  (contributed by Michal F)
 


### PR DESCRIPTION
Support of Avro logical type `decimal`.  See [Logical Types - Decimal](https://avro.apache.org/docs/1.11.1/specification/#decimal) specification.

`@Decimal` annotation instructs generator to create schema with logical type decimal in bytes Avro type. To create `decimal` in `fixed` type, the field has to be annotated also with `@AvroFixedSize`.
It only works when log

Limitations:
- Exception is not thrown when other than `BigDecimal` filed is annotated with `@Decimal`. The `@Decimal` annotation is ignored.

BigDecimal serialization is delegated to Apache `org.apache.avro.Conversions.DecimalConversion`. 
It validates whether value fits available schema. If not, then it throws `org.apache.avro.AvroTypeException`.      

BigDecimal deserialization is taken from #133 . Deserialization is implemented in `AvroParserImpl` where decoding from bytes of fixed is delegated to child implementations (`ApacheAvroParserImpl`, resp `JacksonAvroParserImpl`). 


Fixes  #308 , #535.