### PR TITLE
Fix #715: _reportWrongWireType() always reports `string`, ignoring actual type

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufGenerator.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufGenerator.java
@@ -1885,8 +1885,8 @@ public class ProtobufGenerator extends GeneratorBase
         if (_currField == UNKNOWN_FIELD) {
             return;
         }
-        _reportErrorF("Can not write `string` value for '%s' (type %s)",
-                _currField.name, _currField.type);
+        _reportErrorF("Can not write `%s` value for '%s' (type %s)",
+                typeStr, _currField.name, _currField.type);
     }
 
     private void _reportErrorF(String format, Object... args) throws JsonGenerationException {

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/WriteErrorsTest.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/WriteErrorsTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
 import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchemaLoader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests for generation that trigger exceptions (or would
@@ -68,5 +69,55 @@ public class WriteErrorsTest extends ProtobufTestBase
         Point3D result = MAPPER.readerFor(Point3D.class).with(schema)
                 .readValue(b);
         assertEquals(290, result.x);
+    }
+
+    // [dataformats-binary#715]: error must name the value type actually written,
+    // not always report `string`
+    @Test
+    public void testWrongWireTypeNamesActualType() throws Exception
+    {
+        // "Point" declares `x` as an int32, so any non-integral value is a mismatch
+        ProtobufSchema schema = ProtobufSchemaLoader.std.parse(PROTOC_BOX, "Point");
+
+        _verifyWrongWireType(schema, "double", new ValueWriter() {
+            @Override
+            public void write(JsonGenerator g) throws Exception {
+                g.writeNumber(0.25);
+            }
+        });
+        _verifyWrongWireType(schema, "binary", new ValueWriter() {
+            @Override
+            public void write(JsonGenerator g) throws Exception {
+                g.writeBinary(new byte[] { 1, 2, 3 });
+            }
+        });
+        _verifyWrongWireType(schema, "string", new ValueWriter() {
+            @Override
+            public void write(JsonGenerator g) throws Exception {
+                g.writeString("foo");
+            }
+        });
+    }
+
+    private interface ValueWriter {
+        void write(JsonGenerator g) throws Exception;
+    }
+
+    private void _verifyWrongWireType(ProtobufSchema schema, String expType,
+            ValueWriter w) throws Exception
+    {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        JsonGenerator g = MAPPER.getFactory().createGenerator(bytes);
+        g.setSchema(schema);
+        g.writeStartObject();
+        g.writeFieldName("x");
+        try {
+            w.write(g);
+            fail("Should not pass: `x` is an int32 field");
+        } catch (JsonProcessingException e) {
+            verifyException(e, "Can not write `"+expType+"` value for 'x'");
+        } finally {
+            g.close();
+        }
     }
 }

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Active maintainers:
 
 #708: (protobuf) proto3 label-less field declarations fail to parse
  (NOTE: `map<K,V>` fields still not supported, but now fail with a clear error)
+#715: (protobuf) `ProtobufGenerator._reportWrongWireType()` always reports `string`,
+  ignoring actual type
 
 2.21.5 (06-Jul-2026)
 


### PR DESCRIPTION
Fixes #715.

`ProtobufGenerator._reportWrongWireType(String typeStr)` never used its `typeStr` argument; the message hardcoded `` `string` ``. All 16 call sites already pass a meaningful type name (`"int"`, `"long"`, `"double"`, `"float"`, `"binary"`, `"boolean"`, `"string"`), so writing e.g. a double into an `int32` field misreported as:

```
Can not write `string` value for 'x' (type VINT32_STD)
```

Fix is to use the argument. Test added to `WriteErrorsTest` covering the `double`, `binary` and `string` cases; it fails on the current code (reporting `string` for a double) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)