### PR TITLE
Fix #759: use direct `String` construction for Smile "long" ASCII text values

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -25,6 +25,7 @@ implementations)
  (contributed by @pjfanning)
 #759: (smile) Use more efficient `String` construction wrt "Compact Strings"
   for "long" text values
+ (fix by @cowtowncoder, w/ Claude code)
 
 3.2.3 (not yet released)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -23,6 +23,8 @@ implementations)
  (contributed by @pjfanning)
 #752: (cbor) Use `VarHandle` for multi-byte primitive writes in `CBORGenerator`
  (contributed by @pjfanning)
+#759: (smile) Use more efficient `String` construction wrt "Compact Strings"
+  for "long" text values
 
 3.2.3 (not yet released)
 

--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
@@ -2797,8 +2797,42 @@ currentToken(), firstCh);
         return _textBuffer.setCurrentAndReturn(outPtr);
     }
 
+    /**
+     * Fast path shared by "long" (64+ byte) text value decoding: if the
+     * end-of-string marker is found within the current input buffer, preceded
+     * only by ASCII bytes, the whole value is contiguous and the String can be
+     * constructed straight from input bytes -- skipping the char[] round-trip
+     * (which JDK 17+ "Compact Strings" makes measurably cheaper).
+     *
+     * @return {@code true} if value was fully decoded into {@code _textBuffer};
+     *    {@code false} if caller needs to use general (slower) handling
+     */
+    private final boolean _tryDecodeLongContiguousAscii() throws JacksonException
+    {
+        final byte[] inBuf = _inputBuffer;
+        final int start = _inputPtr;
+        final int end = _inputEnd;
+        int ptr = start;
+        while (ptr < end) {
+            final byte b = inBuf[ptr];
+            if (b < 0) { // end marker, or start of multi-byte UTF-8 sequence
+                if (b == SmileConstants.BYTE_MARKER_END_OF_STRING) {
+                    _inputPtr = ptr + 1;
+                    _textBuffer.resetWithASCII(inBuf, start, ptr - start);
+                    return true;
+                }
+                return false; // actual non-ASCII content
+            }
+            ++ptr;
+        }
+        return false; // marker not within current buffer
+    }
+
     private final void _decodeLongAsciiValue() throws JacksonException
     {
+        if (_tryDecodeLongContiguousAscii()) {
+            return;
+        }
         int outPtr = 0;
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         main_loop:
@@ -2828,6 +2862,11 @@ currentToken(), firstCh);
 
     private final void _decodeLongUnicodeValue() throws JacksonException
     {
+        // 22-Aug-2026: note that generator is forced to use "Unicode" token type for
+        //   any text too long to speculate on, so content here may well be all-ASCII
+        if (_tryDecodeLongContiguousAscii()) {
+            return;
+        }
         int outPtr = 0;
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         final int[] codes = SmileConstants.sUtf8UnitLengths;

--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
@@ -2821,8 +2821,12 @@ currentToken(), firstCh);
             final byte b = inBuf[ptr];
             if (b < 0) { // end marker, or start of multi-byte UTF-8 sequence
                 if (b == SmileConstants.BYTE_MARKER_END_OF_STRING) {
-                    _inputPtr = ptr + 1;
+                    // NOTE: only advance input pointer AFTER decoding succeeds;
+                    //   `resetWithASCII()` validates against `maxStringLength` and
+                    //   may throw, and leaving the pointer past the offending value
+                    //   would be needlessly confusing for anyone inspecting state
                     _textBuffer.resetWithASCII(inBuf, start, ptr - start);
+                    _inputPtr = ptr + 1;
                     return -1;
                 }
                 break; // actual non-ASCII content

--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileParser.java
@@ -2798,16 +2798,20 @@ currentToken(), firstCh);
     }
 
     /**
-     * Fast path shared by "long" (64+ byte) text value decoding: if the
-     * end-of-string marker is found within the current input buffer, preceded
-     * only by ASCII bytes, the whole value is contiguous and the String can be
-     * constructed straight from input bytes -- skipping the char[] round-trip
-     * (which JDK 17+ "Compact Strings" makes measurably cheaper).
+     * Fast path shared by "long" (64+ byte) text value decoding: scans current
+     * input buffer for the end-of-string marker. If found with only ASCII bytes
+     * before it, the whole value is contiguous and the String can be constructed
+     * straight from input bytes -- skipping the char[] round-trip (which JDK 17+
+     * "Compact Strings" makes measurably cheaper).
+     *<p>
+     * If the marker is NOT reached (either non-ASCII content, or end of buffer),
+     * the offset at which scanning stopped is returned so that the caller can
+     * retain the already-verified ASCII prefix instead of scanning it again.
      *
-     * @return {@code true} if value was fully decoded into {@code _textBuffer};
-     *    {@code false} if caller needs to use general (slower) handling
+     * @return {@code -1} if value was fully decoded into {@code _textBuffer};
+     *    otherwise offset in {@code _inputBuffer} at which ASCII scan stopped
      */
