### PR TITLE
Swapped constants in _expandSeenNames / _expandSeenStringValues

### DIFF
--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
@@ -574,7 +574,7 @@ versionBits);
            newShared = oldShared;
            _seenStringValueCount = 0; // could also clear, but let's not yet bother
         } else {
-            int newSize = (len == DEFAULT_NAME_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_STRING_VALUES;
+            int newSize = (len == DEFAULT_STRING_VALUE_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_STRING_VALUES;
             newShared = Arrays.copyOf(oldShared, newSize);
         }
         _seenStringValues = newShared;
@@ -1853,7 +1853,7 @@ _typeAsInt);
       	   newShared = oldShared;
       	   _seenNameCount = 0; // could also clear, but let's not yet bother
         } else {
-            int newSize = (len == DEFAULT_STRING_VALUE_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_NAMES;
+            int newSize = (len == DEFAULT_NAME_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_NAMES;
             newShared = Arrays.copyOf(oldShared, newSize);
         }
         return newShared;


### PR DESCRIPTION
Fix: Swapped constants in _expandSeenNames / _expandSeenStringValues

SmileParser.java:577, 1856 — Each method was checking the other method's default buffer length constant:

- _expandSeenStringValues checked DEFAULT_NAME_BUFFER_LENGTH → fixed to DEFAULT_STRING_VALUE_BUFFER_LENGTH
- _expandSeenNames checked DEFAULT_STRING_VALUE_BUFFER_LENGTH → fixed to DEFAULT_NAME_BUFFER_LENGTH

Both constants are 64 today, so the growth logic (64 → 256 → MAX) worked by coincidence. If either constant were changed independently, the growth path would silently break — _expandSeenNames would jump straight from 64 to MAX_SHARED_NAMES (1024) skipping the intermediate 256, or vice versa.
