### PR TITLE
Fix #649

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORFactory.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORFactory.java
@@ -425,6 +425,8 @@ public class CBORFactory extends JsonFactory
     @Override
     protected CBORParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException
     {
+        // [core#1548] Validate doc length up front for fixed buffers
+        _streamReadConstraints.validateDocumentLength(len);
         return new CBORParserBootstrapper(ctxt, data, offset, len).constructParser(
                 _factoryFeatures, _parserFeatures, _formatParserFeatures,
                 _objectCodec, _byteSymbolCanonicalizer);

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/gen/constraints/LongDocumentCBORReadTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/gen/constraints/LongDocumentCBORReadTest.java
@@ -8,18 +8,19 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.exc.StreamConstraintsException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.cbor.CBORTestBase;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class LongDocumentCBORReadTest extends CBORTestBase
 {
-    private final ObjectMapper MAPPER_VANILLA = cborMapper();
+    private final CBORMapper MAPPER_VANILLA = cborMapper();
 
-    private final ObjectMapper MAPPER_CONSTRAINED = cborMapper(
+    private final CBORMapper MAPPER_CONSTRAINED = cborMapper(
             CBORFactory.builder()
             // limit to 100kB doc reads
                 .streamReadConstraints(StreamReadConstraints.builder()
@@ -32,13 +33,20 @@ public class LongDocumentCBORReadTest extends CBORTestBase
     {
         // Need a bit longer than minimum since checking is approximate, not exact
         byte[] doc = createBigDoc(60_000);
-        // Must read from `InputStream` as validation is during "loadMore()":
-        try (JsonParser p = MAPPER_CONSTRAINED.createParser(new ByteArrayInputStream(doc))) {
+        _testLongDocumentConstraint(doc, true);
+        // [dataformats-binary#649] fixed buffer too
+        _testLongDocumentConstraint(doc, false);
+    }
+
+    private void _testLongDocumentConstraint(byte[] doc, boolean stream) throws Exception
+    {
+        try (JsonParser p = stream
+                ? MAPPER_CONSTRAINED.createParser(new ByteArrayInputStream(doc))
+                : MAPPER_CONSTRAINED.createParser(doc, 0, doc.length)) {
             while (p.nextToken() != null) { }
             fail("expected StreamConstraintsException");
         } catch (StreamConstraintsException e) {
             final String msg = e.getMessage();
-
             assertTrue(msg.contains("Document length ("));
             assertTrue(msg.contains("exceeds the maximum allowed (50000"));
         }

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Active maintainers:
 
 #645: (avro) Remove use of Avro `Schema.Parser().setValidate()` to allow
   use of Avro core 1.12.1 (2.x)
+#649: (cbor, smile) `StreamReadConstraints.maxDocumentLength` not checked
+  when creating parser with fixed buffer
 
 2.21.0 (18-Jan-2026)
 

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileFactory.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileFactory.java
@@ -458,6 +458,8 @@ public class SmileFactory extends JsonFactory
     @Override
     protected SmileParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException
     {
+        // [core#1548] Validate doc length up front for fixed buffers
+        _streamReadConstraints.validateDocumentLength(len);
         return new SmileParserBootstrapper(ctxt, data, offset, len).constructParser(
                 _factoryFeatures, _parserFeatures, _smileParserFeatures,
                 _objectCodec, _byteSymbolCanonicalizer);

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/constraints/LongDocumentSmileReadTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/constraints/LongDocumentSmileReadTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.exc.StreamConstraintsException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.BaseTestForSmile;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
@@ -17,9 +16,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class LongDocumentSmileReadTest extends BaseTestForSmile
 {
-    private final ObjectMapper MAPPER_VANILLA = new SmileMapper();
+    private final SmileMapper MAPPER_VANILLA = new SmileMapper();
 
-    private final ObjectMapper MAPPER_CONSTRAINED = new SmileMapper(
+    private final SmileMapper MAPPER_CONSTRAINED = new SmileMapper(
             SmileFactory.builder()
             // limit to 100kB doc reads
                 .streamReadConstraints(StreamReadConstraints.builder()
@@ -32,13 +31,20 @@ public class LongDocumentSmileReadTest extends BaseTestForSmile
     {
         // Need a bit longer than minimum since checking is approximate, not exact
         byte[] doc = createBigDoc(60_000);
-        // Must read from `InputStream` as validation is during "loadMore()":
-        try (JsonParser p = MAPPER_CONSTRAINED.createParser(new ByteArrayInputStream(doc))) {
+        _testLongDocumentConstraint(doc, true);
+        // [dataformats-binary#649] fixed buffer too
+        _testLongDocumentConstraint(doc, false);
+    }
+
+    private void _testLongDocumentConstraint(byte[] doc, boolean stream) throws Exception
+    {
+        try (JsonParser p = stream
+                ? MAPPER_CONSTRAINED.createParser(new ByteArrayInputStream(doc))
+                : MAPPER_CONSTRAINED.createParser(doc, 0, doc.length)) {
             while (p.nextToken() != null) { }
             fail("expected StreamConstraintsException");
         } catch (StreamConstraintsException e) {
             final String msg = e.getMessage();
-
             assertTrue(msg.contains("Document length ("));
             assertTrue(msg.contains("exceeds the maximum allowed (50000"));
         }


### PR DESCRIPTION
(`StreamReadConstraints.maxDocumentLength` not checked when creating parser with fixed buffer)