### PR TITLE
Backport fix for #73: (protobuf) in 2.21 - Cannot resolve inner types in protoc definitions

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/TypeResolver.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/TypeResolver.java
@@ -223,7 +223,31 @@ public class TypeResolver
         if (nativeMt != null) {
             return new ProtobufField(nativeField, resolve(this, nativeMt));
         }
-        return null;
+        // [dataformats-binary#73] Handle dot-notation references to nested message types
+        // (e.g. "OuterType.InnerType")
+        return _findDottedType(nativeField, typeStr);
+    }
+
+    /**
+     * Try to resolve a dot-notation type reference (e.g. {@code "OuterType.InnerType"})
+     * by navigating the message type hierarchy declared at this scope level.
+     */
+    private ProtobufField _findDottedType(FieldElement nativeField, String typeStr)
+    {
+        int dotIx = typeStr.indexOf('.');
+        if (dotIx <= 0) {
+            return null;
+        }
+        String outerName = typeStr.substring(0, dotIx);
+        String innerPath = typeStr.substring(dotIx + 1);
+        MessageElement outerMsg = _declaredMessageTypes.get(outerName);
+        if (outerMsg == null) {
+            return null;
+        }
+        // Create a resolver in the context of the outer type and recursively
+        // resolve the remaining path (handles arbitrary nesting depth)
+        TypeResolver outerResolver = TypeResolver.construct(this, outerName, outerMsg.nestedElements());
+        return outerResolver._findAndResolve(nativeField, innerPath);
     }
 
     private StringBuilder _knownEnums(StringBuilder sb) {

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/schema/NestedTypeRef73Test.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/schema/NestedTypeRef73Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.dataformat.protobuf.tofix;
+package com.fasterxml.jackson.dataformat.protobuf.schema;
 
 import java.io.StringReader;
 
@@ -6,25 +6,17 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.dataformat.protobuf.ProtobufMapper;
 import com.fasterxml.jackson.dataformat.protobuf.ProtobufTestBase;
-import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
-import com.fasterxml.jackson.dataformat.protobuf.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class GenerateNestedType73Test extends ProtobufTestBase
+// [dataformats-binary#73]
+public class NestedTypeRef73Test extends ProtobufTestBase
 {
-    /*
-    /**********************************************************
-    /* Test methods
-    /**********************************************************
-     */
-
     final ProtobufMapper MAPPER = new ProtobufMapper();
 
-    // [dataformats-binary#68]
-    @JacksonTestFailureExpected
+    // [dataformats-binary#73]: dot-notation reference to a nested message type
     @Test
-    public void testNestedTypes() throws Exception
+    public void testNestedTypeRefViaRootType() throws Exception
     {
         final String SCHEMA_STR =
 "        package mypackage;\n"

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -19,6 +19,8 @@ Kenji Noguchi (knoguchi@github)
 
 * Reported #70 (protobuf), contributed fix: Can't deserialize packed repeated field
  (2.8.9)
+* Reported #73: (protobuf) Cannot resolve inner types in protoc definitions
+ (2.21.5)
 
 marsqing@github
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,11 @@ Active maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.21.5 (not yet released)
+
+#73: (protobuf) Cannot resolve inner types in protoc definitions
+ (reported by Kenji N)
+
 2.21.4 (28-May-2026)
 
 #691: (cbor) Add parameterized tests covering all ASCII-optimization exit paths in CBORParser


### PR DESCRIPTION
## Summary

Backports #656 (fixed on `3.x` for 3.1.0) to the `2.21` branch, to fix #73.

`TypeResolver._findAndResolve()` didn't handle dot-notation references to
nested message types (e.g. `t1.i1`), so schemas like:

```proto
message t1 {
    message i1 {
        optional uint32 x = 1;
        optional uint32 y = 2;
    }
}
message t2 {
    optional t1.i1 z = 1;
}
```

failed with:

```
IllegalArgumentException: Unknown protobuf field type 't1.i1' for field 'z' ...
```

Adds `_findDottedType()` to resolve such references by navigating into the
outer type's nested elements (recursively, for arbitrary nesting depth).
