### PR TITLE
Update `ion-java` dep to `1.11.1` (from 1.11.10)

### DIFF
--- a/ion/pom.xml
+++ b/ion/pom.xml
@@ -38,7 +38,7 @@ tree model)
     <dependency>
       <groupId>com.amazon.ion</groupId>
       <artifactId>ion-java</artifactId>
-      <version>1.11.10</version>
+      <version>1.11.11</version>
     </dependency>
 
     <!-- will come from parent pom for later versions -->

--- a/ion/src/test/java/tools/jackson/dataformat/ion/IonNumberOverflowTest.java
+++ b/ion/src/test/java/tools/jackson/dataformat/ion/IonNumberOverflowTest.java
@@ -81,7 +81,8 @@ public class IonNumberOverflowTest
         IonParser bigIntLongParser = (IonParser) new IonFactory().createParser(ObjectReadContext.empty(),
                 bigIntLongValue.toString());
         assertEquals(JsonToken.VALUE_NUMBER_INT, bigIntLongParser.nextToken());
-        assertEquals(JsonParser.NumberType.BIG_INTEGER, bigIntLongParser.getNumberType());
+        // Ion 1.11.11+ changed behavior: values that fit in long are now classified as LONG
+        assertEquals(JsonParser.NumberType.LONG, bigIntLongParser.getNumberType());
         assertEquals(JsonParser.NumberTypeFP.UNKNOWN, bigIntLongParser.getNumberTypeFP());
         assertEquals(bigIntLongValue.longValue(), bigIntLongParser.getLongValue());
     }    


### PR DESCRIPTION
## **Description**

Ion v1.11.11 ([release notes](https://github.com/amazon-ion/ion-java/releases/tag/v1.11.11)) changed how values that fit in long are now classified ([change in Ion Java](https://github.com/amazon-ion/ion-java/pull/1055)), instead of using `BIG INTEGER` they use `LONG`. Using a `BIG INTEGER` was causing test `testLongAsBigIntegerSize` to fail when the Ion version was changed to v1.11.11 from v1.11.10:

```
[ERROR] tools.jackson.dataformat.ion.IonNumberOverflowTest.testLongAsBigIntegerSize -- Time elapsed: 0.035 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <BIG_INTEGER> but was: <LONG>
```

The current version of Ion Java utilizes Jackson-dataformat-ion 2.18.