### PR TITLE
Add support for writing unsigned numbers to CBOR

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -1142,6 +1142,20 @@ public class CBORGenerator extends GeneratorBase
         _writeByte(BYTE_NULL);
     }
 
+    /**
+     * Method for outputting given value as an unsigned integer.
+     * Can be called in any context where a value is expected
+     * (Array value, Object field value, root-level value).
+     *
+     * @param i Number value to write
+     * @throws IOException if there is either an underlying I/O problem or encoding
+     *                     issue at format layer
+     */
+    public void writeNumberUnsigned(int i) throws IOException {
+        _verifyValueWrite("write number unsigned");
+        _writeIntMinimal(PREFIX_TYPE_INT_POS, i);
+    }
+
     @Override
     public void writeNumber(int i) throws IOException {
         _verifyValueWrite("write number");
@@ -1181,6 +1195,33 @@ public class CBORGenerator extends GeneratorBase
         _outputBuffer[_outputTail++] = (byte) (i >> 8);
         _outputBuffer[_outputTail++] = (byte) i;
         _outputBuffer[_outputTail++] = b0;
+    }
+
+    /**
+     * Method for outputting given value as an unsigned integer.
+     * Can be called in any context where a value is expected
+     * (Array value, Object field value, root-level value).
+     *
+     * @param l Number value to write
+     * @throws IOException if there is either an underlying I/O problem or encoding
+     *                     issue at format layer
+     */
+    public void writeNumberUnsigned(long l) throws IOException {
+        if (_cfgMinimalInts && l >= 0 && l < 0x100000000L) {
+            writeNumberUnsigned((int) l);
+            return;
+        }
+        _verifyValueWrite("write number unsigned");
+        _ensureRoomForOutput(9);
+        _outputBuffer[_outputTail++] = (byte) (PREFIX_TYPE_INT_POS + SUFFIX_UINT64_ELEMENTS);
+        _outputBuffer[_outputTail++] = (byte) (l >> 56);
+        _outputBuffer[_outputTail++] = (byte) (l >> 48);
+        _outputBuffer[_outputTail++] = (byte) (l >> 40);
+        _outputBuffer[_outputTail++] = (byte) (l >> 32);
+        _outputBuffer[_outputTail++] = (byte) (l >> 24);
+        _outputBuffer[_outputTail++] = (byte) (l >> 16);
+        _outputBuffer[_outputTail++] = (byte) (l >> 8);
+        _outputBuffer[_outputTail++] = (byte) l;
     }
 
     @Override

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORGenerator.java
@@ -1150,6 +1150,7 @@ public class CBORGenerator extends GeneratorBase
      * @param i Number value to write
      * @throws IOException if there is either an underlying I/O problem or encoding
      *                     issue at format layer
+     * @since 2.20
      */
     public void writeNumberUnsigned(int i) throws IOException {
         _verifyValueWrite("write number unsigned");
@@ -1205,6 +1206,7 @@ public class CBORGenerator extends GeneratorBase
      * @param l Number value to write
      * @throws IOException if there is either an underlying I/O problem or encoding
      *                     issue at format layer
+     * @since 2.20
      */
     public void writeNumberUnsigned(long l) throws IOException {
         if (_cfgMinimalInts && l >= 0 && l < 0x100000000L) {

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/gen/GeneratorSimpleTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/gen/GeneratorSimpleTest.java
@@ -1,15 +1,16 @@
 package com.fasterxml.jackson.dataformat.cbor.gen;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.cbor.*;
-import org.junit.jupiter.api.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/gen/GeneratorSimpleTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/gen/GeneratorSimpleTest.java
@@ -1,16 +1,15 @@
 package com.fasterxml.jackson.dataformat.cbor.gen;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.*;
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.junit.jupiter.api.Test;
-
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.cbor.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -182,6 +181,98 @@ public class GeneratorSimpleTest extends CBORTestBase
     }
 
     @Test
+    public void testUnsignedIntValues() throws Exception
+    {
+        // uint32 max
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGenerator gen = cborGenerator(out);
+        gen.writeNumberUnsigned(-1);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT32_ELEMENTS),
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF);
+
+        // Min int
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(Integer.MIN_VALUE);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT32_ELEMENTS),
+                (byte) 0x80,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0x00);
+
+        // Truncated to 2 bytes
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(1000);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT16_ELEMENTS),
+                (byte) 0x03,
+                (byte) 0xE8);
+
+        // Truncated to 1 byte
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(100);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT8_ELEMENTS),
+                (byte) 0x64);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(25);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT8_ELEMENTS),
+                (byte) 0x19);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(24);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT8_ELEMENTS),
+                (byte) 0x18);
+
+        // Truncated to not take any extra bytes
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(23);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x17);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(10);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x0A);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(1);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x01);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(0);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x00);
+    }
+
+    @Test
     public void testLongValues() throws Exception
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -199,6 +290,119 @@ public class GeneratorSimpleTest extends CBORTestBase
         assertEquals(0, b[1]);
         assertEquals(0, b[2]);
         assertEquals(0, b[3]);
