### PR TITLE
Allow exposing CBOR simple values as VALUE_EMBEDDED_OBJECT

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -1865,7 +1865,7 @@ public class CBORParser extends ParserMinimalBase
         if (_tokenIncomplete) {
             _finishToken();
         }
-        if (_currToken == JsonToken.VALUE_EMBEDDED_OBJECT ) {
+        if (_currToken == JsonToken.VALUE_EMBEDDED_OBJECT) {
             if (_simpleValue != null) {
                 return _simpleValue;
             }
@@ -1958,11 +1958,11 @@ public class CBORParser extends ParserMinimalBase
     /**
      * Checking whether the current token represents an `undefined` value (0xF7).
      * <p>
-     * This method allows distinguishing between real {@code null} and `undefined`,
+     * This method allows distinguishing between real {@code null} and {@code undefined},
      * even if {@link CBORParser.Feature#READ_UNDEFINED_AS_EMBEDDED_OBJECT} is disabled
      * and the token is reported as {@link JsonToken#VALUE_NULL}.
      *
-     * @return {@code true} if current token is an `undefined`, {@code false} otherwise
+     * @return {@code true} if current token is an {@code undefined}, {@code false} otherwise
      *
      * @since 2.20
      */
@@ -3739,7 +3739,7 @@ expType, type, ch));
      * and exposing them as expected token.
      * <p>
      * Starting with Jackson 2.20, this behavior can be changed by enabling the
-     * {@link com.fasterxml.jackson.dataformat.cbor.CBORParser.Feature#READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT}
+     * {@link CBORParser.Feature#READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT}
      * feature, in which case simple values are returned as {@link JsonToken#VALUE_EMBEDDED_OBJECT} with an
      * embedded {@link CBORSimpleValue} instance.
      *
@@ -3749,8 +3749,9 @@ expType, type, ch));
         if (lowBits > 24) {
             _invalidToken(ch);
         }
+        final boolean simpleAsEmbedded = Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures);
         if (lowBits < 24) {
-            if (Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+            if (simpleAsEmbedded) {
                 _simpleValue = new CBORSimpleValue(lowBits);
             } else {
                 _numberInt = lowBits;
@@ -3768,14 +3769,14 @@ expType, type, ch));
                         +Integer.toHexString(value)+" (only values 0x20 - 0xFF allowed)");
             }
 
-            if (Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+            if (simpleAsEmbedded) {
                 _simpleValue = new CBORSimpleValue(value);
             } else {
                 _numberInt = value;
             }
         }
 
