### PR TITLE
Backport #745 (+ follow-ups) to 2.x: Avro union resolution and schema default precision

### DIFF
--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroFieldDefaulters.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/deser/AvroFieldDefaulters.java
@@ -31,11 +31,11 @@ public class AvroFieldDefaulters
         case VALUE_NUMBER_INT:
             switch (defaultAsNode.numberType()) {
             case INT:
-                return new ScalarDefaults.FloatDefaults(name, defaultAsNode.asInt());
+                return new ScalarDefaults.IntDefaults(name, defaultAsNode.asInt());
             case BIG_INTEGER: // TODO: maybe support separately?
             case LONG:
             default:
-                return new ScalarDefaults.FloatDefaults(name, defaultAsNode.asLong());
+                return new ScalarDefaults.LongDefaults(name, defaultAsNode.asLong());
             }
         case VALUE_STRING:
             return new ScalarDefaults.StringDefaults(name, defaultAsNode.asText());

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/AvroWriteContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/AvroWriteContext.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.UnresolvedUnionException;
@@ -171,6 +172,7 @@ public abstract class AvroWriteContext
                 // couldn't find an exact match
                 schema = _recordOrMapFromUnion(schema);
             }
+            type = schema.getType();
         }
         if (type == Schema.Type.MAP) {
             throw new IllegalStateException("_createRecord should never be called for elements of type MAP");
@@ -189,6 +191,7 @@ public abstract class AvroWriteContext
         Type type = schema.getType();
         if (type == Schema.Type.UNION) {
             schema = _recordOrMapFromUnion(schema);
+            type = schema.getType();
         }
         if (type == Schema.Type.MAP) {
             throw new IllegalStateException("_createRecord should never be called for elements of type MAP");
@@ -440,25 +443,41 @@ public abstract class AvroWriteContext
 
     private static int _resolveBigDecimalIndex(Schema unionSchema, List<Schema> types,
             BigDecimal value) {
-        int match = -1;
+        // Branches are considered in order of how well they retain the value,
+        // regardless of declaration order: "decimal" first, then String, then Double
+        int stringMatch = -1;
+        int doubleMatch = -1;
 
         for (int i = 0, size = types.size(); i < size; ++i) {
             Schema schema = types.get(i);
             Schema.Type t = schema.getType();
 
-            if (t == Type.DOUBLE) {
-                return i;
-            }
-            // BigDecimals can be shoved into a double, but optimally would be a String or byte[] with logical type information
-            if (t == Type.DOUBLE) {
-                match = i;
-                continue;
+            if (t == Type.BYTES || t == Type.FIXED) {
+                // Best match: retains both scale and type.
+                // NOTE: plain `bytes`/`fixed` must NOT be chosen, since conversion
+                // requires the "decimal" logical type to exist
+                if (schema.getLogicalType() instanceof LogicalTypes.Decimal) {
+                    return i;
+                }
+            } else if (t == Type.STRING) {
+                // Second best: retains all digits, but reads back as String
+                if (stringMatch < 0) {
+                    stringMatch = i;
+                }
+            } else if (t == Type.DOUBLE) {
+                // Last resort: lossy
+                if (doubleMatch < 0) {
+                    doubleMatch = i;
+                }
             }
         }
-        if (match < 0) {
-            match = ReflectData.get().resolveUnion(unionSchema, value);
+        if (stringMatch >= 0) {
+            return stringMatch;
         }
-        return match;
+        if (doubleMatch >= 0) {
+            return doubleMatch;
+        }
+        return ReflectData.get().resolveUnion(unionSchema, value);
     }
 
     private static int _resolveMapIndex(Schema unionSchema, List<Schema> types,

--- a/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/RootContext.java
+++ b/avro/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/RootContext.java
@@ -60,11 +60,16 @@ class RootContext
         // verify that root type is record (or compatible)
         switch (_schema.getType()) {
         case RECORD:
-        case UNION: // maybe
             {
                 GenericRecord rec = _createRecord(_schema, currValue);
                 _rootValue = rec;
                 return new ObjectWriteContext(this, _generator, rec, currValue);
+            }
+        case UNION: // maybe: may resolve to either Record or Map
+            {
+                AvroWriteContext child = _createObjectContext(_schema, currValue);
+                _rootValue = child.rawValue();
+                return child;
             }
         case MAP: // used to not be supported
             {

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalSerializationAndDeserializationTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalSerializationAndDeserializationTest.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.dataformat.avro;
 
 import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BigDecimal_serialization_and_deserializationTest extends AvroTestBase {
+public class BigDecimalSerializationAndDeserializationTest extends AvroTestBase {
     private static final AvroMapper MAPPER = new AvroMapper();
 
     static class BigDecimalAndName {
@@ -177,4 +179,126 @@ public class BigDecimal_serialization_and_deserializationTest extends AvroTestBa
         assertThat(result.name).isEqualTo("peter");
     }
 
+    /*
+    /**********************************************************************
+    /* Tests for union branch selection
+    /**********************************************************************
+     */
+
+    // Verify BigDecimal in a union with STRING and DOUBLE selects STRING (not DOUBLE)
+    @Test
+    public void testBigDecimalUnionPrefersStringOverDouble() throws Exception
+    {
+        AvroSchema schema = _unionSchema("'string','double'");
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(_value(input));
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        // Serialized as String, not double: retains full precision
+        assertThat(result.get("value")).isInstanceOf(String.class);
+    }
+
+    // Verify BigDecimal in a union with BYTES ("decimal" logical type) selects BYTES
+    @Test
+    public void testBigDecimalUnionPrefersBytesOverDouble() throws Exception
+    {
+        AvroSchema schema = _unionSchema(
+                "{'type':'bytes','logicalType':'decimal','precision':20,'scale':6},'double'");
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(_value(input));
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(BigDecimal.class);
+        assertThat((BigDecimal) result.get("value")).isEqualByComparingTo(input);
+    }
+
+    // Verify that plain BYTES (without "decimal" logical type) is NOT chosen for
+    // BigDecimal: conversion would fail, so DOUBLE must be used instead
+    @Test
+    public void testBigDecimalUnionSkipsPlainBytes() throws Exception
+    {
+        AvroSchema schema = _unionSchema("'bytes','double'");
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(_value(input));
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(Double.class);
+        assertThat((Double) result.get("value")).isEqualTo(input.doubleValue());
+    }
+
+    // Verify that "decimal" BYTES wins over STRING even when declared later:
+    // preference is by type fidelity, not by declaration order
+    @Test
+    public void testBigDecimalUnionPrefersBytesOverString() throws Exception
+    {
+        AvroSchema schema = _unionSchema(
+                "'string',{'type':'bytes','logicalType':'decimal','precision':20,'scale':6},'double'");
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(_value(input));
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(BigDecimal.class);
+        assertThat((BigDecimal) result.get("value")).isEqualByComparingTo(input);
+    }
+
+    // Verify that FIXED with "decimal" logical type is also usable for BigDecimal
+    @Test
+    public void testBigDecimalUnionPrefersFixedOverString() throws Exception
+    {
+        AvroSchema schema = _unionSchema(
+                "'string',{'type':'fixed','name':'Dec','size':16,"
+                +"'logicalType':'decimal','precision':20,'scale':6},'double'");
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(_value(input));
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(BigDecimal.class);
+        assertThat((BigDecimal) result.get("value")).isEqualByComparingTo(input);
+    }
+
+    // Verify that plain FIXED (without "decimal" logical type) is not chosen either
+    @Test
+    public void testBigDecimalUnionSkipsPlainFixed() throws Exception
+    {
+        AvroSchema schema = _unionSchema("{'type':'fixed','name':'Raw','size':16},'double'");
+
+        BigDecimal input = BigDecimal.valueOf(123456789, 6);
+        byte[] bytes = MAPPER.writer(schema).writeValueAsBytes(_value(input));
+
+        Map<String, Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(bytes);
+        assertThat(result.get("value")).isInstanceOf(Double.class);
+        assertThat((Double) result.get("value")).isEqualTo(input.doubleValue());
+    }
+
+    // Record with a single 'value' property, typed as a union of 'null' plus given branches
+    private AvroSchema _unionSchema(String branches) throws Exception {
+        return MAPPER.schemaFrom(aposToQuotes("{"
+                +"'type':'record',"
+                +"'name':'Test',"
+                +"'fields':[{'name':'value', 'type':['null',"+branches+"]}]"
+                +"}"));
+    }
+
+    private Map<String,Object> _value(Object value) {
+        Map<String,Object> map = new LinkedHashMap<>();
+        map.put("value", value);
+        return map;
+    }
 }

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/MapWithUnionTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/MapWithUnionTest.java
@@ -132,6 +132,56 @@ public class MapWithUnionTest extends AvroTestBase
         assertEquals("bing", m.get("zap"));
     }
 
+    // Verify that a root-level union resolving to MAP is written as a Map,
+    // and not passed to Record handling
+    @Test
+    public void testRootUnionResolvingToMapType() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFrom(aposToQuotes(
+                "['null',{'type':'map','values':'string'}]"));
+
+        Map<String,Object> input = _map("key1", "val1", "key2", "val2");
+        byte[] avro = MAPPER.writer(schema).writeValueAsBytes(input);
+
+        Map<String,Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(avro);
+        assertEquals("val1", result.get("key1"));
+        assertEquals("val2", result.get("key2"));
+    }
+
+    // Verify that a union resolving to MAP is handled correctly for Record properties
+    @Test
+    public void testUnionResolvingToMapType() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFrom(aposToQuotes("{"
+                +"'type':'record',"
+                +"'name':'Test',"
+                +"'fields':["
+                +"  {'name':'data', 'type':['null',"
+                +"    {'type':'record','name':'Nested','fields':["
+                +"      {'name':'x','type':'int'}"
+                +"    ]},"
+                +"    {'type':'map','values':'string'}"
+                +"  ]}"
+                +"]"
+                +"}"));
+
+        // Write a record where 'data' is a map (union index 2)
+        Map<String,Object> input = _map("data", _map("key1", "val1", "key2", "val2"));
+        byte[] avro = MAPPER.writer(schema).writeValueAsBytes(input);
+
+        Map<String,Object> result = MAPPER.readerFor(Map.class)
+                .with(schema)
+                .readValue(avro);
+        Object ob = result.get("data");
+        assertTrue(ob instanceof Map<?,?>,
+                "Expected Map but got "+((ob == null) ? "NULL" : ob.getClass().getSimpleName()));
+        Map<?,?> dataMap = (Map<?,?>) ob;
+        assertEquals("val1", dataMap.get("key1"));
+        assertEquals("val2", dataMap.get("key2"));
+    }
+
     private Map<String,Object> _map(Object... args) {
         Map<String,Object> m = new LinkedHashMap<>();
         for (int i = 0; i < args.length; i += 2) {

--- a/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schemaev/ComplexDefaultsTest.java
+++ b/avro/src/test/java/com/fasterxml/jackson/dataformat/avro/schemaev/ComplexDefaultsTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.avro.schemaev;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -192,5 +193,76 @@ public class ComplexDefaultsTest extends AvroTestBase
         assertEquals(2, result.data.size());
         assertEquals("Fo", result.data.get(0));
         assertEquals("obar", result.data.get(1));
+    }
+
+    /*
+    /**********************************************************************
+    /* Tests for integer default precision (not stored as float)
+    /**********************************************************************
+     */
+
+    // Verify that int default values preserve precision (not stored as float)
+    @Test
+    public void testIntDefaultValuePrecision() throws Exception
+    {
+        final AvroSchema srcSchema = MAPPER.schemaFrom(aposToQuotes("{"
+                +"'type':'record','name':'RootType',"
+                +"'fields':["
+                +"  {'name':'x','type':'int'},"
+                +"  {'name':'y','type':'int'}"
+                +"]"
+                +"}"));
+        // Default value 20000001 exceeds float's 24-bit mantissa (max exact int: 16777216)
+        final AvroSchema dstSchema = MAPPER.schemaFrom(aposToQuotes("{"
+                +"'type':'record','name':'RootType',"
+                +"'fields':["
+                +"  {'name':'x','type':'int'},"
+                +"  {'name':'largeInt','type':'int','default':20000001},"
+                +"  {'name':'y','type':'int'}"
+                +"]"
+                +"}"));
+
+        Map<String,Object> input = new LinkedHashMap<>();
+        input.put("x", 1);
+        input.put("y", 2);
+        byte[] avro = MAPPER.writer(srcSchema).writeValueAsBytes(input);
+
+        Map<String,Object> result = MAPPER.readerFor(Map.class)
+                .with(srcSchema.withReaderSchema(dstSchema))
+                .readValue(avro);
+        assertEquals(1, result.get("x"));
+        assertEquals(2, result.get("y"));
+        // The critical assertion: default 20000001 must survive float truncation
+        assertEquals(20000001, ((Number) result.get("largeInt")).intValue(),
+                "Integer default lost precision -- likely stored as float");
+    }
+
+    // Verify that long default values preserve precision
+    @Test
+    public void testLongDefaultValuePrecision() throws Exception
+    {
+        final AvroSchema srcSchema = MAPPER.schemaFrom(aposToQuotes("{"
+                +"'type':'record','name':'RootType',"
+                +"'fields':[{'name':'x','type':'int'}]"
+                +"}"));
+        // Default value 9007199254740993 exceeds float AND double integer precision
+        final AvroSchema dstSchema = MAPPER.schemaFrom(aposToQuotes("{"
+                +"'type':'record','name':'RootType',"
+                +"'fields':["
+                +"  {'name':'x','type':'int'},"
+                +"  {'name':'bigLong','type':'long','default':9007199254740993}"
+                +"]"
+                +"}"));
+
+        Map<String,Object> input = new LinkedHashMap<>();
+        input.put("x", 1);
+        byte[] avro = MAPPER.writer(srcSchema).writeValueAsBytes(input);
+
+        Map<String,Object> result = MAPPER.readerFor(Map.class)
+                .with(srcSchema.withReaderSchema(dstSchema))
+                .readValue(avro);
+        assertEquals(1, result.get("x"));
+        assertEquals(9007199254740993L, ((Number) result.get("bigLong")).longValue(),
+                "Long default lost precision -- likely stored as float");
     }
 }

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,10 @@ Active maintainers:
 
 2.23.0 (not yet released)
 
-No changes since 2.22
+#745: (avro) `BigDecimal` in a union always written as `double`, even when a
+  `decimal` `bytes`/`fixed` or `string` branch is available
+#745: (avro) Root-level union resolving to `map` fails to serialize
+#745: (avro) `int`/`long` schema default values lose precision (stored as `float`)
 
 2.22.2 (16-Aug-2026)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,7 @@ Active maintainers:
 
 2.23.0 (not yet released)
 
-#745: (avro) Avro bug fixes
+#745: (avro) Fix Avro bugs
 
 2.22.2 (16-Aug-2026)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,10 +16,7 @@ Active maintainers:
 
 2.23.0 (not yet released)
 
-#745: (avro) `BigDecimal` in a union always written as `double`, even when a
-  `decimal` `bytes`/`fixed` or `string` branch is available
-#745: (avro) Root-level union resolving to `map` fails to serialize
-#745: (avro) `int`/`long` schema default values lose precision (stored as `float`)
+#745: (avro) Avro bug fixes
 
 2.22.2 (16-Aug-2026)
 


### PR DESCRIPTION
Backport of #745 to the 2.x line, including the follow-up fixes in #753. All four bugs are
present on `2.x` unfixed.

Ported the corrected end state rather than #745 as merged, since #745 alone introduces a
`BigDecimal`/plain-`bytes` NPE that #753 fixes.

### Changes

**`ser/AvroWriteContext.java`** — `_resolveBigDecimalIndex()` tested `Type.DOUBLE` twice; the
first test was meant to be String/Bytes. A `BigDecimal` in a union was therefore always written
as `double`, even when a lossless branch existed. Branches are now ranked by fidelity:
`decimal` `bytes`/`fixed`, then `String`, then `Double`. Plain `bytes`/`fixed` are skipped —
conversion requires the logical type and would otherwise NPE.

**`ser/RootContext.java`** — `createChildObjectContext()` sent every `UNION` to Record handling,
so a root union containing a `map` failed. Now resolves via `_createObjectContext()`, which
routes `MAP` to `MapWriteContext`.

**`deser/AvroFieldDefaulters.java`** — `int` and `long` schema defaults were built as
`FloatDefaults`, truncating values past float's 24-bit mantissa (`20000001` → `20000000`,
`9007199254740993` → `...992`).

Also re-reads `type` after union resolution in `_createRecord()`, so its error message names
the resolved type.