-    private final boolean _tryDecodeLongContiguousAscii() throws JacksonException
+    private final int _scanLongContiguousAscii() throws JacksonException
     {
         final byte[] inBuf = _inputBuffer;
         final int start = _inputPtr;
@@ -2819,22 +2823,47 @@ currentToken(), firstCh);
                 if (b == SmileConstants.BYTE_MARKER_END_OF_STRING) {
                     _inputPtr = ptr + 1;
                     _textBuffer.resetWithASCII(inBuf, start, ptr - start);
-                    return true;
+                    return -1;
                 }
-                return false; // actual non-ASCII content
+                break; // actual non-ASCII content
             }
             ++ptr;
         }
-        return false; // marker not within current buffer
+        return ptr; // marker not reached: caller decodes rest, keeping prefix
+    }
+
+    /**
+     * Copies range of already-verified ASCII bytes into given output segment,
+     * starting new segments as necessary; used to retain the prefix scanned by
+     * {@link #_scanLongContiguousAscii()} when the fast path does not apply.
+     * Advances {@code _inputPtr} past the copied range.
+     *
+     * @return Number of chars in the (possibly new) current segment
+     */
+    private final int _copyScannedAsciiPrefix(int endOffset)
+    {
+        final byte[] inBuf = _inputBuffer;
+        int outPtr = 0;
+        char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
+        for (int i = _inputPtr; i < endOffset; ++i) {
+            if (outPtr >= outBuf.length) {
+                outBuf = _textBuffer.finishCurrentSegment();
+                outPtr = 0;
+            }
+            outBuf[outPtr++] = (char) inBuf[i];
+        }
+        _inputPtr = endOffset;
+        return outPtr;
     }
 
     private final void _decodeLongAsciiValue() throws JacksonException
     {
-        if (_tryDecodeLongContiguousAscii()) {
+        final int scanned = _scanLongContiguousAscii();
+        if (scanned < 0) { // fully decoded from input bytes
             return;
         }
-        int outPtr = 0;
-        char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
+        int outPtr = _copyScannedAsciiPrefix(scanned);
+        char[] outBuf = _textBuffer.getBufferWithoutReset();
         main_loop:
         while (true) {
             if (_inputPtr >= _inputEnd) {
@@ -2862,13 +2891,15 @@ currentToken(), firstCh);
 
     private final void _decodeLongUnicodeValue() throws JacksonException
     {
-        // 22-Aug-2026: note that generator is forced to use "Unicode" token type for
-        //   any text too long to speculate on, so content here may well be all-ASCII
-        if (_tryDecodeLongContiguousAscii()) {
+        // 21-Aug-2026, tatu: [dataformats-binary#759] Note that generator is forced to
+        //   use "Unicode" token type for any text too long to speculate on, so content
+        //   here may well be all-ASCII
+        final int scanned = _scanLongContiguousAscii();
+        if (scanned < 0) { // fully decoded from input bytes
             return;
         }
-        int outPtr = 0;
-        char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
+        int outPtr = _copyScannedAsciiPrefix(scanned);
+        char[] outBuf = _textBuffer.getBufferWithoutReset();
         final int[] codes = SmileConstants.sUtf8UnitLengths;
         int c;
         final byte[] inputBuffer = _inputBuffer;

--- a/smile/src/test/java/tools/jackson/dataformat/smile/parse/LongTextDecode759Test.java
+++ b/smile/src/test/java/tools/jackson/dataformat/smile/parse/LongTextDecode759Test.java
@@ -1,0 +1,151 @@
+package tools.jackson.dataformat.smile.parse;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.*;
+import tools.jackson.dataformat.smile.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for [dataformats-binary#759]: "long" (64+ byte) text values decoded
+ * straight from input bytes when contiguous and all-ASCII. Covers both
+ * `TOKEN_BYTE_LONG_STRING_ASCII` and `TOKEN_MISC_LONG_TEXT_UNICODE` token
+ * types -- generator is forced to use the latter for text too long to
+ * speculate on, even when content is pure ASCII.
+ */
+public class LongTextDecode759Test
+    extends BaseTestForSmile
+{
+    // Lengths straddling the point (~2666 chars) where the generator can no
+    // longer speculate on ASCII-ness and switches to the "Unicode" token type
+    private final static int[] LENGTHS = { 64, 65, 100, 1000, 2665, 2666, 2667, 3000, 9000 };
+
+    @Test
+    public void testLongAsciiValues() throws Exception
+    {
+        for (int len : LENGTHS) {
+            String text = _ascii(len);
+            _verifyRoundTrip(text);
+        }
+    }
+
+    @Test
+    public void testLongValuesWithNonAsciiAtEveryBoundary() throws Exception
+    {
+        // non-ASCII char at start/middle/end must defeat the fast path cleanly
+        for (int len : LENGTHS) {
+            for (int pos : new int[] { 0, 1, len / 2, len - 1 }) {
+                StringBuilder sb = new StringBuilder(_ascii(len));
+                sb.setCharAt(pos, '中');
+                _verifyRoundTrip(sb.toString());
+            }
+        }
+    }
+
+    @Test
+    public void testLongValuesWithSurrogatePair() throws Exception
+    {
+        for (int len : LENGTHS) {
+            StringBuilder sb = new StringBuilder(_ascii(len - 2));
+            sb.appendCodePoint(0x1F601);
+            _verifyRoundTrip(sb.toString());
+        }
+    }
+
+    // Values spanning buffer reloads must fall back to general handling
+    @Test
+    public void testLongValuesFromChunkedStream() throws Exception
+    {
+        List<String> texts = new ArrayList<>();
+        for (int len : LENGTHS) {
+            texts.add(_ascii(len));
+        }
+        byte[] doc = _doc(texts);
+        for (int chunkSize : new int[] { 1, 7, 999 }) {
+            _verifyDoc(texts, new ChunkedStream(doc, chunkSize));
+        }
+    }
+
+    private void _verifyRoundTrip(String text) throws Exception
+    {
+        List<String> texts = new ArrayList<>();
+        texts.add(text);
+        _verifyDoc(texts, null); // byte[] backed
+        _verifyDoc(texts, new ByteArrayInputStream(_doc(texts)));
+    }
+
+    private void _verifyDoc(List<String> expected, InputStream in) throws Exception
+    {
+        try (JsonParser p = (in == null) ? _smileParser(_doc(expected)) : _smileParser(in)) {
+            assertEquals(JsonToken.START_ARRAY, p.nextToken());
+            for (String exp : expected) {
+                assertEquals(JsonToken.VALUE_STRING, p.nextToken());
+                assertEquals(exp, p.getString());
+            }
+            assertEquals(JsonToken.END_ARRAY, p.nextToken());
+            assertNull(p.nextToken());
+        }
+    }
+
+    private byte[] _doc(List<String> texts) throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SmileFactory f = smileFactory(false, false, false);
+        try (JsonGenerator g = f.createGenerator(ObjectWriteContext.empty(), out)) {
+            g.writeStartArray();
+            for (String text : texts) {
+                g.writeString(text);
+            }
+            g.writeEndArray();
+        }
+        return out.toByteArray();
+    }
+
+    private String _ascii(int len)
+    {
+        Random r = new Random(len);
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            sb.append((char) ('a' + r.nextInt(26)));
+        }
+        return sb.toString();
+    }
+
+    // Yields small chunks, forcing buffer reloads in the middle of values
+    static class ChunkedStream extends InputStream
+    {
+        private final byte[] _data;
+        private final int _chunkSize;
+        private int _ptr;
+
+        public ChunkedStream(byte[] data, int chunkSize) {
+            _data = data;
+            _chunkSize = chunkSize;
+        }
+
+        @Override
+        public int read() {
+            return (_ptr < _data.length) ? (_data[_ptr++] & 0xFF) : -1;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int len) {
+            if (_ptr >= _data.length) {
+                return -1;
+            }
+            int count = Math.min(Math.min(len, _chunkSize), _data.length - _ptr);
+            System.arraycopy(_data, _ptr, buffer, offset, count);
+            _ptr += count;
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #624/#625, which did the same for CBOR.

### Problem

`SmileParser` already constructs `String` directly from input bytes for **short** ASCII
values and names (`_decodeShortAsciiValue()` / `_decodeShortAsciiName()`), but both
**"long"** (64+ byte) text paths still decoded byte-by-byte into a `char[]`, then
compressed that back down to a Latin-1 `String`.

This matters for `_decodeLongUnicodeValue()` too, not just the ASCII token type:
`SmileGenerator._writeNonSharedString()` cannot speculate on ASCII-ness once
`3 * len + 2` exceeds the output buffer, so it writes `TOKEN_MISC_LONG_TEXT_UNICODE`
even for pure-ASCII text above roughly 2666 characters. Those values previously got
no benefit at all.

### Change

`_scanLongContiguousAscii()` scans the current input buffer for the end-of-string
marker. If it is reached with only ASCII before it, the value is contiguous and
`TextBuffer.resetWithASCII()` builds the `String` straight from input bytes.

Unlike CBOR, Smile "long" text is **marker-terminated rather than length-prefixed**,
so whether a value is contiguous cannot be known up front. The scan therefore returns
*where it stopped* rather than merely succeeding or failing, and `_copyScannedAsciiPrefix()`
materializes the already-verified prefix so decoding resumes from there. Without that,
the fallback paths were measurably **slower** than before (see below).

### Measurements

**Method and its limits, up front:** these are wall-clock timings on a single machine
(Apple Silicon, JDK 17) -- minimum of 3 JVM trials, best-of-10 runs each -- **not JMH**.
No forking, no confidence intervals. Comparable harnesses in this codebase showed
roughly ±2-5% run-to-run variance, so **any row within a few percent of 1.00x should be
read as "no regression detected" rather than as a measured gain.**

ns per decoded character, pure-ASCII values:

| len | `byte[]` input | `InputStream` input |
|---|---|---|
| 100 | 1.31x | 1.51x |
| 1500 | 1.30x | 1.21x |
| 2600 | 1.26x | 1.08x † |
| 4000 | 1.18x | 1.10x † |
| 8000 | 1.18x | 1.05x † |
| 20000 | 1.39x | 1.05x † |

† within or close to the noise band; treat as "not slower", not as a demonstrated speedup.

The results I would actually stand behind are the `byte[]` column (1.18-1.39x) and the
short/streamed 100-char case. The `InputStream` column matters mainly because it used to
be a **regression**: with the default ~8000-byte read buffer, values larger than the
buffer never have their marker in the current window, and before the prefix handoff every
one of them paid a wasted full-buffer scan (measured 0.96x at 20000 chars). Those values
now break even or better; claiming more than that would overstate the data.

**Remaining trade-off:** a long value that is ASCII until very near its end pays for a
scan that cannot be turned into a `String`. Measured **0.94x** for a 20000-char value
whose final character is non-ASCII (stable across 6 trials). Shorter values of the same
shape gain (1.77x at 5000 chars). This is inherent to marker-terminated framing -- fusing
the scan with the char-fill would remove it but would also remove the optimization.

I have **not** quantified how common that shape is in real Smile payloads; it is plausible
(long mostly-English text ending in an accented word or a smart quote) but that is a guess,
not evidence. Reviewers weighing this trade-off should treat the frequency as unknown.

### Verification

* Full Smile suite green (294 tests), full multi-module build green, CI green on JDK 17/21/25.
* Decoded output verified byte-identical (SHA-256 over all decoded text) against the
  previous implementation across lengths 65-30000, with non-ASCII at first/middle/last
  position, surrogate pairs, and pure ASCII -- each read four ways: `byte[]`-backed,
  full `InputStream`, and 7-byte and 1-byte chunked streams (forcing buffer reloads
  mid-value, i.e. the fall-back path).
* `maxStringLength` still enforced identically (`resetWithASCII` validates); confirmed
  `StreamConstraintsException` on both paths.
* Not reachable for property names -- both methods are called only for value tokens
  (`type == 7`, subtypes 0/1) -- so the `maxNameLength` hardening from #725/#726 is
  untouched.
* `getStringCharacters()` / `getStringOffset()` / `getStringLength()` agree with
  `getString()`. Note `hasStringCharacters()` now returns `false` for long ASCII values
  (advisory only; short ASCII values have behaved this way for a long time via
  `resetWithString`).
* New `LongTextDecode759Test` covers the above; confirmed it fails if the fast path's
  length arithmetic is perturbed. Note it does not assert that the fast path is *taken*,
  so it would not catch a future change that silently disables the optimization.

### Not addressed here

`origin/2.x` has the identical gap: short-ASCII values/names are already optimized there,
but `_decodeLongAsciiValue()` / `_decodeLongUnicodeValue()` are not. This PR targets `3.x`
only, so the 2.x line would need a separate change if the optimization should ship there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)