-        if (Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+        if (simpleAsEmbedded) {
             return JsonToken.VALUE_EMBEDDED_OBJECT;
         }
 

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -48,36 +48,37 @@ public class CBORParser extends ParserMinimalBase
         DECODE_USING_STANDARD_NEGATIVE_BIGINT_ENCODING(false),
 
         /**
-         * Feature that determines how an {@code undefined} value ({@code 0xF7}) is decoded.
+         * Feature that determines how an {@code undefined} value ({@code 0xF7}) is exposed
+         * by parser.
          * <p>
-         * When enabled, the parser returns {@link JsonToken#VALUE_EMBEDDED_OBJECT} with a
-         * value of {@code null}, allowing the caller to distinguish {@code undefined} from actual
+         * When enabled, the parser returns {@link JsonToken#VALUE_EMBEDDED_OBJECT} with
+         * a value of {@code null}, allowing the caller to distinguish {@code undefined} from actual
          * {@link JsonToken#VALUE_NULL}.
-         * When disabled (default, for backwards compatibility), {@code undefined} value is
-         * reported as {@link JsonToken#VALUE_NULL}, maintaining legacy behavior
-         * in use up to Jackson 2.19.
+         * When disabled {@code undefined} value is reported as {@link JsonToken#VALUE_NULL}.
+         *<p>
+         * The default value is {@code false} for backwards compatibility (with versions prior to 2.20).
          *
          * @since 2.20
          */
-        HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT(false),
-
+        READ_UNDEFINED_AS_EMBEDDED_OBJECT(false),
 
         /**
-         * Feature that determines how a CBOR "simple value" of major type 7 is decoded.
+         * Feature that determines how a CBOR "simple value" of major type 7 is exposed by parser.
          * <p>
-         * When enabled, the parser returns {@link JsonToken#VALUE_EMBEDDED_OBJECT} with an embedded value
-         * of type {@link CBORSimpleValue}, allowing the caller to distinguish these values from actual {@link JsonToken#VALUE_NUMBER_INT}.
-         * <p>
-         * When disabled (the default, for backwards compatibility), simple values are returned as {@link JsonToken#VALUE_NUMBER_INT},
-         * from Jackson 2.10 to 2.19.
+         * When enabled, the parser returns {@link JsonToken#VALUE_EMBEDDED_OBJECT} with
+         * an embedded value of type {@link CBORSimpleValue}, allowing the caller to distinguish
+         * these values from actual {@link JsonToken#VALUE_NUMBER_INT}s.
+         * When disabled, simple values are returned as {@link JsonToken#VALUE_NUMBER_INT}.
+         *<p>
+         * The default value is {@code false} for backwards compatibility (with versions prior to 2.20).
          *
          * @since 2.20
          */
-        HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT(false)
+        READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT(false)
         ;
 
-        final boolean _defaultState;
-        final int _mask;
+        private final boolean _defaultState;
+        private final int _mask;
 
         /**
          * Method that calculates bit set (flags) of all features that
@@ -1953,7 +1954,7 @@ public class CBORParser extends ParserMinimalBase
      * Checking whether the current token represents an `undefined` value (0xF7).
      * <p>
      * This method allows distinguishing between real {@code null} and `undefined`,
-     * even if {@link CBORParser.Feature#HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT} is disabled
+     * even if {@link CBORParser.Feature#READ_UNDEFINED_AS_EMBEDDED_OBJECT} is disabled
      * and the token is reported as {@link JsonToken#VALUE_NULL}.
      *
      * @return {@code true} if current token is an `undefined`, {@code false} otherwise
@@ -3714,14 +3715,14 @@ expType, type, ch));
      * as {@link JsonToken#VALUE_NULL} by default.
      * <p>
      *
-     * since 2.20 If {@link CBORParser.Feature#HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT} is enabled,
+     * since 2.20 If {@link CBORParser.Feature#READ_UNDEFINED_AS_EMBEDDED_OBJECT} is enabled,
      * the value will instead be decoded as {@link JsonToken#VALUE_EMBEDDED_OBJECT}
      * with an embedded value of {@code null}.
      *
      * @since 2.10
      */
     protected JsonToken _decodeUndefinedValue() {
-        if (Feature.HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+        if (Feature.READ_UNDEFINED_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
             _binaryValue = null; // should be clear but just in case
             return JsonToken.VALUE_EMBEDDED_OBJECT;
         }
@@ -3733,7 +3734,7 @@ expType, type, ch));
      * and exposing them as expected token.
      * <p>
      * Starting with Jackson 2.20, this behavior can be changed by enabling the
-     * {@link com.fasterxml.jackson.dataformat.cbor.CBORParser.Feature#HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT}
+     * {@link com.fasterxml.jackson.dataformat.cbor.CBORParser.Feature#READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT}
      * feature, in which case simple values are returned as {@link JsonToken#VALUE_EMBEDDED_OBJECT} with an
      * embedded {@link CBORSimpleValue} instance.
      *
@@ -3744,7 +3745,7 @@ expType, type, ch));
             _invalidToken(ch);
         }
         if (lowBits < 24) {
-            if (Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+            if (Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
                 _simpleValue = new CBORSimpleValue(lowBits);
             } else {
                 _numberInt = lowBits;
@@ -3762,14 +3763,14 @@ expType, type, ch));
                         +Integer.toHexString(value)+" (only values 0x20 - 0xFF allowed)");
             }
 