+    }
+
+    @Test
+    public void testUnsignedLongValues() throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CBORGenerator gen = cborGenerator(out);
+
+        // uint64 max
+        gen.writeNumberUnsigned(-1L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT64_ELEMENTS),
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF,
+                (byte) 0xFF);
+
+        // Min long
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(Long.MIN_VALUE);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT64_ELEMENTS),
+                (byte) 0x80,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0x00,
+                (byte) 0x00);
+
+        // Truncated to 4 bytes
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(1000000L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT32_ELEMENTS),
+                (byte) 0x00,
+                (byte) 0x0F,
+                (byte) 0x42,
+                (byte) 0x40);
+
+        // Truncated to 2 bytes
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(1000L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT16_ELEMENTS),
+                (byte) 0x03,
+                (byte) 0xE8);
+
+        // Truncated to 1 byte
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(100L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT8_ELEMENTS),
+                (byte) 0x64);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(25L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT8_ELEMENTS),
+                (byte) 0x19);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(24L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) (CBORConstants.PREFIX_TYPE_INT_POS + CBORConstants.SUFFIX_UINT8_ELEMENTS),
+                (byte) 0x18);
+
+        // Truncated to not take any extra bytes
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(23L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x17);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(10L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x0A);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(1L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x01);
+
+        out = new ByteArrayOutputStream();
+        gen = cborGenerator(out);
+        gen.writeNumberUnsigned(0L);
+        gen.close();
+        _verifyBytes(out.toByteArray(),
+                (byte) 0x00);
     }
 
     @Test


### PR DESCRIPTION
Hey guys,

In a project I use Jackson CBOR dataformat for, the CBOR encoded in Kotlin is decoded by software expecting `uint64`. This PR implements support for writing unsigned numbers (long, int) in custom serializers, so values negative in Java do not end up negative in the CBOR. (https://datatracker.ietf.org/doc/html/rfc7049#appendix-A, https://datatracker.ietf.org/doc/html/rfc7049#appendix-B)

I've added generator methods and tests for them, but I am currently not sure what to do with the parser. In fact, an unsigned number can be parsed as BigInteger which is then converted to long via `BigInteger::toLong`, but it lacks the boundary check.

Currently, this can be used with custom serializers like this:
```kotlin
class UnsignedLongSerializer : JsonSerializer<Long>() {
    override fun serialize(value: Long, generator: JsonGenerator, serializerProvider: SerializerProvider) =
        (generator as CBORGenerator).writeNumberUnsigned(value)
}

class UnsignedLongDeserializer : JsonDeserializer<Long>() {
    override fun deserialize(parser: JsonParser, deserializationContext: DeserializationContext): Long =
        (parser as CBORParser).bigIntegerValue.toLong()
}

data class Account
@JsonCreator
constructor(
    val name: String,
    @JsonSerialize(using = UnsignedLongSerializer::class)
    @JsonDeserialize(using = UnsignedLongDeserializer::class)
    val balance: Long,
)
```

Do you think if support for unsigned numbers is needed in Jackson? If so, what should I add to proceed?

Thanks.