### PR TITLE
add big decimal tests

### DIFF
--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/mapper/NumberBeanTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/mapper/NumberBeanTest.java
@@ -4,9 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.core.JsonToken;

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/mapper/NumberBeanTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/mapper/NumberBeanTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -46,6 +47,25 @@ public class NumberBeanTest extends CBORTestBase
         @JsonUnwrapped
         public BigDecimalHolder2784 holder;
     }
+
+    static class DeserializationIssue4917 {
+        public DecimalHolder4917 decimalHolder;
+        public double number;
+    }
+
+    static class DecimalHolder4917 {
+        public BigDecimal value;
+
+        private DecimalHolder4917(BigDecimal value) {
+            this.value = value;
+        }
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static DecimalHolder4917 of(BigDecimal value) {
+            return new DecimalHolder4917(value);
+        }
+    }
+
 
     /*
     /**********************************************************
@@ -256,4 +276,20 @@ public class NumberBeanTest extends CBORTestBase
                 NestedBigDecimalHolder2784.class);
         assertEquals(VALUE, result.holder.value);
     }
+
+    // [databind#4917]
+    @Test
+    public void testIssue4917() throws Exception {
+        final String bd = "100.00";
+        final double d = 50.0;
+        final DeserializationIssue4917 value = new DeserializationIssue4917();
+        value.decimalHolder = DecimalHolder4917.of(new BigDecimal(bd));
+        value.number = d;
+        final byte[] data = MAPPER.writeValueAsBytes(value);
+        final DeserializationIssue4917 result = MAPPER.readValue(
+                data, DeserializationIssue4917.class);
+        assertEquals(value.decimalHolder.value, result.decimalHolder.value);
+        assertEquals(value.number, result.number);
+    }
+
 }

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/mapper/NumberBeanTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/mapper/NumberBeanTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,7 +55,8 @@ public class NumberBeanTest extends CBORTestBase
     }
 
     static class DecimalHolder4917 {
-        public BigDecimal value;
+        @JsonValue
+        BigDecimal value;
 
         private DecimalHolder4917(BigDecimal value) {
             this.value = value;
@@ -65,7 +67,6 @@ public class NumberBeanTest extends CBORTestBase
             return new DecimalHolder4917(value);
         }
     }
-
 
     /*
     /**********************************************************
@@ -286,6 +287,7 @@ public class NumberBeanTest extends CBORTestBase
         value.decimalHolder = DecimalHolder4917.of(new BigDecimal(bd));
         value.number = d;
         final byte[] data = MAPPER.writeValueAsBytes(value);
+
         final DeserializationIssue4917 result = MAPPER.readValue(
                 data, DeserializationIssue4917.class);
         assertEquals(value.decimalHolder.value, result.decimalHolder.value);

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/mapper/NumberReadTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/mapper/NumberReadTest.java
@@ -1,0 +1,50 @@
+package com.fasterxml.jackson.dataformat.smile.mapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.dataformat.smile.BaseTestForSmile;
+import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NumberReadTest extends BaseTestForSmile {
+
+    static class DeserializationIssue4917 {
+        public DecimalHolder4917 decimalHolder;
+        public double number;
+    }
+
+    static class DecimalHolder4917 {
+        public BigDecimal value;
+
+        private DecimalHolder4917(BigDecimal value) {
+            this.value = value;
+        }
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static DecimalHolder4917 of(BigDecimal value) {
+            return new DecimalHolder4917(value);
+        }
+    }
+
+    // [databind#4917]
+    @Test
+    public void testIssue4917() throws Exception {
+        final String bd = "100.00";
+        final double d = 50.0;
+        final DeserializationIssue4917 value = new DeserializationIssue4917();
+        value.decimalHolder = DecimalHolder4917.of(new BigDecimal(bd));
+        value.number = d;
+        final SmileMapper mapper = smileMapper();
+        final byte[] data = mapper.writeValueAsBytes(value);
+        final DeserializationIssue4917 result = mapper.readValue(
+                data, DeserializationIssue4917.class);
+        assertEquals(value.decimalHolder.value, result.decimalHolder.value);
+        assertEquals(value.number, result.number);
+    }
+
+}

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/mapper/NumberReadTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/mapper/NumberReadTest.java
@@ -1,12 +1,11 @@
 package com.fasterxml.jackson.dataformat.smile.mapper;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.dataformat.smile.BaseTestForSmile;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,7 +18,8 @@ public class NumberReadTest extends BaseTestForSmile {
     }
 
     static class DecimalHolder4917 {
-        public BigDecimal value;
+        @JsonValue
+        BigDecimal value;
 
         private DecimalHolder4917(BigDecimal value) {
             this.value = value;


### PR DESCRIPTION
Currently broken. CBOR and Smile tests based on https://github.com/FasterXML/jackson-databind/issues/4917

These are round trip tests and I would have expected that the binary data that is serialized to be ok to read back (deserialized).

The tests fail with exceptions like:
```
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.math.BigDecimal` from Object value (token `JsonToken.FIELD_NAME`)
 at [Source: (byte[])[46 bytes]; byte offset: #16] (through reference chain: com.fasterxml.jackson.dataformat.cbor.mapper.NumberBeanTest$DeserializationIssue4917["decimalHolder"])

	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1794)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1568)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1515)
	at com.fasterxml.jackson.databind.deser.std.NumberDeserializers$BigDecimalDeserializer.deserialize(NumberDeserializers.java:1034)
	at com.fasterxml.jackson.databind.deser.std.NumberDeserializers$BigDecimalDeserializer.deserialize(NumberDeserializers.java:988)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1492)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:348)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)

```