-            if (Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+            if (Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
                 _simpleValue = new CBORSimpleValue(value);
             } else {
                 _numberInt = value;
             }
         }
 
-        if (Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+        if (Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
             return JsonToken.VALUE_EMBEDDED_OBJECT;
         }
 

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -3732,9 +3732,10 @@ expType, type, ch));
      * Helper method that deals with details of decoding unallocated "simple values"
      * and exposing them as expected token.
      * <p>
-     * As of Jackson 2.12, simple values are exposed as
-     * {@link JsonToken#VALUE_NUMBER_INT}s,
-     * but in later versions this is planned to be changed to separate value type.
+     * Starting with Jackson 2.20, this behavior can be changed by enabling the
+     * {@link com.fasterxml.jackson.dataformat.cbor.CBORParser.Feature#HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT}
+     * feature, in which case simple values are returned as {@link JsonToken#VALUE_EMBEDDED_OBJECT} with an
+     * embedded {@link CBORSimpleValue} instance.
      *
      * @since 2.12
      */

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -378,6 +378,14 @@ public class CBORParser extends ParserMinimalBase
     protected TagList _tagValues = new TagList();
 
     /**
+     * When major type 7 value is encountered and exposed as {@link JsonToken#VALUE_EMBEDDED_OBJECT},
+     * the value will be stored here.
+     *
+     * @since 2.20
+     */
+    protected CBORSimpleValue _simpleValue;
+    
+    /**
      * Flag that indicates that the current token has not yet
      * been fully processed, and needs to be finished for
      * some access (or skipped to obtain the next token)
@@ -554,9 +562,6 @@ public class CBORParser extends ParserMinimalBase
     protected long _numberLong;
     protected float _numberFloat;
     protected double _numberDouble;
-
-    protected CBORSimpleValue _simpleValue;
-
 
     // And then object types
 
@@ -842,7 +847,7 @@ public class CBORParser extends ParserMinimalBase
         }
         _tokenInputTotal = _currInputProcessed + _inputPtr;
 
-        // also: clear any data retained so far.
+        // also: clear any data retained for previous token
         clearRetainedValues();
 
         // First: need to keep track of lengths of defined-length Arrays and
@@ -1470,11 +1475,12 @@ public class CBORParser extends ParserMinimalBase
     {
         // Two parsing modes; can only succeed if expecting field name, so handle that first:
         if (_streamReadContext.inObject() && _currToken != JsonToken.FIELD_NAME) {
-            clearRetainedValues();
             if (_tokenIncomplete) {
                 _skipIncomplete();
             }
             _tokenInputTotal = _currInputProcessed + _inputPtr;
+            // need to clear retained values for previous token
+            clearRetainedValues();
             _tagValues.clear();
             // completed the whole Object?
             if (!_streamReadContext.expectMoreValues()) {
@@ -1522,18 +1528,19 @@ public class CBORParser extends ParserMinimalBase
             }
         }
         // otherwise just fall back to default handling; should occur rarely
-        return (nextToken() == JsonToken.FIELD_NAME) && str.getValue().equals(getCurrentName());
+        return (nextToken() == JsonToken.FIELD_NAME) && str.getValue().equals(currentName());
     }
 
     @Override
     public String nextFieldName() throws IOException
     {
         if (_streamReadContext.inObject() && _currToken != JsonToken.FIELD_NAME) {
-            clearRetainedValues();
             if (_tokenIncomplete) {
                 _skipIncomplete();
             }
             _tokenInputTotal = _currInputProcessed + _inputPtr;
+            // need to clear retained values for previous token
+            clearRetainedValues();
             _tagValues.clear();
             // completed the whole Object?
             if (!_streamReadContext.expectMoreValues()) {
@@ -4131,6 +4138,7 @@ strLenBytes, firstUTFByteValue, truncatedCharOffset, bytesExpected));
         _streamReadConstraints.validateNestingDepth(_streamReadContext.getNestingDepth());
     }
 
+    // @since 2.20
     private void clearRetainedValues() {
         _numTypesValid = NR_UNKNOWN;
         _binaryValue = null;

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -1470,12 +1470,11 @@ public class CBORParser extends ParserMinimalBase
     {
         // Two parsing modes; can only succeed if expecting field name, so handle that first:
         if (_streamReadContext.inObject() && _currToken != JsonToken.FIELD_NAME) {
-            _numTypesValid = NR_UNKNOWN;
+            clearRetainedValues();
             if (_tokenIncomplete) {
                 _skipIncomplete();
             }
             _tokenInputTotal = _currInputProcessed + _inputPtr;
-            _binaryValue = null;
             _tagValues.clear();
             // completed the whole Object?
             if (!_streamReadContext.expectMoreValues()) {
@@ -1530,12 +1529,11 @@ public class CBORParser extends ParserMinimalBase
     public String nextFieldName() throws IOException
     {
         if (_streamReadContext.inObject() && _currToken != JsonToken.FIELD_NAME) {
-            _numTypesValid = NR_UNKNOWN;
+            clearRetainedValues();
             if (_tokenIncomplete) {
                 _skipIncomplete();
             }
             _tokenInputTotal = _currInputProcessed + _inputPtr;
-            _binaryValue = null;
             _tagValues.clear();
             // completed the whole Object?
             if (!_streamReadContext.expectMoreValues()) {

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -59,7 +59,21 @@ public class CBORParser extends ParserMinimalBase
          *
          * @since 2.20
          */
-        HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT(false)
+        HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT(false),
+
+
+        /**
+         * Feature that determines how a CBOR "simple value" of major type 7 is decoded.
+         * <p>
+         * When enabled, the parser returns {@link JsonToken#VALUE_EMBEDDED_OBJECT} with an embedded value
+         * of type {@link CBORSimpleValue}, allowing the caller to distinguish these values from actual {@link JsonToken#VALUE_NUMBER_INT}.
+         * <p>
+         * When disabled (the default, for backwards compatibility), simple values are returned as {@link JsonToken#VALUE_NUMBER_INT},
+         * from Jackson 2.10 to 2.19.
+         *
+         * @since 2.20
+         */
+        HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT(false)
         ;
 
         final boolean _defaultState;
@@ -206,7 +220,7 @@ public class CBORParser extends ParserMinimalBase
      * @since 2.20
      */
     protected int _formatFeatures;
-    
+
     /**
      * Codec used for data binding when (if) requested.
      */
@@ -540,6 +554,9 @@ public class CBORParser extends ParserMinimalBase
     protected float _numberFloat;
     protected double _numberDouble;
 
+    protected CBORSimpleValue _simpleValue;
+
+
     // And then object types
 
     protected BigInteger _numberBigInt;
@@ -823,9 +840,9 @@ public class CBORParser extends ParserMinimalBase
             _skipIncomplete();
         }
         _tokenInputTotal = _currInputProcessed + _inputPtr;
-        // also: clear any data retained so far
-        _numTypesValid = NR_UNKNOWN;
-        _binaryValue = null;
+
+        // also: clear any data retained so far.
+        clearRetainedValues();
 
         // First: need to keep track of lengths of defined-length Arrays and
         // Objects (to materialize END_ARRAY/END_OBJECT as necessary);
@@ -1843,6 +1860,9 @@ public class CBORParser extends ParserMinimalBase
             _finishToken();
         }
         if (_currToken == JsonToken.VALUE_EMBEDDED_OBJECT ) {
+            if (_simpleValue != null) {
+                return _simpleValue;
+            }
             return _binaryValue;
         }
         return null;
@@ -3723,27 +3743,37 @@ expType, type, ch));
             _invalidToken(ch);
         }
         if (lowBits < 24) {
-            _numberInt = lowBits;
+            if (Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+                _simpleValue = new CBORSimpleValue(lowBits);
+            } else {
+                _numberInt = lowBits;
+            }
         } else { // need another byte
             if (_inputPtr >= _inputEnd) {
                 loadMoreGuaranteed();
             }
-            _numberInt = _inputBuffer[_inputPtr++] & 0xFF;
+
             // As per CBOR spec, values below 32 not allowed to avoid
             // confusion (as well as guarantee uniqueness of encoding)
-            if (_numberInt < 32) {
+            int value = _inputBuffer[_inputPtr++] & 0xFF;
+            if (value < 32) {
                 throw _constructError("Invalid second byte for simple value: 0x"
-                        +Integer.toHexString(_numberInt)+" (only values 0x20 - 0xFF allowed)");
+                        +Integer.toHexString(value)+" (only values 0x20 - 0xFF allowed)");
+            }
+
+            if (Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+                _simpleValue = new CBORSimpleValue(value);
+            } else {
+                _numberInt = value;
             }
         }
 
