### PR TITLE
Fix #735: CBOR stringref property-name paths pass length marker instead of actual length

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/dataformat/cbor/CBORParser.java
@@ -1614,6 +1614,7 @@ public class CBORParser extends ParserMinimalBase
             _sharedString = null;
             String name;
             boolean chunked = false;
+            int nameLen = lenMarker;
             if (lenMarker <= 23) {
                 // NOTE: [dataformats-binary#725] `maxNameLength` NOT enforced for
                 //   these shortest (at most 23 bytes) names; see
@@ -1646,10 +1647,11 @@ public class CBORParser extends ParserMinimalBase
                     //    decoding (or even reading) content
                     _streamReadConstraints.validateNameLength(actualLen);
                     name = _decodeLongerName(actualLen);
+                    nameLen = actualLen;
                 }
             }
             if (!chunked && !_stringRefs.empty() &&
-                    shouldReferenceString(_stringRefs.peek().stringRefs.size(), lenMarker)) {
+                    shouldReferenceString(_stringRefs.peek().stringRefs.size(), nameLen)) {
                 _stringRefs.peek().stringRefs.add(name);
                 _sharedString = name;
             }
@@ -3123,6 +3125,7 @@ CBORConstants.MAJOR_TYPE_BYTES, type);
         final int lenMarker = ch & 0x1F;
         boolean chunked = false;
         String name;
+        int nameLen = lenMarker;
         if (lenMarker <= 23) {
             // NOTE: [dataformats-binary#725] `maxNameLength` NOT enforced for
             //   these shortest (at most 23 bytes) names: enforcement is
@@ -3156,10 +3159,11 @@ CBORConstants.MAJOR_TYPE_BYTES, type);
                 //    decoding (or even reading) content
                 _streamReadConstraints.validateNameLength(actualLen);
                 name = _decodeLongerName(actualLen);
+                nameLen = actualLen;
             }
         }
         if (!chunked && !_stringRefs.empty() &&
-                shouldReferenceString(_stringRefs.peek().stringRefs.size(), lenMarker)) {
+                shouldReferenceString(_stringRefs.peek().stringRefs.size(), nameLen)) {
             _stringRefs.peek().stringRefs.add(name);
             _sharedString = name;
         }

--- a/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/StringrefTest.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/dataformat/cbor/StringrefTest.java
@@ -605,6 +605,36 @@ public class StringrefTest extends CBORTestBase
         assertToken(JsonToken.END_ARRAY, parser.nextToken());
     }
 
+    // [dataformats-binary#735]: property name marker (24-27), not actual length,
+    // was passed to shouldReferenceString(), so a non-canonically-encoded short
+    // name (marker 24, length 2) got registered when it should have been skipped.
+    @Test
+    public void testNonCanonicalLengthPropertyName() throws Exception {
+        byte[] bytes = new byte[]{
+                (byte) 0xD9, 0x01, 0x00, (byte) 0xA3,
+                0x78, 0x02, 0x61, 0x62, 0x01,
+                0x68, 0x6C, 0x6F, 0x6E, 0x67, 0x6E, 0x61, 0x6D, 0x65, 0x02,
+                (byte) 0xD8, 0x19, 0x00, 0x03
+        };
+        CBORParser parser = cborParser(bytes);
+        assertToken(JsonToken.START_OBJECT, parser.nextToken());
+        assertToken(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("ab", parser.currentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(1, parser.getValueAsInt());
+        assertToken(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("longname", parser.currentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(2, parser.getValueAsInt());
+        // "ab" is only 2 bytes so it must not have been registered as index 0;
+        // the backreference below must resolve to "longname" instead
+        assertToken(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("longname", parser.currentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(3, parser.getValueAsInt());
+        assertToken(JsonToken.END_OBJECT, parser.nextToken());
+    }
+
     @Test
     public void testNestedTags() throws Exception {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -461,3 +461,8 @@ Benjamin Muschko (@bmuschko)
 * Reported #720: (smile) `SmileGenerator` int overflow in `maxLen` for very long
   Strings causes `ArrayIndexOutOfBoundsException`
  (2.21.6)
+
+arimu1 (@arimu1)
+* Contributed fix for #735: (cbor) "stringref" property-name paths pass 5-bit
+  length marker instead of actual length to `shouldReferenceString()`
+ (2.21.6)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -32,6 +32,8 @@ Active maintainers:
   marker 23 with 24 ("1-byte length suffix follows")
 #728: (cbor) `CBORParser.nextFieldName(SerializableString)` consumes Object entry
   slot twice on fast-path miss, truncating definite-length Objects
+#735: (cbor) "stringref" property-name paths pass 5-bit length marker instead of
+  actual length to `shouldReferenceString()`
 
 2.21.5 (06-Jul-2026)
 


### PR DESCRIPTION
Fixes https://github.com/FasterXML/jackson-dataformats-binary/issues/735

### Problem

On the Object property-name decode paths, `CBORParser` decided whether a
name should be added to the CBOR "stringref" reference table by passing
the raw 5-bit length marker to `shouldReferenceString()` instead of the
name's actual decoded byte length:

- `nextFieldName()` fast path
- `_decodePropertyName()`

For markers 0-23 the marker *is* the length, so those paths were correct.
For markers 24-27 ("1/2/4/8-byte length suffix follows") the marker value
itself (24, 25, 26, or 27) was passed on unconditionally. Since
`CBORConstants.shouldReferenceString()`'s thresholds top out at 7 bytes,
markers 24-27 satisfy every threshold regardless of the name's real
length.

That means a non-canonically encoded short name (legal-but-non-minimal
CBOR, e.g. marker 24 with an explicit length of 2, `0x78 0x02 'a' 'b'`)
gets registered in the parser's stringref table when a conformant encoder
would have skipped it (its real length is below the threshold for the
current index). The parser's table then desyncs from the encoder's from
that point on, so later backreferences resolve to the wrong String or
fail with "String reference out of range".

All the value paths (`_finishShortText()`, `_finishLongText()`,
`_finishBytes()`) already pass the real decoded length, so this brought
the two name paths in line with them.

### Fix

Both sites now track the actual decoded length (the explicit length read
from the 1/2/4/8-byte suffix when present) in a separate `nameLen`
variable and pass that to `shouldReferenceString()` instead of the raw
`lenMarker`.

### Testing

Added `StringrefTest#testNonCanonicalLengthPropertyName`, which encodes a
property name with a non-canonical length prefix (`0x78 0x02 'a' 'b'`,
the issue's example) inside a stringref namespace, followed by a longer
canonical name and a stringref backreference, and asserts the
backreference resolves to the correctly-registered name. Reverting the
fix locally reproduces the bug: the backreference resolves to `"ab"`
instead of `"longname"`.

Ran the CBOR module's full test suite (JDK 17): 459 tests, 0 failures.

Targeted `2.21` per this repo's branch model (oldest maintained 2.x line;
merges forward through `2.22` -> `2.x` -> `3.1` -> ... automatically).