### PR TITLE
Fix #571: Unable to deserialize a pojo with IonStruct

### DIFF
--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -53,6 +53,18 @@ public class IonParser
          * @since 2.12.3
          */
         USE_NATIVE_TYPE_ID(true),
+        /**
+         * Whether to convert "null" to an IonValueNull (true);
+         * or leave as a java null (false) when deserializing.
+         *<p>
+         * Enabled by default for backwards compatibility as that has been the behavior
+         * of `jackson-dataformat-ion` since 2.13.
+         *
+         * @see <a href="https://amzn.github.io/ion-docs/docs/spec.html#annot">The Ion Specification</a>
+         *
+         * @since 2.19.0
+         */
+        READ_NULL_AS_IONVALUE(true),
         ;
 
         final boolean _defaultState;
@@ -563,6 +575,12 @@ public class IonParser
         writer.writeValue(_reader);
         IonValue v = l.get(0);
         v.removeFromContainer();
+
+        if (v.isNullValue() && !Feature.READ_NULL_AS_IONVALUE.enabledIn(_formatFeatures)) {
+            if (_valueToken == JsonToken.VALUE_NULL && !IonType.isContainer(v.getType())) {
+                return null;
+            }
+        }
         return v;
     }
 

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/IonParser.java
@@ -576,8 +576,13 @@ public class IonParser
         IonValue v = l.get(0);
         v.removeFromContainer();
 
