### PR TITLE
Fix #599: handle skipping of CBOR string refs

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -3414,6 +3414,50 @@ CBORConstants.MAJOR_TYPE_BYTES, type);
                 && type != CBORConstants.MAJOR_TYPE_BYTES) {
             _throwInternal();
         }
+
+        // [dataformats-binary#599]: If we are in a stringref namespace, we need to
+        // actually read and store the string/bytes value instead of just skipping it,
+        // so that later string references can find it.
+        if (!_stringRefs.empty()) {
+            final int lowBits = _typeByte & 0x1F;
+            final int len = _decodeExplicitLength(lowBits);
+
+            if (type == CBORConstants.MAJOR_TYPE_TEXT) {
+                // For text, need to read the string to potentially store as reference
+                if (len >= 0) {
+                    // Non-chunked text
+                    if (shouldReferenceString(_stringRefs.peek().stringRefs.size(), len)) {
+                        // Need to actually read and store the string
+                        String str = _finishTextToken(_typeByte);
+                        // _finishTextToken already handles adding to stringRefs
+                        return;
+                    }
+                    // No need to store, can skip
+                } else {
+                    // Chunked text - must read to potentially store
+                    // Note: chunked strings may still need to be stored if large enough
+                    String str = _finishTextToken(_typeByte);
+                    return;
+                }
+            } else {
+                // For bytes, similar logic
+                if (len >= 0) {
+                    if (shouldReferenceString(_stringRefs.peek().stringRefs.size(), len)) {
+                        // Need to actually read and store the bytes
+                        byte[] b = _finishBytes(len);
+                        // _finishBytes already handles adding to stringRefs
+                        return;
+                    }
+                    // No need to store, can skip
+                } else {
+                    // Chunked bytes
+                    byte[] b = _finishChunkedBytes();
+                    return;
+                }
+            }
+        }
+
+        // Standard skip logic when not in stringref namespace
         final int lowBits = _typeByte & 0x1F;
         if (lowBits <= 23) {
             if (lowBits > 0) {

--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -3418,43 +3418,18 @@ CBORConstants.MAJOR_TYPE_BYTES, type);
         // [dataformats-binary#599]: If we are in a stringref namespace, we need to
         // actually read and store the string/bytes value instead of just skipping it,
         // so that later string references can find it.
+        // The finish methods will determine if the value should be added to the
+        // reference table based on shouldReferenceString().
         if (!_stringRefs.empty()) {
-            final int lowBits = _typeByte & 0x1F;
-            final int len = _decodeExplicitLength(lowBits);
-
             if (type == CBORConstants.MAJOR_TYPE_TEXT) {
-                // For text, need to read the string to potentially store as reference
-                if (len >= 0) {
-                    // Non-chunked text
-                    if (shouldReferenceString(_stringRefs.peek().stringRefs.size(), len)) {
-                        // Need to actually read and store the string
-                        String str = _finishTextToken(_typeByte);
-                        // _finishTextToken already handles adding to stringRefs
-                        return;
-                    }
-                    // No need to store, can skip
-                } else {
-                    // Chunked text - must read to potentially store
-                    // Note: chunked strings may still need to be stored if large enough
-                    String str = _finishTextToken(_typeByte);
-                    return;
-                }
+                // Need to actually read the text (which may add to stringRefs)
+                _finishTextToken(_typeByte);
             } else {
-                // For bytes, similar logic
-                if (len >= 0) {
-                    if (shouldReferenceString(_stringRefs.peek().stringRefs.size(), len)) {
-                        // Need to actually read and store the bytes
-                        byte[] b = _finishBytes(len);
-                        // _finishBytes already handles adding to stringRefs
-                        return;
-                    }
-                    // No need to store, can skip
-                } else {
-                    // Chunked bytes
-                    byte[] b = _finishChunkedBytes();
-                    return;
-                }
+                // For bytes: decode length then read (which may add to stringRefs)
+                int len = _decodeExplicitLength(_typeByte & 0x1F);
+                _finishBytes(len);
             }
+            return;
         }
 
         // Standard skip logic when not in stringref namespace

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/StringRef599Test.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/StringRef599Test.java
@@ -1,12 +1,9 @@
-package com.fasterxml.jackson.dataformat.cbor.tofix;
+package com.fasterxml.jackson.dataformat.cbor;
 
 import java.util.Arrays;
 
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import com.fasterxml.jackson.dataformat.cbor.*;
-import com.fasterxml.jackson.dataformat.cbor.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -27,7 +24,6 @@ public class StringRef599Test extends CBORTestBase
     }
 
     // [dataformats-binary#599]
-    @JacksonTestFailureExpected
     @Test
     public void testDupsWithStringRef() throws Exception
     {

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -422,3 +422,7 @@ Vincent Eigenberger (@beseder1)
  * Contributed fix for #601: Jackson subtype Avro schema unions are non-deterministic
    and therefore incompatible with each other
   (2.20.1)
+
+Yohei Kishimoto (@morokosi)
+ * Reported #599: (cbor) Unable to deserialize stringref-enabled CBOR with ignored properties
+  (2.21.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,8 @@ Active maintainers:
 
 2.21.0 (not yet released)
 
+#599: (cbor) Unable to deserialize stringref-enabled CBOR with ignored properties
+ (reported by Yohei K)
 #623: (ion) Upgrade `ion-java` dep to 1.11.11 (from 1.11.10)
  (requested by @Shaurya0108)
 


### PR DESCRIPTION
## Summary

Problem:

When using CBOR with string references enabled, deserialization failed if a string value was  skipped (e.g., when a property is ignored via @JsonIgnoreProperties). The parser would skip over the  string without adding it to the string reference table, causing later string references to fail with "String reference out of range" errors.

Root Cause:

The _skipIncomplete() method in CBORParser was designed to skip over string/bytes content without actually reading it. However, when in a stringref namespace, the parser needs to read and potentially store these values in the reference table for later use.

Solution:

 Modified _skipIncomplete() in CBORParser.java (lines 3418-3432) to:

1. Check if we're in a stringref namespace (!_stringRefs.empty())
2. If yes, actually read the value using the appropriate finish methods (_finishTextToken() for text, _finishBytes() for bytes)
3. The finish methods already contain logic to determine if values should be added to the reference table based on shouldReferenceString()
4. If not in a stringref namespace, use the original skip logic
