### PR TITLE
[AVRO] Make RecordVisitor _avroSchema and _fields properties final

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -62,11 +62,9 @@ public class RecordVisitor
      */
     private final Schema _typeSchema;
 
-    // !!! 19-May-2025: TODO: make final in 2.20
-    protected Schema _avroSchema;
+    protected final Schema _avroSchema;
 
-    // !!! 19-May-2025: TODO: make final in 2.20
-    protected List<Schema.Field> _fields = new ArrayList<>();
+    protected final List<Schema.Field> _fields = new ArrayList<>();
 
     public RecordVisitor(SerializerProvider p, JavaType type, VisitorFormatWrapperImpl visitorWrapper)
     {
@@ -82,12 +80,11 @@ public class RecordVisitor
             _typeSchema = null;
         } else {
             // If Avro schema for this _type results in UNION I want to know Avro type where to assign fields
-            _avroSchema = AvroSchemaHelper.initializeRecordSchema(bean);
-            _typeSchema = _avroSchema;
+            _typeSchema = AvroSchemaHelper.initializeRecordSchema(bean);
             _overridden = false;
             AvroMeta meta = bean.getClassInfo().getAnnotation(AvroMeta.class);
             if (meta != null) {
-                _avroSchema.addProp(meta.key(), meta.value());
+                _typeSchema.addProp(meta.key(), meta.value());
             }
 
             List<NamedType> subTypes = getProvider().getAnnotationIntrospector().findSubtypes(bean.getClassInfo());
@@ -126,10 +123,12 @@ public class RecordVisitor
                             unionSchemas.add(subTypeSchema);
                         }
                     }
-                    _avroSchema = Schema.createUnion(new ArrayList<>(unionSchemas));
                 } catch (JsonMappingException jme) {
                     throw new RuntimeJsonMappingException("Failed to build schema", jme);
                 }
+                _avroSchema = Schema.createUnion(new ArrayList<>(unionSchemas));
+            } else {
+                _avroSchema = _typeSchema;
             }
         }
         _visitorWrapper.getSchemas().addSchema(type, _avroSchema);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_schemaCreationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimal_schemaCreationTest.java
