### PR TITLE
[avro] Apply StreamReadConstraints to BigDecimal decode paths (#693, 3.x)

### DIFF
--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
@@ -627,6 +627,8 @@ public abstract class AvroParserImpl
     // @since 2.19
     public JsonToken decodeBytesDecimal(int scale) throws IOException {
         decodeBytes();
+        // Enforce maxNumberLength against raw 2's-complement payload length,
+        // matching CBOR/Smile codecs handling which also uses raw byte length.
         streamReadConstraints().validateFPLength(_binaryValue.length);
         _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
         _numTypesValid = NR_BIGDECIMAL;

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
@@ -627,6 +627,7 @@ public abstract class AvroParserImpl
     // @since 2.19
     public JsonToken decodeBytesDecimal(int scale) throws IOException {
         decodeBytes();
+        streamReadConstraints().validateFPLength(_binaryValue.length);
         _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
         _numTypesValid = NR_BIGDECIMAL;
         return JsonToken.VALUE_NUMBER_FLOAT;
@@ -640,6 +641,7 @@ public abstract class AvroParserImpl
     // @since 2.19
     public JsonToken decodeFixedDecimal(int scale, int size) throws IOException {
         decodeFixed(size);
+        streamReadConstraints().validateFPLength(_binaryValue.length);
         _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
         _numTypesValid = NR_BIGDECIMAL;
         return JsonToken.VALUE_NUMBER_FLOAT;

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
@@ -627,10 +627,7 @@ public abstract class AvroParserImpl
     // @since 2.19
     public JsonToken decodeBytesDecimal(int scale) throws IOException {
         decodeBytes();
-        // Enforce maxNumberLength against raw 2's-complement payload length,
-        // matching CBOR/Smile codecs handling which also uses raw byte length.
-        streamReadConstraints().validateFPLength(_binaryValue.length);
-        _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
+        _numberBigDecimal = _decimalFromUnscaledBytes(_binaryValue, scale);
         _numTypesValid = NR_BIGDECIMAL;
         return JsonToken.VALUE_NUMBER_FLOAT;
     }
@@ -643,10 +640,21 @@ public abstract class AvroParserImpl
     // @since 2.19
     public JsonToken decodeFixedDecimal(int scale, int size) throws IOException {
         decodeFixed(size);
-        streamReadConstraints().validateFPLength(_binaryValue.length);
-        _numberBigDecimal = new BigDecimal(new BigInteger(_binaryValue), scale);
+        _numberBigDecimal = _decimalFromUnscaledBytes(_binaryValue, scale);
         _numTypesValid = NR_BIGDECIMAL;
         return JsonToken.VALUE_NUMBER_FLOAT;
+    }
+
+    private BigDecimal _decimalFromUnscaledBytes(byte[] raw, int scale) {
+        // Empty payload: BigInteger(byte[]) would throw NumberFormatException,
+        // so short-circuit to zero (matches SmileParser._finishBigDecimal).
+        if (raw.length == 0) {
+            return BigDecimal.ZERO;
+        }
+        // Enforce maxNumberLength against raw 2's-complement payload length,
+        // matching CBOR/Smile codecs handling which also uses raw byte length.
+        streamReadConstraints().validateFPLength(raw.length);
+        return new BigDecimal(new BigInteger(raw), scale);
     }
 
     // @since 2.19

--- a/avro/src/test/java/tools/jackson/dataformat/avro/dos/AvroDecimalLengthLimitTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/dos/AvroDecimalLengthLimitTest.java
@@ -1,0 +1,126 @@
+package tools.jackson.dataformat.avro.dos;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+
+import tools.jackson.dataformat.avro.AvroFactory;
+import tools.jackson.dataformat.avro.AvroMapper;
+import tools.jackson.dataformat.avro.AvroSchema;
+import tools.jackson.dataformat.avro.AvroTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AvroDecimalLengthLimitTest extends AvroTestBase
+{
+    private final AvroMapper DEFAULT_MAPPER = new AvroMapper();
+
+    private final AvroMapper STRICT_MAPPER;
+    {
+        AvroFactory f = AvroFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNumberLength(4).build())
+                .build();
+        STRICT_MAPPER = new AvroMapper(f);
+    }
+
+    private final String BYTES_DECIMAL_SCHEMA =
+            "{\"type\":\"record\",\"name\":\"D\",\"fields\":[{"
+            + "\"name\":\"v\",\"type\":{"
+            + "\"type\":\"bytes\",\"logicalType\":\"decimal\","
+            + "\"precision\":40,\"scale\":2}}]}";
+
+    private final String FIXED_DECIMAL_SCHEMA =
+            "{\"type\":\"record\",\"name\":\"D\",\"fields\":[{"
+            + "\"name\":\"v\",\"type\":{"
+            + "\"type\":\"fixed\",\"name\":\"F\",\"size\":16,"
+            + "\"logicalType\":\"decimal\","
+            + "\"precision\":38,\"scale\":2}}]}";
+
+    @Test
+    public void testBytesDecimalLargePayloadTripsLimit() throws Exception
+    {
+        BigDecimal big = new BigDecimal("12345678901234567890123456789012.34");
+        byte[] doc = encodeBytesDecimal(big);
+        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
+
+        try (JsonParser p = STRICT_MAPPER.reader().with(schema).createParser(doc)) {
+            assertEquals(JsonToken.START_OBJECT, p.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
+            StreamConstraintsException e = assertThrows(StreamConstraintsException.class,
+                    () -> p.nextToken());
+            assertTrue(e.getMessage().contains("Number value length"),
+                    "unexpected: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFixedDecimalLargePayloadTripsLimit() throws Exception
+    {
+        BigDecimal big = new BigDecimal("100.00");
+        byte[] doc = encodeFixedDecimal(big);
+        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(FIXED_DECIMAL_SCHEMA);
+
+        try (JsonParser p = STRICT_MAPPER.reader().with(schema).createParser(doc)) {
+            assertEquals(JsonToken.START_OBJECT, p.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
+            StreamConstraintsException e = assertThrows(StreamConstraintsException.class,
+                    () -> p.nextToken());
+            assertTrue(e.getMessage().contains("Number value length"),
+                    "unexpected: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testBytesDecimalSmallPayloadPasses() throws Exception
+    {
+        BigDecimal small = new BigDecimal("42.20");
+        byte[] doc = encodeBytesDecimal(small);
+        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
+
+        try (JsonParser p = STRICT_MAPPER.reader().with(schema).createParser(doc)) {
+            assertEquals(JsonToken.START_OBJECT, p.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(small, p.getDecimalValue());
+        }
+    }
+
+    @Test
+    public void testDefaultLimitAllowsTypicalDecimals() throws Exception
+    {
+        BigDecimal v = new BigDecimal("12345678901234567890.42");
+        byte[] doc = encodeBytesDecimal(v);
+        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
+
+        try (JsonParser p = DEFAULT_MAPPER.reader().with(schema).createParser(doc)) {
+            assertEquals(JsonToken.START_OBJECT, p.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(v, p.getDecimalValue());
+        }
+    }
+
+    private byte[] encodeBytesDecimal(BigDecimal v) throws Exception {
+        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
+        Map<String, Object> m = new HashMap<>();
+        m.put("v", v);
+        return DEFAULT_MAPPER.writer(schema).writeValueAsBytes(m);
+    }
+
+    private byte[] encodeFixedDecimal(BigDecimal v) throws Exception {
+        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(FIXED_DECIMAL_SCHEMA);
+        Map<String, Object> m = new HashMap<>();
+        m.put("v", v);
+        return DEFAULT_MAPPER.writer(schema).writeValueAsBytes(m);
+    }
+}

--- a/avro/src/test/java/tools/jackson/dataformat/avro/dos/AvroDecimalLengthLimitTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/dos/AvroDecimalLengthLimitTest.java
@@ -18,76 +18,81 @@ import tools.jackson.dataformat.avro.AvroTestBase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Verifies that {@link StreamReadConstraints#getMaxNumberLength()} is enforced
+ * by the Avro parser when decoding the {@code decimal} logical type
+ * (both {@code bytes}- and {@code fixed}-backed forms), matching the behavior
+ * of CBOR / Smile codecs which guard equivalent native big-number tokens.
+ */
 public class AvroDecimalLengthLimitTest extends AvroTestBase
 {
     private final AvroMapper DEFAULT_MAPPER = new AvroMapper();
 
+    // Strict limit: 20 bytes of unscaled magnitude (≈ 48 decimal digits)
     private final AvroMapper STRICT_MAPPER;
     {
         AvroFactory f = AvroFactory.builder()
                 .streamReadConstraints(StreamReadConstraints.builder()
-                        .maxNumberLength(4).build())
+                        .maxNumberLength(20).build())
                 .build();
         STRICT_MAPPER = new AvroMapper(f);
     }
 
-    private final String BYTES_DECIMAL_SCHEMA =
+    private final AvroSchema BYTES_DECIMAL_SCHEMA = DEFAULT_MAPPER.schemaFrom(
             "{\"type\":\"record\",\"name\":\"D\",\"fields\":[{"
             + "\"name\":\"v\",\"type\":{"
             + "\"type\":\"bytes\",\"logicalType\":\"decimal\","
-            + "\"precision\":40,\"scale\":2}}]}";
+            + "\"precision\":100,\"scale\":2}}]}");
 
-    private final String FIXED_DECIMAL_SCHEMA =
+    private final AvroSchema FIXED_DECIMAL_SCHEMA = DEFAULT_MAPPER.schemaFrom(
             "{\"type\":\"record\",\"name\":\"D\",\"fields\":[{"
             + "\"name\":\"v\",\"type\":{"
-            + "\"type\":\"fixed\",\"name\":\"F\",\"size\":16,"
+            + "\"type\":\"fixed\",\"name\":\"F\",\"size\":24,"
             + "\"logicalType\":\"decimal\","
-            + "\"precision\":38,\"scale\":2}}]}";
+            + "\"precision\":56,\"scale\":2}}]}");
 
     @Test
     public void testBytesDecimalLargePayloadTripsLimit() throws Exception
     {
-        BigDecimal big = new BigDecimal("12345678901234567890123456789012.34");
+        // Unscaled value with ~62 digits -> ~26 bytes, above limit of 20
+        BigDecimal big = new BigDecimal(
+                "123456789012345678901234567890123456789012345678901234567890.12");
         byte[] doc = encodeBytesDecimal(big);
-        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
 
-        try (JsonParser p = STRICT_MAPPER.reader().with(schema).createParser(doc)) {
+        try (JsonParser p = STRICT_MAPPER.reader().with(BYTES_DECIMAL_SCHEMA).createParser(doc)) {
             assertEquals(JsonToken.START_OBJECT, p.nextToken());
             assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
             StreamConstraintsException e = assertThrows(StreamConstraintsException.class,
                     () -> p.nextToken());
-            assertTrue(e.getMessage().contains("Number value length"),
-                    "unexpected: " + e.getMessage());
+            verifyException(e, "Number value length");
         }
     }
 
     @Test
     public void testFixedDecimalLargePayloadTripsLimit() throws Exception
     {
+        // fixed size 24 bytes -> always 24 bytes of payload, exceeds limit of 20
         BigDecimal big = new BigDecimal("100.00");
         byte[] doc = encodeFixedDecimal(big);
-        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(FIXED_DECIMAL_SCHEMA);
 
-        try (JsonParser p = STRICT_MAPPER.reader().with(schema).createParser(doc)) {
+        try (JsonParser p = STRICT_MAPPER.reader().with(FIXED_DECIMAL_SCHEMA).createParser(doc)) {
             assertEquals(JsonToken.START_OBJECT, p.nextToken());
             assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
             StreamConstraintsException e = assertThrows(StreamConstraintsException.class,
                     () -> p.nextToken());
-            assertTrue(e.getMessage().contains("Number value length"),
-                    "unexpected: " + e.getMessage());
+            verifyException(e, "Number value length");
         }
     }
 
     @Test
     public void testBytesDecimalSmallPayloadPasses() throws Exception
     {
+        // Unscaled 4220 fits in 2 bytes -> well below limit of 20
         BigDecimal small = new BigDecimal("42.20");
         byte[] doc = encodeBytesDecimal(small);
-        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
 
-        try (JsonParser p = STRICT_MAPPER.reader().with(schema).createParser(doc)) {
+        try (JsonParser p = STRICT_MAPPER.reader().with(BYTES_DECIMAL_SCHEMA).createParser(doc)) {
             assertEquals(JsonToken.START_OBJECT, p.nextToken());
             assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
@@ -100,9 +105,8 @@ public class AvroDecimalLengthLimitTest extends AvroTestBase
     {
         BigDecimal v = new BigDecimal("12345678901234567890.42");
         byte[] doc = encodeBytesDecimal(v);
-        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
 
-        try (JsonParser p = DEFAULT_MAPPER.reader().with(schema).createParser(doc)) {
+        try (JsonParser p = DEFAULT_MAPPER.reader().with(BYTES_DECIMAL_SCHEMA).createParser(doc)) {
             assertEquals(JsonToken.START_OBJECT, p.nextToken());
             assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
@@ -111,16 +115,14 @@ public class AvroDecimalLengthLimitTest extends AvroTestBase
     }
 
     private byte[] encodeBytesDecimal(BigDecimal v) throws Exception {
-        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(BYTES_DECIMAL_SCHEMA);
         Map<String, Object> m = new HashMap<>();
         m.put("v", v);
-        return DEFAULT_MAPPER.writer(schema).writeValueAsBytes(m);
+        return DEFAULT_MAPPER.writer(BYTES_DECIMAL_SCHEMA).writeValueAsBytes(m);
     }
 
     private byte[] encodeFixedDecimal(BigDecimal v) throws Exception {
-        AvroSchema schema = DEFAULT_MAPPER.schemaFrom(FIXED_DECIMAL_SCHEMA);
         Map<String, Object> m = new HashMap<>();
         m.put("v", v);
-        return DEFAULT_MAPPER.writer(schema).writeValueAsBytes(m);
+        return DEFAULT_MAPPER.writer(FIXED_DECIMAL_SCHEMA).writeValueAsBytes(m);
     }
 }

--- a/avro/src/test/java/tools/jackson/dataformat/avro/dos/AvroDecimalLengthLimitTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/dos/AvroDecimalLengthLimitTest.java
@@ -100,6 +100,23 @@ public class AvroDecimalLengthLimitTest extends AvroTestBase
         }
     }
 
+    // Empty bytes-decimal payload must decode to zero rather than blow up on
+    // BigInteger(new byte[0]) (matches SmileParser._finishBigDecimal handling).
+    @Test
+    public void testBytesDecimalEmptyPayloadDecodesToZero() throws Exception
+    {
+        // Avro: single record with one `bytes` field, value = length-prefix 0
+        // (zig-zag varint 0 = 0x00), no payload bytes follow.
+        byte[] doc = new byte[] { 0x00 };
+
+        try (JsonParser p = DEFAULT_MAPPER.reader().with(BYTES_DECIMAL_SCHEMA).createParser(doc)) {
+            assertEquals(JsonToken.START_OBJECT, p.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(BigDecimal.ZERO, p.getDecimalValue());
+        }
+    }
+
     @Test
     public void testDefaultLimitAllowsTypicalDecimals() throws Exception
     {


### PR DESCRIPTION
## Summary

3.x mirror of #694 for #693.

`AvroParserImpl.decodeBytesDecimal` and `decodeFixedDecimal` did not invoke
`StreamReadConstraints.validateFPLength` against the raw 2's-complement
payload length before constructing the `BigDecimal` value. Sibling binary
parsers (`CBORParser`, `SmileParser`) cap via byte-length at the
equivalent native big-number token. This change aligns `AvroParserImpl`
with that shape on 3.x.

## Changes

- `avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java`:
  apply `streamReadConstraints().validateFPLength(_binaryValue.length)` on
  both the `bytes`-backed and `fixed`-backed decimal decode paths.
- `avro/src/test/java/tools/jackson/dataformat/avro/dos/AvroDecimalLengthLimitTest.java`:
  verifies that values larger than the configured `maxNumberLength` are
  rejected for both decimal payload forms, and that small / default-limit
  decimals continue to round-trip.

## Test plan

`mvn -pl avro test`

- 152 tests, 0 failures (148 existing + 4 new).
- Without the patch, the two `*LargePayloadTripsLimit` tests fail
  (no exception thrown); the two non-limit tests pass.
- With the patch, all four new tests pass.
