### PR TITLE
Remove IOException from IonObjectMapper read and write method signatures

### DIFF
--- a/ion/src/main/java/tools/jackson/dataformat/ion/IonObjectMapper.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/IonObjectMapper.java
@@ -17,9 +17,10 @@ package tools.jackson.dataformat.ion;
 import java.io.IOException;
 import java.util.Date;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.Version;
+import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.core.type.TypeReference;
-
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.MapperBuilder;
@@ -27,7 +28,6 @@ import tools.jackson.databind.cfg.MapperBuilderState;
 import tools.jackson.databind.deser.DeserializationContextExt;
 import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.ser.SerializationContextExt;
-
 import tools.jackson.dataformat.ion.ionvalue.IonValueModule;
 
 import com.amazon.ion.IonDatagram;
@@ -335,7 +335,7 @@ public class IonObjectMapper extends ObjectMapper
      * Note: method does not close the underlying reader
      */
     @SuppressWarnings("unchecked")
-    public <T> T readValue(IonReader r, Class<T> valueType) throws IOException {
+    public <T> T readValue(IonReader r, Class<T> valueType) throws JacksonException {
         DeserializationContextExt ctxt = _deserializationContext();
         return (T)_readMapAndClose(ctxt, tokenStreamFactory().createParser(ctxt, r),
                 _typeFactory.constructType(valueType));
@@ -348,7 +348,7 @@ public class IonObjectMapper extends ObjectMapper
      * Note: method does not close the underlying reader
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(IonReader r, TypeReference valueTypeRef) throws IOException {
+    public <T> T readValue(IonReader r, TypeReference valueTypeRef) throws JacksonException {
         DeserializationContextExt ctxt = _deserializationContext();
         return (T)_readMapAndClose(ctxt, tokenStreamFactory().createParser(ctxt, r),
                 _typeFactory.constructType(valueTypeRef));
@@ -361,7 +361,7 @@ public class IonObjectMapper extends ObjectMapper
      * Note: method does not close the underlying reader
      */
     @SuppressWarnings("unchecked")
-    public <T> T readValue(IonReader r, JavaType valueType) throws IOException {
+    public <T> T readValue(IonReader r, JavaType valueType) throws JacksonException {
         DeserializationContextExt ctxt = _deserializationContext();
         return (T)_readMapAndClose(ctxt, tokenStreamFactory().createParser(ctxt, r), valueType);
     }
@@ -370,7 +370,7 @@ public class IonObjectMapper extends ObjectMapper
      * Convenience method for converting Ion value into given value type.
      */
     @SuppressWarnings("unchecked")
-    public <T> T readValue(IonValue value, Class<T> valueType) throws IOException {
+    public <T> T readValue(IonValue value, Class<T> valueType) throws JacksonException {
         if (value == null) {
             return null;
         }
@@ -383,7 +383,7 @@ public class IonObjectMapper extends ObjectMapper
      * Convenience method for converting Ion value into given value type.
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public <T> T readValue(IonValue value, TypeReference valueTypeRef) throws IOException {
+    public <T> T readValue(IonValue value, TypeReference valueTypeRef) throws JacksonException {
         if (value == null) {
             return null;
         }
@@ -396,7 +396,7 @@ public class IonObjectMapper extends ObjectMapper
      * Convenience method for converting Ion value into given value type.
      */
     @SuppressWarnings("unchecked")
-    public <T> T readValue(IonValue value, JavaType valueType) throws IOException  {
+    public <T> T readValue(IonValue value, JavaType valueType) throws JacksonException  {
         if (value == null) {
             return null;
         }
@@ -410,7 +410,7 @@ public class IonObjectMapper extends ObjectMapper
      *<p>
      * Note: method does not close the underlying writer explicitly
      */
-    public void writeValue(IonWriter w, Object value) throws IOException {
+    public void writeValue(IonWriter w, Object value) throws JacksonException {
         SerializationContextExt prov = _serializationContext();
         _configAndWriteValue(prov,
                 tokenStreamFactory().createGenerator(prov, w), value);
@@ -419,7 +419,7 @@ public class IonObjectMapper extends ObjectMapper
     /**
      * Method that can be used to map any Java value to an IonValue.
      */
-    public IonValue writeValueAsIonValue(Object value) throws IOException
+    public IonValue writeValueAsIonValue(Object value) throws JacksonException
     {
         // 04-Jan-2017, tatu: Bit of incompatiblity wrt 2.x handling: should this result in
         //   Java `null`, or Ion null marker? For now, choose latter
@@ -436,6 +436,8 @@ public class IonObjectMapper extends ObjectMapper
             IonValue result = container.get(0);
             result.removeFromContainer();
             return result;
+        } catch (IOException e) {
+            throw JacksonIOException.construct(e);
         }
     }
 

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -23,3 +23,8 @@ Andy Wilkinson (@wilkinsona)
 * Requested #619: (avro, cbor, ion, smile) Add `isEnabled()` methods for format-specific features
   (like `CBORReadFeature` and `CBORWriteFeature`) to mappers
  (3.1.0)
+
+Michael Liedtke (@mcliedtke)
+
+* Contributed #629: (ion) Unnecessary `IOException` in `IonObjectMapper` method signatures
+ (3.1.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -23,6 +23,8 @@ implementations)
  (requested by Andy W)
 #623: (ion) Upgrade `ion-java` dep to 1.11.11 (from 1.11.10)
  (requested by @Shaurya0108)
+#629: (ion) Unnecessary `IOException` in `IonObjectMapper` method signatures
+ (fix contributed by Michael L)
 
 3.0.1 (21-Oct-2025)
 


### PR DESCRIPTION
Remove IOException from IonObjectMapper read and write method signatures. Most are unnecessary and one is now wrapped as JacksonIOException

Ref: https://github.com/FasterXML/jackson-dataformats-binary/issues/629