### PR TITLE
Follow-up to #745: fix BigDecimal union regression, root union-to-map

### DIFF
--- a/avro/src/main/java/tools/jackson/dataformat/avro/ser/AvroWriteContext.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/ser/AvroWriteContext.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.UnresolvedUnionException;
@@ -440,9 +441,12 @@ public abstract class AvroWriteContext
             Schema schema = types.get(i);
             Schema.Type t = schema.getType();
 
-            // Prefer String or Bytes with logical type info for BigDecimal;
-            // fall back to DOUBLE if nothing better is found
-            if (t == Type.STRING || t == Type.BYTES) {
+            // Prefer String, or Bytes with "decimal" logical type, for BigDecimal;
+            // fall back to DOUBLE if nothing better is found.
+            // NOTE: plain `bytes` (without logical type) must NOT be chosen, since
+            // conversion to bytes requires the "decimal" logical type to exist
+            if (t == Type.STRING
+                    || (t == Type.BYTES && schema.getLogicalType() instanceof LogicalTypes.Decimal)) {
                 return i;
             }
             if (t == Type.DOUBLE) {

--- a/avro/src/main/java/tools/jackson/dataformat/avro/ser/AvroWriteContext.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/ser/AvroWriteContext.java
@@ -435,29 +435,41 @@ public abstract class AvroWriteContext
 
     private static int _resolveBigDecimalIndex(Schema unionSchema, List<Schema> types,
             BigDecimal value) {
-        int match = -1;
+        // Branches are considered in order of how well they retain the value,
+        // regardless of declaration order: "decimal" first, then String, then Double
+        int stringMatch = -1;
+        int doubleMatch = -1;
 
         for (int i = 0, size = types.size(); i < size; ++i) {
             Schema schema = types.get(i);
             Schema.Type t = schema.getType();
 
-            // Prefer String, or Bytes with "decimal" logical type, for BigDecimal;
-            // fall back to DOUBLE if nothing better is found.
-            // NOTE: plain `bytes` (without logical type) must NOT be chosen, since
-            // conversion to bytes requires the "decimal" logical type to exist
-            if (t == Type.STRING
-                    || (t == Type.BYTES && schema.getLogicalType() instanceof LogicalTypes.Decimal)) {
-                return i;
-            }
-            if (t == Type.DOUBLE) {
-                match = i;
-                continue;
+            if (t == Type.BYTES || t == Type.FIXED) {
+                // Best match: retains both scale and type.
+                // NOTE: plain `bytes`/`fixed` must NOT be chosen, since conversion
+                // requires the "decimal" logical type to exist
+                if (schema.getLogicalType() instanceof LogicalTypes.Decimal) {
+                    return i;
+                }
+            } else if (t == Type.STRING) {
+                // Second best: retains all digits, but reads back as String
+                if (stringMatch < 0) {
+                    stringMatch = i;
+                }
+            } else if (t == Type.DOUBLE) {
+                // Last resort: lossy
+                if (doubleMatch < 0) {
+                    doubleMatch = i;
+                }
             }
         }
-        if (match < 0) {
-            match = ReflectData.get().resolveUnion(unionSchema, value);
+        if (stringMatch >= 0) {
+            return stringMatch;
         }
-        return match;
+        if (doubleMatch >= 0) {
+            return doubleMatch;
+        }
+        return ReflectData.get().resolveUnion(unionSchema, value);
     }
 
     private static int _resolveMapIndex(Schema unionSchema, List<Schema> types,

--- a/avro/src/main/java/tools/jackson/dataformat/avro/ser/RootContext.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/ser/RootContext.java
@@ -59,11 +59,16 @@ class RootContext
         // verify that root type is record (or compatible)
         switch (_schema.getType()) {
         case RECORD:
-        case UNION: // maybe
             {
                 GenericRecord rec = _createRecord(_schema, currValue);
                 _rootValue = rec;
                 return new ObjectWriteContext(this, _generator, rec, currValue);
+            }
+        case UNION: // maybe: may resolve to either Record or Map
+            {
+                AvroWriteContext child = _createObjectContext(_schema, currValue);
+                _rootValue = child.rawValue();
+                return child;
             }
         case MAP: // used to not be supported
             {

--- a/avro/src/test/java/tools/jackson/dataformat/avro/BigDecimalSerializationAndDeserializationTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/BigDecimalSerializationAndDeserializationTest.java
@@ -259,4 +259,84 @@ public class BigDecimalSerializationAndDeserializationTest extends AvroTestBase 
         assertThat((Double) result.get("value")).isEqualTo(input.doubleValue());
     }
 
+    // Verify that "decimal" BYTES wins over STRING even when declared later:
+    // preference is by type fidelity, not by declaration order
+    @Test
+    public void testBigDecimalUnionPrefersBytesOverString() throws Exception
+    {
+        String schemaJson = a2q("{" +
+                "'type':'record'," +
+                "'name':'Test'," +
+                "'fields':[" +
+                "  {'name':'value', 'type':['null','string'," +
+                "    {'type':'bytes','logicalType':'decimal','precision':20,'scale':6}," +
+                "    'double']}" +
+                "]" +
+                "}");
+        AvroSchema schema = MAPPER.schemaFrom(schemaJson);
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        Map<String, Object> data = Map.of("value", input);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(data);
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(BigDecimal.class);
+        assertThat((BigDecimal) result.get("value")).isEqualByComparingTo(input);
+    }
+
+    // Verify that FIXED with "decimal" logical type is also usable for BigDecimal
+    @Test
+    public void testBigDecimalUnionPrefersFixedOverString() throws Exception
+    {
+        String schemaJson = a2q("{" +
+                "'type':'record'," +
+                "'name':'Test'," +
+                "'fields':[" +
+                "  {'name':'value', 'type':['null','string'," +
+                "    {'type':'fixed','name':'Dec','size':16," +
+                "     'logicalType':'decimal','precision':20,'scale':6}," +
+                "    'double']}" +
+                "]" +
+                "}");
+        AvroSchema schema = MAPPER.schemaFrom(schemaJson);
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        Map<String, Object> data = Map.of("value", input);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(data);
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(BigDecimal.class);
+        assertThat((BigDecimal) result.get("value")).isEqualByComparingTo(input);
+    }
+
+    // Verify that plain FIXED (without "decimal" logical type) is not chosen either
+    @Test
+    public void testBigDecimalUnionSkipsPlainFixed() throws Exception
+    {
+        String schemaJson = a2q("{" +
+                "'type':'record'," +
+                "'name':'Test'," +
+                "'fields':[" +
+                "  {'name':'value', 'type':['null'," +
+                "    {'type':'fixed','name':'Raw','size':16}," +
+                "    'double']}" +
+                "]" +
+                "}");
+        AvroSchema schema = MAPPER.schemaFrom(schemaJson);
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        Map<String, Object> data = Map.of("value", input);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(data);
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(Double.class);
+        assertThat((Double) result.get("value")).isEqualTo(input.doubleValue());
+    }
+
 }

--- a/avro/src/test/java/tools/jackson/dataformat/avro/BigDecimalSerializationAndDeserializationTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/BigDecimalSerializationAndDeserializationTest.java
@@ -233,4 +233,30 @@ public class BigDecimalSerializationAndDeserializationTest extends AvroTestBase 
         assertThat((BigDecimal) result.get("value")).isEqualByComparingTo(input);
     }
 
+    // Verify that plain BYTES (without "decimal" logical type) is NOT chosen for
+    // BigDecimal: conversion would fail, so DOUBLE must be used instead
+    @Test
+    public void testBigDecimalUnionSkipsPlainBytes() throws Exception
+    {
+        String schemaJson = a2q("{" +
+                "'type':'record'," +
+                "'name':'Test'," +
+                "'fields':[" +
+                "  {'name':'value', 'type':['null','bytes','double']}" +
+                "]" +
+                "}");
+        AvroSchema schema = MAPPER.schemaFrom(schemaJson);
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        Map<String, Object> data = Map.of("value", input);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(data);
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        // Written as DOUBLE (index 2) since plain `bytes` cannot hold a BigDecimal
+        assertThat(result.get("value")).isInstanceOf(Double.class);
+        assertThat((Double) result.get("value")).isEqualTo(input.doubleValue());
+    }
+
 }

--- a/avro/src/test/java/tools/jackson/dataformat/avro/MapWithUnionTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/MapWithUnionTest.java
@@ -131,7 +131,26 @@ public class MapWithUnionTest extends AvroTestBase
         assertEquals("bing", m.get("zap"));
     }
 
-    // Verify that a union resolving to MAP is handled correctly in _createRecord
+    // Verify that a root-level union resolving to MAP is written as a Map,
+    // and not passed to Record handling
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRootUnionResolvingToMapType() throws Exception
+    {
+        String schemaJson = a2q("['null',{'type':'map','values':'string'}]");
+        AvroSchema schema = MAPPER.schemaFrom(schemaJson);
+
+        Map<String, Object> input = Map.of("key1", "val1", "key2", "val2");
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(input);
+
+        Map<String, String> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertEquals("val1", result.get("key1"));
+        assertEquals("val2", result.get("key2"));
+    }
+
+    // Verify that a union resolving to MAP is handled correctly for Record properties
     @SuppressWarnings("unchecked")
     @Test
     public void testUnionResolvingToMapType() throws Exception


### PR DESCRIPTION
Follow-up to #745, which is already merged to `3.x`. Three issues found in post-merge review.

### 1. Plain `bytes` union branch breaks `BigDecimal` writes (regression from #745)

`_resolveBigDecimalIndex()` accepted any `BYTES` branch, but `NonBSGenericDatumWriter` calls
`BIG_DECIMAL_CONVERSION.toBytes(datum, schema, schema.getLogicalType())`, which NPEs when the
schema carries no `decimal` logical type. With union `["null","bytes","double"]` and
`BigDecimal.valueOf(123456789, 6)`:

- before #745: written as `double`, reads back `123.456789`
- after #745: `NullPointerException: null value for (non-nullable) [null, bytes, double]`

Now requires the logical type, so plain `bytes` falls through to `DOUBLE`.

### 2. Branch chosen by declaration order rather than fidelity

The loop returned the first `STRING`-or-`BYTES` match, so for
`["null","string",{"bytes",logicalType:decimal},"double"]` plain `string` won and the value
round-tripped as a `String`. Branches are now ranked: `decimal` `bytes`/`fixed`, then `String`,
then `Double`. This also considers `fixed` with a `decimal` logical type, which was skipped
entirely even though both writer and reader support it.

### 3. Root-level union resolving to `map` fails to serialize

`RootContext.createChildObjectContext()` sent every `UNION` to Record handling, so the
`case MAP:` branch below was unreachable for a root union containing a `map`. It now resolves
via `_createObjectContext()`, which routes `MAP` to `MapWriteContext` the way nested values do.

This also makes the `MAP` guards in `_createRecord()` true invariants — no in-tree caller can
reach them any more, so the `IllegalStateException` there is now appropriate.

### Testing

Each fix verified by reverting the source and confirming the new test reproduces the original
symptom. Full avro module: 163 tests, 0 failures, 0 errors.

Note: the release-notes entry for #745 is unchanged and does not mention the root union-to-map
fix.