### PR TITLE
reduce smile buffer expansion

### DIFF
--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileGenerator.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileGenerator.java
@@ -1075,7 +1075,8 @@ public class SmileGenerator
             }
         } else { // "long" String
             // but might still fit within buffer?
-            long maxLen = (long) len + len + len + 2;
+            // Input is already UTF-8 encoded, so no expansion needed — just type byte + end marker
+            long maxLen = (long) len + 2;
             if (maxLen <= _outputBuffer.length) { // yes indeed
                 if ((_outputTail + maxLen) >= _outputEnd) {
                     _flushBuffer();


### PR DESCRIPTION
Suggested by Claude AI and looks plausible

The fix changes len + len + len + 2 (3x expansion + header) to len + 2 (just header) in writeRawUTF8String, since the input bytes are already UTF-8 encoded and don't need expansion. This avoids unnecessary falls to the slower _writeBytes streaming path for long strings that would comfortably fit in the buffer.