-        // 25-Nov-2020, tatu: Although ideally we should report these
-        //    as `JsonToken.VALUE_EMBEDDED_OBJECT`, due to late addition
-        //    of handling in 2.12, simple value in 2.12 will be reported
-        //    as simple ints.
+        if (Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT.enabledIn(_formatFeatures)) {
+            return JsonToken.VALUE_EMBEDDED_OBJECT;
+        }
 
         _numTypesValid = NR_INT;
-        return (JsonToken.VALUE_NUMBER_INT);
+        return JsonToken.VALUE_NUMBER_INT;
     }
 
     /*
@@ -4099,5 +4129,11 @@ strLenBytes, firstUTFByteValue, truncatedCharOffset, bytesExpected));
     private void createChildObjectContext(final int len) throws IOException {
         _streamReadContext = _streamReadContext.createChildObjectContext(len);
         _streamReadConstraints.validateNestingDepth(_streamReadContext.getNestingDepth());
+    }
+
+    private void clearRetainedValues() {
+        _numTypesValid = NR_UNKNOWN;
+        _binaryValue = null;
+        _simpleValue = null;
     }
 }

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/SimpleValuesTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/SimpleValuesTest.java
@@ -31,6 +31,23 @@ public class SimpleValuesTest extends CBORTestBase
     }
 
     @Test
+    public void testTinySimpleValuesAsEmbeddedObjectWhenEnabled() throws Exception
+    {
+        CBORFactory f = CBORFactory.builder()
+                .enable(CBORParser.Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT)
+                .build();
+        // Values 0..19 are unassigned, valid to encounter
+        for (int v = 0; v <= 19; ++v) {
+            byte[] doc = new byte[1];
+            doc[0] = (byte) (CBORConstants.PREFIX_TYPE_MISC + v);
+            try (CBORParser p = cborParser(f, doc)) {
+                assertToken(JsonToken.VALUE_EMBEDDED_OBJECT, p.nextToken());
+                assertEquals(new CBORSimpleValue(v), p.getEmbeddedObject());
+            }
+        }
+    }
+
+    @Test
     public void testValidByteLengthMinimalValues() throws Exception {
         // Values 32..255 are unassigned, valid to encounter
         for (int v = 32; v <= 255; ++v) {
@@ -40,6 +57,21 @@ public class SimpleValuesTest extends CBORTestBase
                 // exposes as `int`, fwtw
                 assertEquals(NumberType.INT, p.getNumberType());
                 assertEquals(v, p.getIntValue());
+            }
+        }
+    }
+
+    @Test
+    public void testValidByteLengthMinimalValuesAsEmbeddedObjectWhenEnabled() throws Exception {
+        // Values 32..255 are unassigned, valid to encounter
+        CBORFactory f = CBORFactory.builder()
+                .enable(CBORParser.Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT)
+                .build();
+        for (int v = 32; v <= 255; ++v) {
+            byte[] doc = { (byte) (CBORConstants.PREFIX_TYPE_MISC + 24), (byte) v };
+            try (CBORParser p = cborParser(f, doc)) {
+                assertToken(JsonToken.VALUE_EMBEDDED_OBJECT, p.nextToken());
+                assertEquals(new CBORSimpleValue(v), p.getEmbeddedObject());
             }
         }
     }

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/SimpleValuesTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/SimpleValuesTest.java
@@ -34,7 +34,7 @@ public class SimpleValuesTest extends CBORTestBase
     public void testTinySimpleValuesAsEmbeddedObjectWhenEnabled() throws Exception
     {
         CBORFactory f = CBORFactory.builder()
-                .enable(CBORParser.Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT)
+                .enable(CBORParser.Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT)
                 .build();
         // Values 0..19 are unassigned, valid to encounter
         for (int v = 0; v <= 19; ++v) {
@@ -65,7 +65,7 @@ public class SimpleValuesTest extends CBORTestBase
     public void testValidByteLengthMinimalValuesAsEmbeddedObjectWhenEnabled() throws Exception {
         // Values 32..255 are unassigned, valid to encounter
         CBORFactory f = CBORFactory.builder()
-                .enable(CBORParser.Feature.HANDLE_SIMPLE_VALUES_AS_EMBEDDED_OBJECT)
+                .enable(CBORParser.Feature.READ_SIMPLE_VALUE_AS_EMBEDDED_OBJECT)
                 .build();
         for (int v = 32; v <= 255; ++v) {
             byte[] doc = { (byte) (CBORConstants.PREFIX_TYPE_MISC + 24), (byte) v };

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/UndefinedValueTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/parse/UndefinedValueTest.java
@@ -32,7 +32,7 @@ public class UndefinedValueTest extends CBORTestBase
     @Test
     public void testUndefinedLiteralAsEmbeddedObject() throws Exception {
         CBORFactory f = CBORFactory.builder()
-                .enable(CBORParser.Feature.HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT)
+                .enable(CBORParser.Feature.READ_UNDEFINED_AS_EMBEDDED_OBJECT)
                 .build();
         CBORParser p = cborParser(f, new byte[] { BYTE_UNDEFINED });
 
@@ -62,7 +62,7 @@ public class UndefinedValueTest extends CBORTestBase
     @Test
     public void testUndefinedInArrayAsEmbeddedObject() throws Exception {
         CBORFactory f = CBORFactory.builder()
-                .enable(CBORParser.Feature.HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT)
+                .enable(CBORParser.Feature.READ_UNDEFINED_AS_EMBEDDED_OBJECT)
                 .build();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -108,7 +108,7 @@ public class UndefinedValueTest extends CBORTestBase
     @Test
     public void testUndefinedInObjectAsEmbeddedObject() throws Exception {
         CBORFactory f = CBORFactory.builder()
-                .enable(CBORParser.Feature.HANDLE_UNDEFINED_AS_EMBEDDED_OBJECT)
+                .enable(CBORParser.Feature.READ_UNDEFINED_AS_EMBEDDED_OBJECT)
                 .build();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -397,3 +397,7 @@ Fawzi Essam (@iifawzi)
  * Contributed fix for #431: (cbor) Negative `BigInteger` values not encoded/decoded
    correctly
   (2.20.0)
+ * Contributed implementation of #587: (cbor) Allow exposing CBOR Simple values as
+   `JsonToken.VALUE_EMBEDDED_OBJECT` with a feature flag
+  (2.20.0)
+

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,11 +18,13 @@ Active maintainers:
 
 #137: (cbor) Allow exposing CBOR "undefined" value as `JsonToken.VALUE_EMBEDDED_OBJECT`;
   with embedded value of `null`
- (implementation contributed by Fawzi E) 
-  
+ (implementation contributed by Fawzi E)   
 #431: (cbor) Negative `BigInteger` values not encoded/decoded correctly
  (reported by Brian G)
  (fix contributed by Fawzi E) 
+#587: (cbor) Allow exposing CBOR Simple values as `JsonToken.VALUE_EMBEDDED_OBJECT`
+  with a feature flag
+ (implementation contributed by Fawzi E)   
 - Generate SBOMs [JSTEP-14]
 
 2.19.0 (24-Apr-2025)


### PR DESCRIPTION
Hello, this PR is resolving #587 to allow exposing simple values as value embedded objects