### PR TITLE
use java 17 features

### DIFF
--- a/avro/src/main/java/tools/jackson/dataformat/avro/AvroAnnotationIntrospector.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/AvroAnnotationIntrospector.java
@@ -81,7 +81,7 @@ public class AvroAnnotationIntrospector extends AnnotationIntrospector
         if (ann == null) {
             return null;
         }
-        return Collections.singletonList(PropertyName.construct(ann.alias()));
+        return List.of(PropertyName.construct(ann.alias()));
     }
 
     protected PropertyName _findName(Annotated a)
@@ -100,8 +100,7 @@ public class AvroAnnotationIntrospector extends AnnotationIntrospector
 
     @Override
     public JsonCreator.Mode findCreatorAnnotation(MapperConfig<?> config, Annotated a) {
-        if (a instanceof AnnotatedConstructor) {
-            AnnotatedConstructor constructor = (AnnotatedConstructor) a;
+        if (a instanceof AnnotatedConstructor constructor) {
             // 09-Mar-2017, tatu: Ideally would allow mix-ins etc, but for now let's take
             //   a short-cut here:
             Class<?> declClass = constructor.getDeclaringClass();

--- a/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/schema/AvroSchemaHelper.java
@@ -59,11 +59,11 @@ public abstract class AvroSchemaHelper
     /**
      * Default stringable classes
      */
-    protected static final Set<Class<?>> STRINGABLE_CLASSES = new HashSet<>(Arrays.asList(
+    protected static final Set<Class<?>> STRINGABLE_CLASSES = Set.of(
             URI.class, URL.class, File.class,
             BigInteger.class, BigDecimal.class,
             String.class
-    ));
+    );
 
     /**
      * Checks if a given type is "Stringable", that is one of the default
@@ -206,7 +206,7 @@ public abstract class AvroSchemaHelper
 
     public static Schema anyNumberSchema()
     {
-        return Schema.createUnion(Arrays.asList(
+        return Schema.createUnion(List.of(
                 Schema.create(Schema.Type.INT),
                 Schema.create(Schema.Type.LONG),
                 Schema.create(Schema.Type.DOUBLE)

--- a/avro/src/main/java/tools/jackson/dataformat/avro/schema/RecordVisitor.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/schema/RecordVisitor.java
@@ -254,8 +254,7 @@ public class RecordVisitor
                 ValueSerializer<?> ser = null;
 
                 // 23-Nov-2012, tatu: Ideally shouldn't need to do this but...
-                if (prop instanceof BeanPropertyWriter) {
-                    BeanPropertyWriter bpw = (BeanPropertyWriter) prop;
+                if (prop instanceof BeanPropertyWriter bpw) {
                     ser = bpw.getSerializer();
                     // 2-Mar-2017, bryan: AvroEncode annotation expects to have the schema used directly
                     optional = optional && !(ser instanceof CustomEncodingSerializer); // Don't modify schema

--- a/avro/src/main/java/tools/jackson/dataformat/avro/ser/CustomEncodingSerializer.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/ser/CustomEncodingSerializer.java
@@ -37,8 +37,8 @@ public class CustomEncodingSerializer<T> extends ValueSerializer<T> {
     @Override
     public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType type)
     {
-        if (visitor instanceof VisitorFormatWrapperImpl) {
-            ((VisitorFormatWrapperImpl) visitor).expectAvroFormat(new AvroSchema(encoding.getSchema()));
+        if (visitor instanceof VisitorFormatWrapperImpl wrapper) {
+            wrapper.expectAvroFormat(new AvroSchema(encoding.getSchema()));
         } else {
             super.acceptJsonFormatVisitor(visitor, type);
         }

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORParser.java
@@ -806,8 +806,8 @@ public class CBORParser extends ParserBase
             }
 
             Object str = stringRefs.stringRefs.get(i);
-            if (str instanceof String) {
-                return (String) str;
+            if (str instanceof String s) {
+                return s;
             }
             return new String((byte[]) str, UTF8);
         }
@@ -833,8 +833,8 @@ public class CBORParser extends ParserBase
         }
 
         Object str = stringRefs.stringRefs.get(_numberInt);
-        if (str instanceof String) {
-            _sharedString = (String) str;
+        if (str instanceof String s) {
+            _sharedString = s;
             return _updateToken(JsonToken.VALUE_STRING);
         }
         _binaryValue = (byte[]) str;

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORSimpleValue.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORSimpleValue.java
@@ -53,8 +53,7 @@ public class CBORSimpleValue {
     public boolean equals(Object o)
     {
         if (o == this) return true;
-        if (o instanceof CBORSimpleValue) {
-            CBORSimpleValue other = (CBORSimpleValue) o;
+        if (o instanceof CBORSimpleValue other) {
             return _value == other._value;
         }
         return false;

--- a/ion/src/main/java/tools/jackson/dataformat/ion/EnumAsIonSymbolSerializer.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/EnumAsIonSymbolSerializer.java
@@ -42,12 +42,12 @@ public class EnumAsIonSymbolSerializer extends StdScalarSerializer<Enum<?>>
 
     @Override
     public void serialize(Enum<?> value, JsonGenerator g, SerializationContext provider) {
-        if (g instanceof IonGenerator) {
+        if (g instanceof IonGenerator ionGenerator) {
             String valueString = provider.isEnabled(EnumFeature.WRITE_ENUMS_USING_TO_STRING)
                 ? value.toString()
                 : value.name();
 
-            ((IonGenerator) g).writeSymbol(valueString);
+            ionGenerator.writeSymbol(valueString);
         } else {
             throw new StreamWriteException(g, "Can only use EnumAsIonSymbolSerializer with IonGenerator");
         }

--- a/ion/src/main/java/tools/jackson/dataformat/ion/IonGenerator.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/IonGenerator.java
@@ -148,8 +148,8 @@ public class IonGenerator
             _destination.close();
         } else {
             if (isEnabled(StreamWriteFeature.FLUSH_PASSED_TO_STREAM)) {
-                if (_destination instanceof Flushable) {
-                    ((Flushable) _destination).flush();
+                if (_destination instanceof Flushable flushable) {
+                    flushable.flush();
                 }
             }
         }
@@ -692,8 +692,7 @@ public class IonGenerator
 
     @Override
     public JsonGenerator writeTypeId(Object rawId) throws JacksonException {
-        if (rawId instanceof String[]) {
-            String[] ids = (String[]) rawId;
+        if (rawId instanceof String[] ids) {
             for (String id : ids) {
                 annotateNextValue(id);
             }

--- a/ion/src/main/java/tools/jackson/dataformat/ion/IonParser.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/IonParser.java
@@ -166,9 +166,9 @@ public class IonParser
         // should only close if manage the resource
         if (_ioContext.isResourceManaged()) {
             Object src = _ioContext.contentReference().getRawContent();
-            if (src instanceof Closeable) {
+            if (src instanceof Closeable closeable) {
                 try {
-                    ((Closeable) src).close();
+                    closeable.close();
                 } catch (IOException e) {
                     throw _wrapIOFailure(e);
                 }

--- a/ion/src/main/java/tools/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/ionvalue/IonValueDeserializer.java
@@ -48,8 +48,8 @@ class IonValueDeserializer extends ValueDeserializer<IonValue>
     public IonValue deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException
     {
         Object embeddedObject = jp.getEmbeddedObject();
-        if (embeddedObject instanceof IonValue) {
-            return (IonValue) embeddedObject;
+        if (embeddedObject instanceof IonValue ionValue) {
+            return ionValue;
         }
         // We rely on the IonParser's IonSystem to wrap supported types into an IonValue
         if (!(jp instanceof IonParser)) {
@@ -58,8 +58,8 @@ class IonValueDeserializer extends ValueDeserializer<IonValue>
         }
 
         IonSystem ionSystem = ((IonParser) jp).getIonSystem();
-        if (embeddedObject instanceof Timestamp) {
-            return ionSystem.newTimestamp((Timestamp) embeddedObject);
+        if (embeddedObject instanceof Timestamp timestamp) {
+            return ionSystem.newTimestamp(timestamp);
         }
         if (embeddedObject instanceof byte[]) {
             // The parser provides no distinction between BLOB and CLOB, deserializing to a BLOB is the safest choice.
@@ -74,8 +74,7 @@ class IonValueDeserializer extends ValueDeserializer<IonValue>
         final JsonParser parser = ctxt.getParser();
         if (parser != null && parser.currentToken() != JsonToken.END_OBJECT) {
             final Object embeddedObj = parser.getEmbeddedObject();
-            if (embeddedObj instanceof IonValue) {
-                IonValue iv = (IonValue) embeddedObj;
+            if (embeddedObj instanceof IonValue iv) {
                 if (iv.isNullValue()) {
                     if (IonType.isContainer(iv.getType())) {
                         return iv;

--- a/ion/src/main/java/tools/jackson/dataformat/ion/ionvalue/TimestampSerializer.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/ionvalue/TimestampSerializer.java
@@ -32,8 +32,8 @@ class TimestampSerializer extends StdScalarSerializer<Timestamp>
 
     @Override
     public void serialize(Timestamp value, JsonGenerator g, SerializationContext ctxt) {
-        if (g instanceof IonGenerator) {
-            ((IonGenerator) g).writeValue(value);
+        if (g instanceof IonGenerator ionGenerator) {
+            ionGenerator.writeValue(value);
         } else {
             // Otherwise probably `TokenBuffer`, so
             g.writeEmbeddedObject(value);

--- a/ion/src/main/java/tools/jackson/dataformat/ion/polymorphism/IonAnnotationTypeDeserializer.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/polymorphism/IonAnnotationTypeDeserializer.java
@@ -55,8 +55,8 @@ public class IonAnnotationTypeDeserializer extends TypeDeserializerBase
     }
 
     private IonParser ionParser(JsonParser p) throws StreamReadException {
-        if (p instanceof IonParser) {
-            return (IonParser) p;
+        if (p instanceof IonParser ionParser) {
+            return ionParser;
         }
         throw new StreamReadException(p,
                 "Can only use IonAnnotationTypeDeserializer with IonParser");
@@ -68,8 +68,8 @@ public class IonAnnotationTypeDeserializer extends TypeDeserializerBase
         String[] typeIds = ionParser(p).getTypeAnnotations(); //cannot return null
         String typeIdToUse = null;
         TypeIdResolver typeIdResolver = super.getTypeIdResolver();
-        if (typeIdResolver instanceof MultipleTypeIdResolver) {
-            typeIdToUse = ((MultipleTypeIdResolver) typeIdResolver).selectId(typeIds);
+        if (typeIdResolver instanceof MultipleTypeIdResolver multiResolver) {
+            typeIdToUse = multiResolver.selectId(typeIds);
         } else if (null != typeIdResolver) {
             // Possibly multiple ids, but we don't have a polymorphic resolver; pick the first one which resolves
             for (String typeId : typeIds) {

--- a/ion/src/main/java/tools/jackson/dataformat/ion/polymorphism/IonAnnotationTypeSerializer.java
+++ b/ion/src/main/java/tools/jackson/dataformat/ion/polymorphism/IonAnnotationTypeSerializer.java
@@ -80,8 +80,8 @@ public class IonAnnotationTypeSerializer extends TypeSerializerBase
         if (id == null) {
             final Object value = idMetadata.forValue;
             TypeIdResolver resolver = getTypeIdResolver();
-            if (resolver instanceof MultipleTypeIdResolver) {
-                id = ((MultipleTypeIdResolver)resolver).idsFromValue(ctxt, value);
+            if (resolver instanceof MultipleTypeIdResolver multiResolver) {
+                id = multiResolver.idsFromValue(ctxt, value);
             } else {
                 Class<?> typeForId = idMetadata.forValueType;
                 if (typeForId == null) {

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/ProtobufGenerator.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/ProtobufGenerator.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import tools.jackson.core.*;
@@ -1344,7 +1345,7 @@ public class ProtobufGenerator extends GeneratorBase
     /**********************************************************************
      */
 
-    private final static Charset UTF8 = Charset.forName("UTF-8");
+    private final static Charset UTF8 = StandardCharsets.UTF_8;
 
     protected void _encodeLongerString(char[] text, int offset, int clen) throws JacksonException
     {

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/EnumLookup.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/EnumLookup.java
@@ -68,7 +68,7 @@ public abstract class EnumLookup
 
         @Override
         public Collection<String> getEnumValues() {
-            return Collections.emptySet();
+            return Set.of();
         }
 
         @Override
@@ -113,7 +113,7 @@ public abstract class EnumLookup
 
         @Override
         public Collection<String> getEnumValues() {
-            return Collections.singletonList(key1);
+            return List.of(key1);
         }
     }
 
@@ -179,7 +179,7 @@ public abstract class EnumLookup
 
         @Override
         public Collection<String> getEnumValues() {
-            return Arrays.asList(key1, key2);
+            return List.of(key1, key2);
         }
     }
 
@@ -243,7 +243,7 @@ public abstract class EnumLookup
 
         @Override
         public Collection<String> getEnumValues() {
-            return Arrays.asList(key1, key2, key3);
+            return List.of(key1, key2, key3);
         }
 
         private int _findIndex2(String key) {

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/FieldTypes.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/FieldTypes.java
@@ -26,8 +26,8 @@ public class FieldTypes
     }
 
     private FieldType _findType(DataType rawType) {
-        if (rawType instanceof DataType.ScalarType) {
-            return instance._types.get(rawType);
+        if (rawType instanceof DataType.ScalarType scalarType) {
+            return instance._types.get(scalarType);
         }
         return null;
     }

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/NativeProtobufSchema.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/NativeProtobufSchema.java
@@ -117,8 +117,8 @@ public class NativeProtobufSchema
 
     protected MessageElement _firstMessageType() {
         for (TypeElement type : _nativeTypes) {
-            if (type instanceof MessageElement) {
-                return (MessageElement) type;
+            if (type instanceof MessageElement msg) {
+                return msg;
             }
         }
         return null;
@@ -126,9 +126,9 @@ public class NativeProtobufSchema
 
     protected MessageElement _messageType(String name) {
         for (TypeElement type : _nativeTypes) {
-            if ((type instanceof MessageElement)
+            if ((type instanceof MessageElement msg)
                     && name.equals(type.name())) {
-                return (MessageElement) type;
+                return msg;
             }
         }
         return null;

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/ProtobufField.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/ProtobufField.java
@@ -218,8 +218,8 @@ public class ProtobufField
         for (OptionElement opt : f.options()) {
             if (key.equals(opt.name())) {
                 Object val = opt.value();
-                if (val instanceof Boolean) {
-                    return (Boolean) val;
+                if (val instanceof Boolean boolVal) {
+                    return boolVal;
                 }
                 return Boolean.valueOf("true".equals(String.valueOf(val).trim()));
             }

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/ProtobufSchemaLoader.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/ProtobufSchemaLoader.java
@@ -3,6 +3,7 @@ package tools.jackson.dataformat.protobuf.schema;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import com.squareup.protoparser.ProtoFile;
@@ -22,7 +23,7 @@ public class ProtobufSchemaLoader
 {
     private static final long serialVersionUID = 1L;
 
-    private final static Charset UTF8 = Charset.forName("UTF-8");
+    private final static Charset UTF8 = StandardCharsets.UTF_8;
 
     public final static String DEFAULT_SCHEMA_NAME = "Unnamed-protobuf-schema";
 

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/ProtobufSchemaPreprocessor.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/ProtobufSchemaPreprocessor.java
@@ -1,8 +1,6 @@
 package tools.jackson.dataformat.protobuf.schema;
 
-import java.util.Arrays;
 import java.util.BitSet;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -48,11 +46,11 @@ class ProtobufSchemaPreprocessor
      * Statement-leading keywords that may appear in a message / extend body but
      * do NOT begin a label-less field, and so must never receive an injected label.
      */
-    private static final Set<String> NON_FIELD_KEYWORDS = new HashSet<String>(Arrays.asList(
+    private static final Set<String> NON_FIELD_KEYWORDS = Set.of(
             "message", "enum", "oneof", "extend", "group",
             "option", "reserved", "extensions",
             "required", "optional", "repeated"
-    ));
+    );
 
     private final char[] _data;
     private final int _end;

--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/TypeResolver.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/TypeResolver.java
@@ -57,10 +57,10 @@ public class TypeResolver
         _enumTypes = enums;
         _isProto3 = isProto3;
         if (declaredMsgs == null) {
-            declaredMsgs = Collections.emptyMap();
+            declaredMsgs = Map.of();
         }
         _declaredMessageTypes = declaredMsgs;
-        _resolvedMessageTypes = Collections.emptyMap();
+        _resolvedMessageTypes = Map.of();
     }
 
     /**
@@ -89,13 +89,13 @@ public class TypeResolver
         Map<String,ProtobufEnum> declaredEnums = new LinkedHashMap<>();
 
         for (TypeElement nt : nativeTypes) {
-            if (nt instanceof MessageElement) {
+            if (nt instanceof MessageElement msgElement) {
                 if (declaredMsgs == null) {
                     declaredMsgs = new LinkedHashMap<String,MessageElement>();
                 }
-                declaredMsgs.put(nt.name(), (MessageElement) nt);
-            } else if (nt instanceof EnumElement) {
-                final ProtobufEnum enumType = constructEnum((EnumElement) nt);
+                declaredMsgs.put(nt.name(), msgElement);
+            } else if (nt instanceof EnumElement enumEl) {
+                final ProtobufEnum enumType = constructEnum(enumEl);
                 declaredEnums.put(nt.name(), enumType);
                 // ... and don't forget parent scopes!
                 if (parent != null) {
@@ -171,8 +171,8 @@ public class TypeResolver
 
             if (type != null) { // simple type
                 pbf = new ProtobufField(f, type, _isProto3);
-            } else if (fieldType instanceof DataType.NamedType) {
-                final String typeStr = ((DataType.NamedType) fieldType).name();
+            } else if (fieldType instanceof DataType.NamedType namedType) {
+                final String typeStr = namedType.name();
 
                 // If not, a resolved local definition?
                 ProtobufField resolvedF = _findLocalResolved(f, typeStr);
@@ -199,11 +199,11 @@ public class TypeResolver
                         }
                     }
                 }
-            } else if (fieldType instanceof DataType.MapType) {
+            } else if (fieldType instanceof DataType.MapType mapType) {
                 // 15-Jul-2026, tatu: [dataformats-binary#712] `map<K,V>` is encoded
                 //   exactly like a `repeated` entry sub-message; synthesize that entry
                 //   type and expose the field as a map.
-                pbf = _resolveMapField(f, (DataType.MapType) fieldType, rawType);
+                pbf = _resolveMapField(f, mapType, rawType);
             } else {
                 throw new IllegalArgumentException(String.format(
                         "Unrecognized DataType '%s' for field '%s'", fieldType.getClass().getName(), f.name()));
@@ -341,8 +341,8 @@ public class TypeResolver
         for (OptionElement opt : rawType.options()) {
             if ("map_entry".equals(opt.name())) {
                 Object v = opt.value();
-                if (v instanceof Boolean) {
-                    return ((Boolean) v).booleanValue();
+                if (v instanceof Boolean boolVal) {
+                    return boolVal.booleanValue();
                 }
                 return "true".equals(String.valueOf(v).trim());
             }
@@ -357,8 +357,8 @@ public class TypeResolver
      */
     private static void _verifyMapKeyType(DataType keyType, FieldElement f, MessageElement rawType)
     {
-        if (keyType instanceof DataType.ScalarType) {
-            switch ((DataType.ScalarType) keyType) {
+        if (keyType instanceof DataType.ScalarType scalarType) {
+            switch (scalarType) {
             case DOUBLE:
             case FLOAT:
             case BYTES:

--- a/protobuf/src/test/java/tools/jackson/dataformat/protobuf/schema/Proto3LabellessField708Test.java
+++ b/protobuf/src/test/java/tools/jackson/dataformat/protobuf/schema/Proto3LabellessField708Test.java
@@ -5,7 +5,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -219,7 +219,7 @@ public class Proto3LabellessField708Test extends ProtobufTestBase
                 + "  int32 x = 1;\n"
                 + "}\n";
         ProtobufSchema schema = ProtobufSchemaLoader.std.load(
-                new ByteArrayInputStream(proto.getBytes(Charset.forName("UTF-8"))));
+                new ByteArrayInputStream(proto.getBytes(StandardCharsets.UTF_8)));
         assertNotNull(schema.getRootType().field("x"));
     }
 
@@ -233,7 +233,7 @@ public class Proto3LabellessField708Test extends ProtobufTestBase
                 + "}\n";
         File f = File.createTempFile("proto708-", ".proto");
         f.deleteOnExit();
-        Writer w = new OutputStreamWriter(new FileOutputStream(f), Charset.forName("UTF-8"));
+        Writer w = new OutputStreamWriter(new FileOutputStream(f), StandardCharsets.UTF_8);
         try {
             w.write(proto);
         } finally {

--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
@@ -17,24 +17,6 @@ import tools.jackson.core.util.ByteArrayBuilder;
 
 public class SmileParser extends SmileParserBase
 {
-    /**
-     * Flag to indicate if the JDK version is 11 or later. This can be used in some methods
-     * to choose more optimal behavior. In particular, jdk9+ have different internals for
-     * the String class.
-     */
-    private static final boolean JDK11_OR_LATER;
-    static {
-        boolean recentJdk;
-        try {
-            // The strip method was added in jdk11, so use it to detect a newer version
-            String.class.getMethod("strip");
-            recentJdk = true;
-        } catch (Exception e) {
-            recentJdk = false;
-        }
-        JDK11_OR_LATER = recentJdk;
-    }
-
     /*
     /**********************************************************************
     /* Input source config, state (from ex StreamBasedParserBase)
@@ -1878,26 +1860,12 @@ _typeAsInt);
     {
         // note: caller ensures we have enough bytes available
         // also note that since it's a short name (64 bytes), segment WILL have enough space
-        if (JDK11_OR_LATER) {
-            // On newer JDKs the String internals changed and for ASCII strings the constructor
-            // that takes a byte array can be used and internally is just Arrays.copyOfRange.
-            final int inPtr = _inputPtr;
-            _inputPtr = inPtr + len;
-            String str = new String(_inputBuffer, inPtr, len, StandardCharsets.US_ASCII);
-            _textBuffer.resetWithString(str);
-            return str;
-        } else {
-            char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
-            int outPtr = 0;
-            final byte[] inBuf = _inputBuffer;
-            int inPtr = _inputPtr;
-
-            for (int inEnd = inPtr + len; inPtr < inEnd; ++inPtr) {
-                outBuf[outPtr++] = (char) inBuf[inPtr];
-            }
-            _inputPtr = inPtr;
-            return _textBuffer.setCurrentAndReturn(len);
-        }
+        // Java 17+ has optimized String constructor for ASCII byte arrays
+        final int inPtr = _inputPtr;
+        _inputPtr = inPtr + len;
+        String str = new String(_inputBuffer, inPtr, len, StandardCharsets.US_ASCII);
+        _textBuffer.resetWithString(str);
+        return str;
     }
 
     /**
@@ -2768,27 +2736,12 @@ currentToken(), firstCh);
             _loadToHaveAtLeast(len);
         }
 
-        if (JDK11_OR_LATER) {
-            // On newer JDKs the String internals changed and for ASCII strings the constructor
-            // that takes a byte array can be used and internally is just Arrays.copyOfRange.
-            final int inPtr = _inputPtr;
-            _inputPtr = inPtr + len;
-            String str = new String(_inputBuffer, inPtr, len, StandardCharsets.US_ASCII);
-            _textBuffer.resetWithString(str);
-            return str;
-        } else {
-            // Note: we count on fact that buffer must have at least 'len' (<= 64) empty char slots
-            final char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
-            int outPtr = 0;
-            final byte[] inBuf = _inputBuffer;
-            int inPtr = _inputPtr;
-
-            for (final int end = inPtr + len; inPtr < end; ++inPtr) {
-                outBuf[outPtr++] = (char) inBuf[inPtr];
-            }
-            _inputPtr = inPtr;
-            return _textBuffer.setCurrentAndReturn(len);
-        }
+        // Java 17+ has optimized String constructor for ASCII byte arrays
+        final int inPtr = _inputPtr;
+        _inputPtr = inPtr + len;
+        String str = new String(_inputBuffer, inPtr, len, StandardCharsets.US_ASCII);
+        _textBuffer.resetWithString(str);
+        return str;
     }
 
     protected final String _decodeShortUnicodeValue(int byteLen) throws JacksonException


### PR DESCRIPTION
Dead JDK detection removed (Smile)

- SmileParser.java — Removed JDK11_OR_LATER reflection check and two dead else branches in _decodeShortAsciiName and _decodeShortAsciiValue (-53 lines)

Collections/Arrays → List.of()/Set.of()/Map.of()

- AvroAnnotationIntrospector.java — Collections.singletonList → List.of
- AvroSchemaHelper.java — new HashSet<>(Arrays.asList(...)) → Set.of(...), Arrays.asList → List.of
- EnumLookup.java — Collections.emptySet → Set.of, Collections.singletonList → List.of, Arrays.asList → List.of
- TypeResolver.java — Collections.emptyMap → Map.of
- ProtobufSchemaPreprocessor.java — new HashSet<>(Arrays.asList(...)) → Set.of(...)

Charset.forName("UTF-8") → StandardCharsets.UTF_8

- ProtobufGenerator.java
- ProtobufSchemaLoader.java
- Proto3LabellessField708Test.java

instanceof pattern matching (Java 16)

- avro (3 sites) — AvroAnnotationIntrospector, CustomEncodingSerializer, RecordVisitor
- cbor (3 sites) — CBORParser (2), CBORSimpleValue
- ion (11 sites) — IonGenerator (2), IonParser, IonValueDeserializer (3), TimestampSerializer, EnumAsIonSymbolSerializer, IonAnnotationTypeDeserializer (2), IonAnnotationTypeSerializer
- protobuf (9 sites) — TypeResolver (6), NativeProtobufSchema (2), ProtobufField, FieldTypes