### PR TITLE
Fix #714: packed repeated field fails to decode across input buffer reload

### DIFF
--- a/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufReadContext.java
+++ b/protobuf/src/main/java/com/fasterxml/jackson/dataformat/protobuf/ProtobufReadContext.java
@@ -76,6 +76,7 @@ public final class ProtobufReadContext
         _currentName = null;
         _currentValue = null;
         _endOffset = endOffset;
+        _field = null;
     }
 
     @Override
@@ -113,11 +114,10 @@ public final class ProtobufReadContext
         ProtobufReadContext ctxt = _child;
         if (ctxt == null) {
             _child = ctxt = new ProtobufReadContext(this, _messageType,
-                    TYPE_ARRAY, 0);
+                    TYPE_ARRAY, endOffset);
         } else {
             ctxt.reset(_messageType, TYPE_ARRAY, endOffset);
         }
-        ctxt._field = f;
         return ctxt;
     }
 

--- a/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedArrayAcrossReload714Test.java
+++ b/protobuf/src/test/java/com/fasterxml/jackson/dataformat/protobuf/ReadPackedArrayAcrossReload714Test.java
@@ -1,0 +1,80 @@
+package com.fasterxml.jackson.dataformat.protobuf;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.dataformat.protobuf.schema.ProtobufSchema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for [dataformats-binary#714]: a "packed" repeated field whose contents span
+ * an input buffer reload used to fail with a spurious "corrupt content" error, since
+ * the array context was created with an end offset of 0 (instead of the actual one)
+ * whenever the context was freshly allocated rather than recycled.
+ */
+public class ReadPackedArrayAcrossReload714Test extends ProtobufTestBase
+{
+    // proto3 defaults repeated scalars to packed encoding
+    private final static String SCHEMA_STR =
+            "syntax = \"proto3\";\n"
+            + "message Ints {\n"
+            + "  repeated int32 values = 1;\n"
+            + "}\n";
+
+    static class Ints {
+        public int[] values;
+
+        protected Ints() { }
+        public Ints(int[] v) { values = v; }
+    }
+
+    // Enough values that the encoded packed block is much bigger than the input
+    // buffer (8000 bytes), forcing at least one reload while inside the array
+    private final static int COUNT = 6000;
+
+    @Test
+    public void testPackedArrayFromInputStream() throws Exception
+    {
+        final ProtobufMapper mapper = newObjectMapper();
+        final ProtobufSchema schema = mapper.schemaLoader().parse(SCHEMA_STR);
+
+        final int[] values = new int[COUNT];
+        for (int i = 0; i < COUNT; ++i) {
+            values[i] = 100_000 + i; // 3-byte varints; ~18kB payload
+        }
+        final byte[] doc = mapper.writer(schema).writeValueAsBytes(new Ints(values));
+
+        // Baseline: byte[] input keeps the whole document in one buffer, so no reload
+        _verify(mapper, schema, mapper.getFactory().createParser(doc), values);
+
+        // The actual regression: reading from a stream forces loadMore() mid-array
+        try (InputStream in = new ByteArrayInputStream(doc)) {
+            _verify(mapper, schema, mapper.getFactory().createParser(in), values);
+        }
+    }
+
+    private void _verify(ProtobufMapper mapper, ProtobufSchema schema,
+            JsonParser p, int[] expected) throws Exception
+    {
+        try {
+            p.setSchema(schema);
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertEquals("values", p.currentName());
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            for (int i = 0; i < expected.length; ++i) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(expected[i], p.getIntValue(), "Mismatch at index "+i);
+            }
+            assertToken(JsonToken.END_ARRAY, p.nextToken());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        } finally {
+            p.close();
+        }
+    }
+}

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Active maintainers:
 
 #708: (protobuf) proto3 label-less field declarations fail to parse
  (NOTE: `map<K,V>` fields still not supported, but now fail with a clear error)
+#714: (protobuf) Packed repeated field fails to decode when array spans an input
+  buffer reload
 
 2.21.5 (06-Jul-2026)
 


### PR DESCRIPTION
Fixes #714.

### Problem

Reading a `packed` repeated field from an `InputStream` fails with a spurious "corrupt content" error when the array spans a buffer reload (~8kB+ of input). The same bytes parse fine from a `byte[]`, and are valid protobuf — written by our own generator.

```
Decoding: current inputPtr (2) exceeds end offset (-8000) (for message of type Ints): corrupt content?
```

Note this is a *false* corruption report, not silent data loss: valid content is rejected. It only reproduces on `InputStream` input large enough to force `loadMore()`, which is why no existing test caught it.

### Cause

`ProtobufReadContext.createChildArrayContext(ProtobufField, int endOffset)` honored `endOffset` only when reusing a recycled context; the fresh-allocation branch passed `0`. So the first packed array at any given nesting level got `_endOffset == 0`; the next `loadMore()` called `adjustEnd()`, driving the offset negative, and `_checkEnd()` then read valid content as corrupt.

### Fix

Pass `endOffset` on that branch. Also cleans up two adjacent oddities in the same method, both of which the upcoming `map<K,V>` work (#712) would otherwise trip over — a map context, unlike a packed-array context, does have children:

- it assigned `_field` on the *child* context (unread, and not done by the other two factory methods)
- `reset()` never cleared `_field`, leaving it stale on a recycled context

### Test

`ReadPackedArrayAcrossReload714Test` writes a proto3 `repeated int32` of 6000 values (~18kB), then reads it back from both `byte[]` and `InputStream`. It fails on the current code with the error above and passes with the fix. Full protobuf suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)