### PR TITLE
Backport fix for #598: (protobuf) Protobuf parser state handling wrong for implicit close (END_OBJECT)

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufParser.java
@@ -51,6 +51,10 @@ public class ProtobufParser extends ParserMinimalBase
     // State after either reaching end-of-input, or getting explicitly closed
     private final static int STATE_CLOSED = 12;
 
+    // State after returning END_OBJECT for root level, before closing
+    // (added for [dataformats-binary#598] to separate END_OBJECT return from close())
+    private final static int STATE_ROOT_END = 13;
+
     private final static int[] UTF8_UNIT_CODES = ProtobufUtil.sUtf8UnitLengths;
 
     // @since 2.14
@@ -592,7 +596,8 @@ public class ProtobufParser extends ParserMinimalBase
             // end-of-input?
             if (_inputPtr >= _inputEnd) {
                 if (!loadMore()) {
-                    close();
+                    _state = STATE_ROOT_END;
+                    _parsingContext.setCurrentName(null);
                     return _updateToken(JsonToken.END_OBJECT);
                 }
             }
@@ -617,6 +622,12 @@ public class ProtobufParser extends ParserMinimalBase
 
             int len = _decodeLength();
             int newEnd = _inputPtr + len;
+            // Guard against integer overflow: _inputPtr and len are both non-negative,
+            // so a result smaller than _inputPtr means the sum wrapped.
+            if (newEnd < _inputPtr) {
+                _reportErrorF("Packed array length overflows for field '%s': ptr=%d, len=%d",
+                        _currentField.name, _inputPtr, len);
+            }
 
             // First: validate that we do not extend past end offset of enclosing message
             if (!_parsingContext.inRoot()) {
@@ -687,8 +698,13 @@ public class ProtobufParser extends ParserMinimalBase
             return _updateToken(_readNextValue(_currentField.type, STATE_NESTED_KEY));
 
         case STATE_MESSAGE_END: // occurs if we end with array
-            close(); // sets state to STATE_CLOSED
+            _state = STATE_ROOT_END;
+            _parsingContext.setCurrentName(null);
             return _updateToken(JsonToken.END_OBJECT);
+
+        case STATE_ROOT_END: // returned END_OBJECT, now close on next call
+            close(); // sets state to STATE_CLOSED
+            return null;
 
         case STATE_CLOSED:
             return null;
@@ -923,6 +939,12 @@ public class ProtobufParser extends ParserMinimalBase
                 _currentMessage = msg;
                 int len = _decodeLength();
                 int newEnd = _inputPtr + len;
+                // Guard against integer overflow: _inputPtr and len are both non-negative,
+                // so a result smaller than _inputPtr means the sum wrapped.
+                if (newEnd < _inputPtr) {
+                    _reportErrorF("Message length overflows for field '%s': ptr=%d, len=%d",
+                            _currentField.name, _inputPtr, len);
+                }
 
                 // First: validate that we do not extend past end offset of enclosing message
                 if (newEnd > _currentEndOffset) {
@@ -964,7 +986,8 @@ public class ProtobufParser extends ParserMinimalBase
                 }
             } else if (_inputPtr >= _inputEnd) {
                 if (!loadMore()) {
-                    close();
+                    _state = STATE_ROOT_END;
+                    _parsingContext.setCurrentName(null);
                     return _updateToken(JsonToken.END_OBJECT);
                 }
             }