@@ -39,8 +39,6 @@ public class BigDecimal_schemaCreationTest extends AvroTestBase {
         // because logical types are disabled by default.
         final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
 
-        System.out.println(BigDecimalWithAvroDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
-
         // THEN
         assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
         Schema bigDecimalValue = actualSchema.getField("bigDecimalValue").schema();
@@ -58,8 +56,6 @@ public class BigDecimal_schemaCreationTest extends AvroTestBase {
         // WHEN
         MAPPER.acceptJsonFormatVisitor(BigDecimalWithAvroDecimalAnnotationWrapper.class, gen);
         final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
-
-        System.out.println(BigDecimalWithAvroDecimalAnnotationWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();
@@ -89,8 +85,6 @@ public class BigDecimal_schemaCreationTest extends AvroTestBase {
         // WHEN
         MAPPER.acceptJsonFormatVisitor(BigDecimalWithAvroDecimalAnnotationToFixedWrapper.class, gen);
         final Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
-
-        System.out.println(BigDecimalWithAvroDecimalAnnotationToFixedWrapper.class.getSimpleName() + " schema:" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getField("bigDecimalValue")).isNotNull();

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/jsr310/AvroJavaTimeModule_schemaCreationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/jsr310/AvroJavaTimeModule_schemaCreationTest.java
@@ -47,8 +47,6 @@ public class AvroJavaTimeModule_schemaCreationTest {
         mapper.acceptJsonFormatVisitor(testClass, gen);
         Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
 
-//        System.out.println(testClass.getName() + " schema:\n" + actualSchema.toString(true));
-
         // THEN
         assertThat(actualSchema.getType()).isEqualTo(expectedType);
         assertThat(actualSchema.getProp(LogicalType.LOGICAL_TYPE_PROP)).isEqualTo(expectedLogicalType);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/DateTimeVisitor_builtAvroSchemaTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/DateTimeVisitor_builtAvroSchemaTest.java
@@ -68,8 +68,6 @@ public class DateTimeVisitor_builtAvroSchemaTest {
         // WHEN
         Schema actualSchema = dateTimeVisitor.builtAvroSchema();
 
-//        System.out.println(testClass.getName() + " schema:\n" + actualSchema.toString(true));
-
         // THEN
         assertThat(actualSchema.getType()).isEqualTo(expectedAvroType);
         assertThat(actualSchema.getProp(LogicalType.LOGICAL_TYPE_PROP)).isEqualTo(expectedLogicalType);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/Enum_schemaCreationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/Enum_schemaCreationTest.java
@@ -27,8 +27,6 @@ public class Enum_schemaCreationTest extends AvroTestBase
         MAPPER.acceptJsonFormatVisitor(NumbersEnum.class , gen);
         Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
 
-        System.out.println("schema:\n" + actualSchema.toString(true));
-
         // THEN
         assertThat(actualSchema.getType()).isEqualTo( Schema.Type.ENUM);
         assertThat(actualSchema.getEnumSymbols()).containsExactlyInAnyOrder("ONE", "TWO", "THREE");
@@ -43,8 +41,6 @@ public class Enum_schemaCreationTest extends AvroTestBase
         // WHEN
         MAPPER.acceptJsonFormatVisitor(NumbersEnum.class , gen);
         Schema actualSchema = gen.getGeneratedSchema().getAvroSchema();
-
-        System.out.println("schema:\n" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getType()).isEqualTo( Schema.Type.STRING);

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/PolymorphicTypeAnnotationsTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schema/PolymorphicTypeAnnotationsTest.java
@@ -45,8 +45,6 @@ public class PolymorphicTypeAnnotationsTest {
         // WHEN
         Schema actualSchema = MAPPER.schemaFor(AnimalInterface.class).getAvroSchema();
 
-        // System.out.println("Animal schema:\n" + actualSchema.toString(true));
-
         // THEN
         assertThat(actualSchema.getType()).isEqualTo(Schema.Type.UNION);
         // Because AnimalInterface is interface and AbstractMammal is abstract, they are not expected to be among types in union
@@ -81,8 +79,6 @@ public class PolymorphicTypeAnnotationsTest {
 
         // WHEN
         Schema actualSchema = MAPPER.schemaFor(Fruit.class).getAvroSchema();
-
-        // System.out.println("Fruit schema:\n" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getType()).isEqualTo(Schema.Type.UNION);
@@ -142,8 +138,6 @@ public class PolymorphicTypeAnnotationsTest {
         // WHEN
         Schema actualSchema = MAPPER.schemaFor(Vehicle.class).getAvroSchema();
 
-        // System.out.println("Vehicle schema:\n" + actualSchema.toString(true));
-
         // THEN
         assertThat(actualSchema.getType()).isEqualTo(Schema.Type.UNION);
         assertThat(actualSchema.getTypes()).containsExactlyInAnyOrder(
@@ -187,8 +181,6 @@ public class PolymorphicTypeAnnotationsTest {
         // WHEN
         Schema actualSchema = MAPPER.schemaFor(ElementInterface.class).getAvroSchema();
 
-        // System.out.println("ElementInterface schema:\n" + actualSchema.toString(true));
-
         // THEN
         assertThat(actualSchema.getType()).isEqualTo(Schema.Type.UNION);
         // ElementInterface and AbstractGas are not concrete classes they are not expected to be among types in union
@@ -222,8 +214,6 @@ public class PolymorphicTypeAnnotationsTest {
 
         // WHEN
         Schema actualSchema = MAPPER.schemaFor(Image.class).getAvroSchema();
-
-        // System.out.println("Image schema:\n" + actualSchema.toString(true));
 
         // THEN
         assertThat(actualSchema.getType()).isEqualTo(Schema.Type.UNION);


### PR DESCRIPTION
Making RecordVisitor `_avroSchema` and `_fields` properties final as per https://github.com/FasterXML/jackson-dataformats-binary/pull/593#issuecomment-2902833563.