### PR TITLE
Bugfix: Flaky test in IonValueDeserializerTest

### DIFF
--- a/ion/src/test/java/tools/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
+++ b/ion/src/test/java/tools/jackson/dataformat/ion/ionvalue/IonValueDeserializerTest.java
@@ -1,6 +1,6 @@
 package tools.jackson.dataformat.ion.ionvalue;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class IonValueDeserializerTest {
     private static class Data<T> {
-        private final Map<String, T> map = new HashMap<>();
+        private final Map<String, T> map = new LinkedHashMap<>();
 
         protected Data() { }
 
@@ -202,7 +202,6 @@ public class IonValueDeserializerTest {
                         incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL)
                                 .withContentInclusion(JsonInclude.Include.NON_NULL))
                 .build();
-
         String data = mapper.writeValueAsString(source);
         assertEquals("{a:1,b:null}", data);
         // Now remove the null element for the comparison below.


### PR DESCRIPTION

## What is the purpose of this PR?

This pull request addresses 1 flaky test, in the `jackson-dataformats-binary` project. The test was failing intermittently due to assumptions about the ordering of fields returned by the code under test.

## Test Affected

- `IonValueDeserializerTest#shouldBeAbleToSerializeAndDeserializeIonValueDataWithIncludeNonNull`

## Why the test fails

The test compares the **exact string** representation which can be returned in any order (when using `HashMap` in the underlying implementation). I switched the test to use `LinkedHashMap` instead to guarantee ordering.

```
String data = mapper.writeValueAsString(source);
        assertEquals("{a:1,b:null}", data);
```

## How to reproduce the test failure

Use the [TestingResearchIllinois's NonDex](https://github.com/TestingResearchIllinois/NonDex) tool and run:

```shell
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex 
```

Before the fix, the test failed intermittently with errors similar to:

```shell
tools.jackson.dataformat.ion.ionvalue.IonValueDeserializerTest:org.opentest4j.AssertionFailedError: expected: <{a:1,b:null}> but was: <{b:null,a:1}>
```

## Expected results

The test should pass consistently, regardless of the order of fields in the returned response.

## Actual results

Before the fix, the test failed intermittently due to changes in the order of the returned response.

## Validation

### Test Results

- Tests run with **NonDex**: Passed consistently across multiple seeds
    
```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex 
```

<img width="1302" height="81" alt="image" src="https://github.com/user-attachments/assets/0de864ca-4270-4afc-abe7-22123276f89d" />

## Additional Notes

- The fix ensures the test is robust to non-deterministic behaviors and compatible with future updates to it or related dependencies.

Let me know if further improvements or clarifications are needed!