@@ -1025,7 +1048,8 @@ public class ProtobufParser extends ParserMinimalBase
         if (_state == STATE_ROOT_KEY) {
             if (_inputPtr >= _inputEnd) {
                 if (!loadMore()) {
-                    close();
+                    _state = STATE_ROOT_END;
+                    _parsingContext.setCurrentName(null);
                     _updateToken(JsonToken.END_OBJECT);
                     return false;
                 }
@@ -1106,7 +1130,8 @@ public class ProtobufParser extends ParserMinimalBase
         if (_state == STATE_ROOT_KEY) {
             if (_inputPtr >= _inputEnd) {
                 if (!loadMore()) {
-                    close();
+                    _state = STATE_ROOT_END;
+                    _parsingContext.setCurrentName(null);
                     _updateToken(JsonToken.END_OBJECT);
                     return null;
                 }

--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/ProtobufField.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/schema/ProtobufField.java
@@ -212,6 +212,6 @@ public class ProtobufField
 
     @Override
     public int compareTo(ProtobufField other) {
-        return id - other.id;
+        return Integer.compare(id, other.id);
     }
 }

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ParserStateEndTest.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ParserStateEndTest.java
@@ -1,0 +1,116 @@
+package com.fasterxml.jackson.dataformat.protobuf;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.*;
+
+import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
+import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchemaLoader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// [dataformats-binary#598]
+public class ParserStateEndTest extends ProtobufTestBase
+{
+    private final ProtobufMapper MAPPER = newObjectMapper();
+
+    @Test
+    public void testParserStateAtEndObject() throws Exception
+    {
+        ProtobufSchema schema = ProtobufSchemaLoader.std.parse(PROTOC_POINT);
+
+        Point input = new Point(42, 13);
+        byte[] bytes = MAPPER.writerFor(Point.class)
+                .with(schema)
+                .writeValueAsBytes(input);
+
+        try (JsonParser p = MAPPER.reader()
+                .with(schema)
+                .createParser(bytes)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertEquals("x", p.currentName());
+
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(42, p.getIntValue());
+
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertEquals("y", p.currentName());
+
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(13, p.getIntValue());
+
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+
+            assertFalse(p.isClosed(),
+                "Parser should NOT be closed immediately after returning END_OBJECT");
+
+            assertEquals(JsonToken.END_OBJECT, p.getCurrentToken(),
+                "currentToken() should return END_OBJECT, not null");
+
+            assertNull(p.nextToken(), "After END_OBJECT, nextToken() should return null");
+            assertTrue(p.isClosed(), "Parser should be closed after nextToken() returns null");
+        }
+    }
+
+    @Test
+    public void testParserStateAtEndObjectWithNextFieldName() throws Exception
+    {
+        ProtobufSchema schema = ProtobufSchemaLoader.std.parse(PROTOC_POINT);
+
+        Point input = new Point(42, 13);
+        byte[] bytes = MAPPER.writerFor(Point.class)
+                .with(schema)
+                .writeValueAsBytes(input);
+
+        try (JsonParser p = MAPPER.reader()
+                .with(schema)
+                .createParser(bytes)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+            assertEquals("x", p.nextFieldName());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+
+            assertEquals("y", p.nextFieldName());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+
+            assertNull(p.nextFieldName());
+
+            assertEquals(JsonToken.END_OBJECT, p.getCurrentToken(),
+                "currentToken() should return END_OBJECT after nextFieldName() returns null");
+
+            assertFalse(p.isClosed(),
+                "Parser should NOT be closed when currentToken is END_OBJECT");
+
+            assertNull(p.nextToken());
+            assertTrue(p.isClosed());
+        }
+    }
+
+    @Test
+    public void testParserStateWithEmptyMessage() throws Exception
+    {
+        final String PROTOC_EMPTY = "message Empty {}\n";
+        ProtobufSchema schema = ProtobufSchemaLoader.std.parse(PROTOC_EMPTY);
+
+        // Empty Protobuf message is legitimately zero bytes: no fields to encode
+        byte[] bytes = new byte[0];
+
+        try (JsonParser p = MAPPER.reader()
+                .with(schema)
+                .createParser(bytes)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertFalse(p.isClosed());
+
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+
+            assertFalse(p.isClosed(),
+                "Parser should NOT be closed immediately after END_OBJECT");
+            assertEquals(JsonToken.END_OBJECT, p.getCurrentToken());
+
+            assertNull(p.nextToken());
+            assertTrue(p.isClosed());
+        }
+    }
+}

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,11 @@ Active maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.21.5 (not yet released)
+
+#598: (protobuf) Protobuf parser state handling wrong for implicit close
+  (END_OBJECT)
+
 2.21.4 (28-May-2026)
 
 #691: (cbor) Add parameterized tests covering all ASCII-optimization exit paths in CBORParser


### PR DESCRIPTION
## Summary

Backports the fix for #598 to the `2.21` maintenance branch (ported from the 3.x fix, adapted to the `com.fasterxml.jackson.*` package namespace).

- `ProtobufParser` previously reported the implicit root-level `END_OBJECT` and called `close()` in the same step. This worked in most cases, but conflicted with the `ParserBase.close()` behavior fixed in jackson-core#1438 (current token no longer reset on `close()`), since dataformats-binary 2.20 already picked up that jackson-core fix.
- Adds a new `STATE_ROOT_END` parser state so that returning `END_OBJECT` and closing the parser become two separate steps: `nextToken()`/`nextFieldName()` first return `END_OBJECT` while leaving the parser open (`isClosed() == false`, `getCurrentToken() == END_OBJECT`), and only close the parser on the following call.

Also includes two small unrelated hardening fixes found while working in the same area:
- Guard against integer overflow when computing packed-array and nested-message end offsets in `ProtobufParser` (`_inputPtr + len` could wrap for maliciously large lengths).
- Fix `ProtobufField.compareTo()` to use `Integer.compare(id, other.id)` instead of `id - other.id`, which could overflow for extreme tag values.