-        if (v.isNullValue() && !Feature.READ_NULL_AS_IONVALUE.enabledIn(_formatFeatures)) {
-            if (_valueToken == JsonToken.VALUE_NULL && !IonType.isContainer(v.getType())) {
+        if (!Feature.READ_NULL_AS_IONVALUE.enabledIn(_formatFeatures)) {
+            // 2025-04-11, seadbrane: The default is to read 'null' as an Ion Null object.
+            // However, there is no way to determine from the serialized ion data if a 'null'
+            // was an IonNullValue or a 'null' container type such as IonNullStruct or IonNullList.
+            // So if READ_NULL_AS_IONVALUE is disabled, then return 'null' if the _valueToken
+            // is 'null' and the Ion value read is not container type already.
+            if (v.isNullValue() && _valueToken == JsonToken.VALUE_NULL && !IonType.isContainer(v.getType())) {
                 return null;
             }
         }

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
@@ -16,21 +16,51 @@ package com.fasterxml.jackson.dataformat.ion.ionvalue;
 
 import java.io.IOException;
 
-import com.amazon.ion.*;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.util.AccessPattern;
 import com.fasterxml.jackson.dataformat.ion.IonParser;
+import com.amazon.ion.IonContainer;
+import com.amazon.ion.IonList;
+import com.amazon.ion.IonSexp;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.Timestamp;
 
 /**
  * Deserializer that knows how to deserialize an IonValue.
  */
-class IonValueDeserializer extends JsonDeserializer<IonValue> {
+class IonValueDeserializer extends JsonDeserializer<IonValue> implements ContextualDeserializer {
+
+    private final JavaType targetType;
+
+    public IonValueDeserializer() {
+        this.targetType = null;
+    }
+
+    public IonValueDeserializer(JavaType targetType) {
+        this.targetType = targetType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+        JavaType contextualType = (property != null)
+            ? property.getType()
+            : ctxt.getContextualType(); // fallback
+        return new IonValueDeserializer(contextualType);
+    }
 
     @Override
     public IonValue deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+
         Object embeddedObject = jp.getEmbeddedObject();
         if (embeddedObject instanceof IonValue) {
             return (IonValue) embeddedObject;
@@ -62,15 +92,32 @@ class IonValueDeserializer extends JsonDeserializer<IonValue> {
                 if (embeddedObj instanceof IonValue) {
                     IonValue iv = (IonValue) embeddedObj;
                     if (iv.isNullValue()) {
+                        if (IonType.isContainer(iv.getType())) {
+                            return iv;
+                        }
+                        IonType containerType = getIonContainerType();
+                        if (containerType != null) {
+                            IonSystem ionSystem = ((IonParser) parser).getIonSystem();
+                            return ionSystem.newNull(containerType);
+                        }
                         return iv;
                     }
                 }
             }
-
             return super.getNullValue(ctxt);
         } catch (IOException e) {
             throw JsonMappingException.from(ctxt, e.toString());
         }
+    }
+
+    private IonType getIonContainerType() {
+        if (targetType != null) {
+            Class<?> clazz = targetType.getRawClass();
+            if (IonStruct.class.isAssignableFrom(clazz)) return IonType.STRUCT;
+            if (IonList.class.isAssignableFrom(clazz)) return IonType.LIST;
+            if (IonSexp.class.isAssignableFrom(clazz)) return IonType.SEXP;
+        }
+        return null;
     }
 
     @Override

--- a/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
+++ b/ion/src/main/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
@@ -18,36 +18,25 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
-import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.util.AccessPattern;
 import com.fasterxml.jackson.dataformat.ion.IonParser;
-import com.amazon.ion.IonContainer;
-import com.amazon.ion.IonList;
-import com.amazon.ion.IonSexp;
-import com.amazon.ion.IonStruct;
-import com.amazon.ion.IonSystem;
-import com.amazon.ion.IonType;
-import com.amazon.ion.IonValue;
-import com.amazon.ion.Timestamp;
+import com.amazon.ion.*;
 
 /**
  * Deserializer that knows how to deserialize an IonValue.
  */
 class IonValueDeserializer extends JsonDeserializer<IonValue> implements ContextualDeserializer {
 
-    private final JavaType targetType;
+    private final JavaType _targetType;
 
     public IonValueDeserializer() {
-        this.targetType = null;
+        this._targetType = null;
     }
 
     public IonValueDeserializer(JavaType targetType) {
-        this.targetType = targetType;
+        this._targetType = targetType;
     }
 
     @Override
@@ -111,8 +100,8 @@ class IonValueDeserializer extends JsonDeserializer<IonValue> implements Context
     }
 
     private IonType getIonContainerType() {
-        if (targetType != null) {
-            Class<?> clazz = targetType.getRawClass();
+        if (_targetType != null) {
+            Class<?> clazz = _targetType.getRawClass();
             if (IonStruct.class.isAssignableFrom(clazz)) return IonType.STRUCT;
             if (IonList.class.isAssignableFrom(clazz)) return IonType.LIST;
             if (IonSexp.class.isAssignableFrom(clazz)) return IonType.SEXP;

--- a/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
+++ b/ion/src/test/java/com/fasterxml/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
@@ -1,28 +1,25 @@
 package com.fasterxml.jackson.dataformat.ion.ionvalue;
 
-import com.amazon.ion.IonList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonStruct;
+
+import org.junit.jupiter.api.Test;
+
 import com.amazon.ion.system.IonSystemBuilder;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.util.AccessPattern;
 import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 import com.fasterxml.jackson.dataformat.ion.IonParser;
 
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
-import org.junit.jupiter.api.Test;
-
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -76,8 +73,10 @@ public class IonValueDeserializerTest {
     }
 
     private static final IonSystem SYSTEM = IonSystemBuilder.standard().build();
-    private static final IonValueMapper ION_VALUE_MAPPER = new IonValueMapper(SYSTEM, SNAKE_CASE);
-    private static final IonValueMapper ION_MAPPER_READ_NULL_DISABLED = (IonValueMapper) new IonValueMapper(SYSTEM, SNAKE_CASE).disable(IonParser.Feature.READ_NULL_AS_IONVALUE);
+    private static final IonValueMapper ION_VALUE_MAPPER
+        = new IonValueMapper(SYSTEM, PropertyNamingStrategies.SNAKE_CASE);
+    private static final IonValueMapper ION_MAPPER_READ_NULL_DISABLED
+        = (IonValueMapper) new IonValueMapper(SYSTEM, PropertyNamingStrategies.SNAKE_CASE).disable(IonParser.Feature.READ_NULL_AS_IONVALUE);
 
     @Test
     public void shouldBeAbleToDeserialize() throws Exception {
@@ -242,7 +241,7 @@ public class IonValueDeserializerTest {
     }
 
     @Test
-    public void testWithMissingProperty() throws IOException
+    public void testWithMissingProperty() throws Exception
     {
         IonSystem ionSystem = IonSystemBuilder.standard().build();
         IonObjectMapper ionObjectMapper = IonObjectMapper.builder(ionSystem)

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -381,3 +381,7 @@ Cormac Redmond (@credmond)
 Manuel Sugawara (@sugmanue)
  * Contributed #568: Improve ASCII decoding performance for `CBORParser`
   (2.19.0)
+
+Josh Curry (@seadbrane)
+ * Reported, contributed fix for #571: Unable to deserialize a pojo with IonStruct
+  (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,9 @@ Active maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+#571: Unable to deserialize a pojo with IonStruct
+ (reported, fix contributed by Josh C)
+
 2.19.0-rc2 (07-Apr-2025)
 
 #300: (smile) Floats are encoded with sign extension while doubles without


### PR DESCRIPTION
(fixes #571)

Make IonValueDeserializer a ContextualDeserializer in order to create the correct Ion null type.   

Also, add new IonParser feature READ_NULL_AS_IONVALUE in order to be able to serialize `null` as either an IonNull or java `null`.  