### PR TITLE
Fix #720: (smile) SmileGenerator int overflow in maxLen for very long Strings

### DIFF
--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileGenerator.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileGenerator.java
@@ -662,7 +662,7 @@ public class SmileGenerator
         _writeByte(TOKEN_KEY_LONG_STRING);
         // can we still make a temp copy?
         // but will encoded version fit in buffer?
-        int maxLen = len + len + len;
+        long maxLen = (long) len + len + len;
         if (maxLen <= _outputBuffer.length) { // yes indeed
             if ((_outputTail + maxLen) >= _outputEnd) {
                 _flushBuffer();
@@ -905,7 +905,7 @@ public class SmileGenerator
     private final void _writeNonSharedString(final String text, final int len) throws JacksonException
     {
         // Expansion can be 3x for Unicode; and then there's type byte and end marker, so:
-        int maxLen = len + len + len + 2;
+        long maxLen = (long) len + len + len + 2;
         // Next: does it always fit within output buffer?
         if (maxLen > _outputBuffer.length) { // nope
             // can't rewrite type buffer, so can't speculate it might be all-ASCII
@@ -965,7 +965,7 @@ public class SmileGenerator
             _outputBuffer[origOffset] = typeToken;
         } else { // "long" String, never shared
             // but might still fit within buffer?
-            int maxLen = len + len + len + 2;
+            long maxLen = (long) len + len + len + 2;
             if (maxLen <= _outputBuffer.length) { // yes indeed
                 if ((_outputTail + maxLen) >= _outputEnd) {
                     _flushBuffer();
@@ -1075,7 +1075,7 @@ public class SmileGenerator
             }
         } else { // "long" String
             // but might still fit within buffer?
-            int maxLen = len + len + len + 2;
+            long maxLen = (long) len + len + len + 2;
             if (maxLen <= _outputBuffer.length) { // yes indeed
                 if ((_outputTail + maxLen) >= _outputEnd) {
                     _flushBuffer();

--- a/smile/src/test/java/tools/jackson/dataformat/smile/gen/SmileGeneratorHugeStringTest.java
+++ b/smile/src/test/java/tools/jackson/dataformat/smile/gen/SmileGeneratorHugeStringTest.java
@@ -1,0 +1,62 @@
+package tools.jackson.dataformat.smile.gen;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.dataformat.smile.BaseTestForSmile;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class SmileGeneratorHugeStringTest extends BaseTestForSmile
+{
+    // 3*len + 2 overflows a signed int for this length
+    private final static int OVERFLOW_LEN = 715_827_882;
+
+    // Require a comfortable margin of heap before even attempting allocation
+    private final static long REQUIRED_HEAP = 3L * 1024 * 1024 * 1024; // 3 GB
+
+    // Discards output but counts bytes, so we do not also retain ~700 MB of encoded data
+    private static final class CountingOutputStream extends OutputStream {
+        long count;
+
+        @Override
+        public void write(int b) { count++; }
+
+        @Override
+        public void write(byte[] b, int off, int len) { count += len; }
+    }
+
+    @Test
+    public void testHugeAsciiStringDoesNotOverflowBuffer() throws IOException
+    {
+        assumeTrue(Runtime.getRuntime().maxMemory() >= REQUIRED_HEAP,
+                "Requires large heap (>= 3 GB) to allocate a ~700M char String");
+
+        char[] chars = new char[OVERFLOW_LEN];
+        Arrays.fill(chars, 'a'); // all-ASCII to hit the fast in-buffer encoding loop
+
+        // (1) String value path: writeString(String) -> _writeNonSharedString
+        String big = new String(chars);
+        CountingOutputStream out = new CountingOutputStream();
+        try (JsonGenerator gen = _smileGenerator(out, true)) {
+            gen.writeString(big);
+        }
+        // type byte + payload + end marker: must have written the whole thing
+        assertTrue(out.count > OVERFLOW_LEN,
+                "Expected > " + OVERFLOW_LEN + " bytes, got " + out.count);
+        big = null;
+
+        // (2) char[] value path: writeString(char[], off, len)
+        out = new CountingOutputStream();
+        try (JsonGenerator gen = _smileGenerator(out, true)) {
+            gen.writeString(chars, 0, chars.length);
+        }
+        assertTrue(out.count > OVERFLOW_LEN,
+                "Expected > " + OVERFLOW_LEN + " bytes, got " + out.count);
+    }
+}


### PR DESCRIPTION
Fixes #720.

## Problem

`SmileGenerator` computes `maxLen = len + len + len (+ 2)` with 32-bit `int` arithmetic when deciding whether an encoded String fits in the output buffer. For a String (or field name) whose length is `>= 715_827_882`, `3*len + 2` overflows to a **negative** value, which defeats the "does it fit in the buffer?" guard. Execution falls through to the fast in-buffer encoder (`_shortUTF8Encode`), which then overruns the fixed-size `_outputBuffer` and throws:

```
java.lang.ArrayIndexOutOfBoundsException: Index 8000 out of bounds for length 8000
    at ...SmileGenerator._shortUTF8Encode(...)
    at ...SmileGenerator._writeNonSharedString(...)
    at ...SmileGenerator.writeString(...)
```

## Fix

Compute `maxLen` in `long` at all four sites where this guard appears, so oversized values are correctly routed to the chunked `_mediumUTF8Encode` path:

- `_writeNonShortFieldName` (long field-name path)
- `_writeNonSharedString` (`writeString(String)` — the reported stack)
- `writeString(char[], off, len)` (long char[] string path)
- `writeUTF8String(byte[], off, len)` (raw UTF-8 write path)

## Test

Adds `SmileGeneratorHugeStringTest`, a regression test covering the `String` and `char[]` value paths. A genuine reproduction needs a ~1.4 GB `char[]`, which exceeds the module's default `-Xmx1024m` test heap, so the test **self-skips via `assumeTrue`** in normal CI and runs only when a large heap is available (verified with `-Xmx6g`).

Verified that reverting the fix makes this test reproduce the exact `ArrayIndexOutOfBoundsException: Index 8000 out of bounds for length 8000` from the report, and the fix makes it pass.

Note: no `release-notes/VERSION` or `release-notes/CREDITS` entries are included in this PR.