### PR TITLE
Use varhandle for float/double reads in Avro parser

### DIFF
--- a/avro/src/main/java/tools/jackson/dataformat/avro/AvroByteShiftUtil.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/AvroByteShiftUtil.java
@@ -1,0 +1,49 @@
+package tools.jackson.dataformat.avro;
+
+/**
+ * Byte-shifting fallback for reading multi-byte primitives out of byte arrays,
+ * used on runtimes where {@link AvroVarHandleUtil} is unusable.
+ *<p>
+ * NOTE: {@code public} only so that the {@code ...avro.deser} package can
+ * use it; this class is an internal implementation detail and NOT part of
+ * the public API: it may change or be removed without notice.
+ *<p>
+ * NOTE: reads here are LITTLE-endian, matching Avro's IEEE-754 encoding of
+ * {@code float} and {@code double}.
+ *<p>
+ * IMPORTANT: this class must NOT reference {@code java.lang.invoke.VarHandle},
+ * directly or indirectly: it is the fallback for runtimes that lack that type,
+ * and naming it here would make this class fail to link on exactly those
+ * runtimes. Keeping the two implementations in separate classes is what makes
+ * the fallback path safe; see {@link AvroVarHandleUtil} for the full pattern.
+ *
+ * @since 3.3
+ */
+public final class AvroByteShiftUtil
+{
+    private AvroByteShiftUtil() { }
+
+    /**
+     * Reads 4 bytes starting at given offset as a little-endian {@code int}.
+     * Caller MUST have verified that {@code offset+4} is within bounds of
+     * given array.
+     */
+    public static int getIntLE(byte[] buffer, int offset) {
+        return (buffer[offset] & 0xFF)
+                | ((buffer[offset+1] & 0xFF) << 8)
+                | ((buffer[offset+2] & 0xFF) << 16)
+                | ((buffer[offset+3] & 0xFF) << 24);
+    }
+
+    /**
+     * Reads 8 bytes starting at given offset as a little-endian {@code long}.
+     * Caller MUST have verified that {@code offset+8} is within bounds of
+     * given array.
+     */
+    public static long getLongLE(byte[] buffer, int offset) {
+        // the two 32-bit halves combine to exactly a little-endian 8-byte read
+        final int i1 = getIntLE(buffer, offset);
+        final int i2 = getIntLE(buffer, offset+4);
+        return (((long) i1) & 0xFFFFFFFFL) | (((long) i2) << 32);
+    }
+}

--- a/avro/src/main/java/tools/jackson/dataformat/avro/AvroVarHandleUtil.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/AvroVarHandleUtil.java
@@ -1,4 +1,4 @@
-package tools.jackson.dataformat.avro.deser;
+package tools.jackson.dataformat.avro;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -7,6 +7,10 @@ import java.nio.ByteOrder;
 /**
  * Utility class that provides {@link VarHandle}-based access for reading
  * multi-byte primitives out of byte arrays.
+ *<p>
+ * NOTE: {@code public} only so that the {@code ...avro.deser} package can
+ * use it; this class is an internal implementation detail and NOT part of
+ * the public API: it may change or be removed without notice.
  *<p>
  * NOTE: handles here are LITTLE-endian, unlike the big-endian ones other
  * Jackson binary backends need: Avro encodes {@code float} and {@code double}
@@ -26,7 +30,7 @@ import java.nio.ByteOrder;
  *
  * @since 3.3
  */
-final class AvroVarHandleUtil
+public final class AvroVarHandleUtil
 {
     /**
      * VarHandle for reading 4 little-endian bytes as an {@code int}.
@@ -60,7 +64,7 @@ final class AvroVarHandleUtil
      * @return {@code true} if {@link #getIntLE} and {@link #getLongLE} may be
      *    called; if {@code false}, caller MUST use its own byte-shifting fallback
      */
-    static boolean isAvailable() {
+    public static boolean isAvailable() {
         return LONG_LE != null;
     }
 
@@ -73,7 +77,7 @@ final class AvroVarHandleUtil
      * Caller MUST also have verified that {@code offset+4} is within bounds of
      * given array.
      */
-    static int getIntLE(byte[] buffer, int offset) {
+    public static int getIntLE(byte[] buffer, int offset) {
         return (int) INT_LE.get(buffer, offset);
     }
 
@@ -86,7 +90,7 @@ final class AvroVarHandleUtil
      * Caller MUST also have verified that {@code offset+8} is within bounds of
      * given array.
      */
-    static long getLongLE(byte[] buffer, int offset) {
+    public static long getLongLE(byte[] buffer, int offset) {
         return (long) LONG_LE.get(buffer, offset);
     }
 }

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroVarHandleUtil.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroVarHandleUtil.java
@@ -1,0 +1,86 @@
+package tools.jackson.dataformat.avro.deser;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+/**
+ * Utility class that provides {@link VarHandle}-based access for reading
+ * multi-byte primitives out of byte arrays.
+ *<p>
+ * NOTE: handles here are LITTLE-endian, unlike the big-endian ones other
+ * Jackson binary backends need: Avro encodes {@code float} and {@code double}
+ * as little-endian IEEE-754.
+ *<p>
+ * IMPORTANT: this class references {@link VarHandle} in field and method
+ * signatures, so on a runtime that does not provide {@code java.lang.invoke.VarHandle}
+ * at all it will fail to <i>link</i>, before any code here gets a chance to run.
+ * Callers MUST therefore both:
+ *<ol>
+ * <li>load this class from within a {@code try}/{@code catch (Throwable)} block,
+ *   so that {@link LinkageError} is caught, and</li>
+ * <li>keep the byte-shifting fallback in a class that does not reference
+ *   {@link VarHandle}, so the fallback path never resolves this class.</li>
+ *</ol>
+ * {@code JacksonAvroParserImpl} does both; see it for the pattern.
+ *
+ * @since 3.3
+ */
+final class AvroVarHandleUtil
+{
+    /**
+     * VarHandle for reading 4 little-endian bytes as an {@code int}.
+     * {@code null} if byte-array views are unsupported.
+     */
+    private static final VarHandle INT_LE;
+
+    /**
+     * VarHandle for reading 8 little-endian bytes as a {@code long}.
+     * {@code null} if byte-array views are unsupported.
+     */
+    private static final VarHandle LONG_LE;
+
+    static {
+        VarHandle intLe = null;
+        VarHandle longLe = null;
+        try {
+            intLe = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+            longLe = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+        } catch (Throwable t) {
+            // Byte-array views not supported: caller falls back to byte shifting
+        }
+        INT_LE = intLe;
+        // assigned last: non-null implies the handle above resolved too
+        LONG_LE = longLe;
+    }
+
+    private AvroVarHandleUtil() { }
+
+    /**
+     * @return {@code true} if the {@code getXxx()} methods may be called; if
+     *    {@code false}, caller MUST use its own byte-shifting fallback
+     */
+    static boolean isAvailable() {
+        return LONG_LE != null;
+    }
+
+    // Helper methods that read primitives via the class's own VarHandle fields.
+    // Only called when {@link #isAvailable()} returned true; the handles are
+    // dereferenced unconditionally and the fallback lives in the caller.
+
+    /**
+     * Reads 4 bytes at given offset as a little-endian {@code int}; caller MUST
+     * have verified that {@code offset+4} is within bounds of given array.
+     */
+    static int getIntLE(byte[] array, int offset) {
+        return (int) INT_LE.get(array, offset);
+    }
+
+    /**
+     * Reads 8 bytes at given offset as a little-endian {@code long}; caller MUST
+     * have verified that {@code offset+8} is within bounds of given array.
+     */
+    static long getLongLE(byte[] array, int offset) {
+        return (long) LONG_LE.get(array, offset);
+    }
+}

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroVarHandleUtil.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroVarHandleUtil.java
@@ -30,13 +30,13 @@ final class AvroVarHandleUtil
 {
     /**
      * VarHandle for reading 4 little-endian bytes as an {@code int}.
-     * {@code null} if byte-array views are unsupported.
+     * {@code null} if {@code byteArrayViewVarHandle()} is unsupported.
      */
     private static final VarHandle INT_LE;
 
     /**
      * VarHandle for reading 8 little-endian bytes as a {@code long}.
-     * {@code null} if byte-array views are unsupported.
+     * {@code null} if {@code byteArrayViewVarHandle()} is unsupported.
      */
     private static final VarHandle LONG_LE;
 
@@ -50,37 +50,43 @@ final class AvroVarHandleUtil
             // Byte-array views not supported: caller falls back to byte shifting
         }
         INT_LE = intLe;
-        // assigned last: non-null implies the handle above resolved too
+        // assigned last: non-null implies every handle above resolved too
         LONG_LE = longLe;
     }
 
     private AvroVarHandleUtil() { }
 
     /**
-     * @return {@code true} if the {@code getXxx()} methods may be called; if
-     *    {@code false}, caller MUST use its own byte-shifting fallback
+     * @return {@code true} if {@link #getIntLE} and {@link #getLongLE} may be
+     *    called; if {@code false}, caller MUST use its own byte-shifting fallback
      */
     static boolean isAvailable() {
         return LONG_LE != null;
     }
 
-    // Helper methods that read primitives via the class's own VarHandle fields.
-    // Only called when {@link #isAvailable()} returned true; the handles are
-    // dereferenced unconditionally and the fallback lives in the caller.
-
     /**
-     * Reads 4 bytes at given offset as a little-endian {@code int}; caller MUST
-     * have verified that {@code offset+4} is within bounds of given array.
+     * Reads 4 bytes starting at given offset as a little-endian {@code int}.
+     *<p>
+     * Only to be called if {@link #isAvailable()} returned {@code true}: the
+     * handle is dereferenced unconditionally, and the fallback lives in the
+     * caller, not here.
+     * Caller MUST also have verified that {@code offset+4} is within bounds of
+     * given array.
      */
-    static int getIntLE(byte[] array, int offset) {
-        return (int) INT_LE.get(array, offset);
+    static int getIntLE(byte[] buffer, int offset) {
+        return (int) INT_LE.get(buffer, offset);
     }
 
     /**
-     * Reads 8 bytes at given offset as a little-endian {@code long}; caller MUST
-     * have verified that {@code offset+8} is within bounds of given array.
+     * Reads 8 bytes starting at given offset as a little-endian {@code long}.
+     *<p>
+     * Only to be called if {@link #isAvailable()} returned {@code true}: the
+     * handle is dereferenced unconditionally, and the fallback lives in the
+     * caller, not here.
+     * Caller MUST also have verified that {@code offset+8} is within bounds of
+     * given array.
      */
-    static long getLongLE(byte[] array, int offset) {
-        return (long) LONG_LE.get(array, offset);
+    static long getLongLE(byte[] buffer, int offset) {
+        return (long) LONG_LE.get(buffer, offset);
     }
 }

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
@@ -4,7 +4,9 @@ import java.io.*;
 
 import tools.jackson.core.*;
 import tools.jackson.core.io.IOContext;
+import tools.jackson.dataformat.avro.AvroByteShiftUtil;
 import tools.jackson.dataformat.avro.AvroSchema;
+import tools.jackson.dataformat.avro.AvroVarHandleUtil;
 
 /**
  * Parser implementation that uses native Jackson avro decoder.
@@ -552,8 +554,7 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         if (_VARHANDLE_AVAILABLE) {
             i = AvroVarHandleUtil.getIntLE(buf, ptr);
         } else {
-            i = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
-                    | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
+            i = AvroByteShiftUtil.getIntLE(buf, ptr);
         }
         _numberFloat = Float.intBitsToFloat(i);
         _numTypesValid = NR_FLOAT;
@@ -579,12 +580,7 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         if (_VARHANDLE_AVAILABLE) {
             l = AvroVarHandleUtil.getLongLE(buf, ptr);
         } else {
-            // the two 32-bit halves combine to exactly a little-endian 8-byte read
-            int i = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
-                    | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
-            int i2 = (buf[ptr+4] & 0xff) | ((buf[ptr+5] & 0xff) << 8)
-                    | ((buf[ptr+6] & 0xff) << 16) | (buf[ptr+7] << 24);
-            l = (((long) i) & 0xffffffffL) | (((long) i2) << 32);
+            l = AvroByteShiftUtil.getLongLE(buf, ptr);
         }
         _numberDouble = Double.longBitsToDouble(l);
         _numTypesValid = NR_DOUBLE;

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
@@ -40,7 +40,31 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         }
         sUtf8UnitLengths = table;
     }
-    
+
+    /**
+     * Whether VarHandles are usable on this runtime; probed once at class load.
+     * Being {@code static final} lets the branches in {@link #decodeFloat()} and
+     * {@link #decodeDouble()} fold away at JIT time.
+     *
+     * @since 3.3
+     */
+    private final static boolean _VARHANDLE_AVAILABLE = _checkVarHandleAvailable();
+
+    private static boolean _checkVarHandleAvailable() {
+        // NOTE: this call is what first loads `AvroVarHandleUtil`, and that class
+        // names `VarHandle` in its field/method signatures. On a runtime lacking
+        // `java.lang.invoke.VarHandle` (some Android builds) loading it raises
+        // `NoClassDefFoundError` -- an Error, not an Exception -- so `Throwable`
+        // is what has to be caught here. Without this guard the failure would
+        // propagate out of this class's initializer and make the parser unusable.
+        try {
+            return AvroVarHandleUtil.isAvailable();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+
     /*
     /**********************************************************************
     /* Input source config
@@ -523,8 +547,14 @@ public class JacksonAvroParserImpl extends AvroParserImpl
         }
         final byte[] buf = _inputBuffer;
         _inputPtr = ptr+4;
-        int i = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
-                | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
+        // Avro encodes float as little-endian IEEE-754
+        final int i;
+        if (_VARHANDLE_AVAILABLE) {
+            i = AvroVarHandleUtil.getIntLE(buf, ptr);
+        } else {
+            i = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
+                    | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
+        }
         _numberFloat = Float.intBitsToFloat(i);
         _numTypesValid = NR_FLOAT;
         return JsonToken.VALUE_NUMBER_FLOAT;
@@ -543,15 +573,22 @@ public class JacksonAvroParserImpl extends AvroParserImpl
             ptr = _inputPtr;
         }
         final byte[] buf = _inputBuffer;
-        int i = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
-                | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
-        ptr += 4;
-        int i2 = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
-                | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
-
+        // Avro encodes double as little-endian IEEE-754; the two 32-bit halves
+        // below combine to exactly a little-endian 8-byte read
+        final long l;
+        if (_VARHANDLE_AVAILABLE) {
+            l = AvroVarHandleUtil.getLongLE(buf, ptr);
+            ptr += 4;
+        } else {
+            int i = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
+                    | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
+            ptr += 4;
+            int i2 = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
+                    | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
+            l = (((long) i) & 0xffffffffL) | (((long) i2) << 32);
+        }
         _inputPtr = ptr+4;
-        _numberDouble = Double.longBitsToDouble((((long) i) & 0xffffffffL)
-                | (((long) i2) << 32));
+        _numberDouble = Double.longBitsToDouble(l);
         _numTypesValid = NR_DOUBLE;
         return JsonToken.VALUE_NUMBER_FLOAT;
     }

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/JacksonAvroParserImpl.java
@@ -573,21 +573,19 @@ public class JacksonAvroParserImpl extends AvroParserImpl
             ptr = _inputPtr;
         }
         final byte[] buf = _inputBuffer;
-        // Avro encodes double as little-endian IEEE-754; the two 32-bit halves
-        // below combine to exactly a little-endian 8-byte read
+        _inputPtr = ptr+8;
+        // Avro encodes double as little-endian IEEE-754
         final long l;
         if (_VARHANDLE_AVAILABLE) {
             l = AvroVarHandleUtil.getLongLE(buf, ptr);
-            ptr += 4;
         } else {
+            // the two 32-bit halves combine to exactly a little-endian 8-byte read
             int i = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
                     | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
-            ptr += 4;
-            int i2 = (buf[ptr] & 0xff) | ((buf[ptr+1] & 0xff) << 8)
-                    | ((buf[ptr+2] & 0xff) << 16) | (buf[ptr+3] << 24);
+            int i2 = (buf[ptr+4] & 0xff) | ((buf[ptr+5] & 0xff) << 8)
+                    | ((buf[ptr+6] & 0xff) << 16) | (buf[ptr+7] << 24);
             l = (((long) i) & 0xffffffffL) | (((long) i2) << 32);
         }
-        _inputPtr = ptr+4;
         _numberDouble = Double.longBitsToDouble(l);
         _numTypesValid = NR_DOUBLE;
         return JsonToken.VALUE_NUMBER_FLOAT;

--- a/avro/src/test/java/tools/jackson/dataformat/avro/VarHandleFallbackTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/VarHandleFallbackTest.java
@@ -1,0 +1,89 @@
+package tools.jackson.dataformat.avro;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link AvroByteShiftUtil}, the byte-shifting fallback used on
+ * runtimes where {@link AvroVarHandleUtil} is unusable.
+ *<p>
+ * Needed because {@code JacksonAvroParserImpl._VARHANDLE_AVAILABLE} is
+ * {@code static final} and true on every JDK we test on: the fallback branches
+ * in {@code decodeFloat()} / {@code decodeDouble()} are constant-folded away, so
+ * reading tests alone never execute them. Here the fallback is called directly
+ * and checked against {@link ByteBuffer} as an independent oracle, plus against
+ * the VarHandle implementation it stands in for.
+ */
+public class VarHandleFallbackTest
+{
+    private final static int OFFSET = 3; // deliberately unaligned
+
+    @Test
+    public void testGetIntLE() throws Exception
+    {
+        for (byte[] input : _inputs(4)) {
+            final int exp = ByteBuffer.wrap(input, OFFSET, 4)
+                    .order(ByteOrder.LITTLE_ENDIAN).getInt();
+            assertEquals(exp, AvroByteShiftUtil.getIntLE(input, OFFSET));
+            if (AvroVarHandleUtil.isAvailable()) {
+                assertEquals(exp, AvroVarHandleUtil.getIntLE(input, OFFSET));
+            }
+        }
+    }
+
+    @Test
+    public void testGetLongLE() throws Exception
+    {
+        for (byte[] input : _inputs(8)) {
+            final long exp = ByteBuffer.wrap(input, OFFSET, 8)
+                    .order(ByteOrder.LITTLE_ENDIAN).getLong();
+            assertEquals(exp, AvroByteShiftUtil.getLongLE(input, OFFSET));
+            if (AvroVarHandleUtil.isAvailable()) {
+                assertEquals(exp, AvroVarHandleUtil.getLongLE(input, OFFSET));
+            }
+        }
+    }
+
+    // Also verify the values the parser actually produces from these bytes
+    @Test
+    public void testFloatAndDoubleBits() throws Exception
+    {
+        for (byte[] input : _inputs(4)) {
+            assertEquals(ByteBuffer.wrap(input, OFFSET, 4)
+                        .order(ByteOrder.LITTLE_ENDIAN).getFloat(),
+                    Float.intBitsToFloat(AvroByteShiftUtil.getIntLE(input, OFFSET)),
+                    0f);
+        }
+        for (byte[] input : _inputs(8)) {
+            assertEquals(ByteBuffer.wrap(input, OFFSET, 8)
+                        .order(ByteOrder.LITTLE_ENDIAN).getDouble(),
+                    Double.longBitsToDouble(AvroByteShiftUtil.getLongLE(input, OFFSET)),
+                    0d);
+        }
+    }
+
+    // Sign-bit and all-bits-set cases first, then pseudo-random ones
+    // (fixed seed, for reproducibility)
+    private byte[][] _inputs(int length) {
+        final int size = OFFSET + length;
+        byte[][] result = new byte[3+100][];
+        result[0] = new byte[size];
+        result[1] = new byte[size];
+        Arrays.fill(result[1], (byte) 0xFF);
+        result[2] = new byte[size];
+        result[2][size-1] = (byte) 0x80; // high bit of most-significant (last) byte
+        Random rnd = new Random(1234);
+        for (int i = 3; i < result.length; ++i) {
+            byte[] b = new byte[size];
+            rnd.nextBytes(b);
+            result[i] = b;
+        }
+        return result;
+    }
+}

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORByteShiftUtil.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORByteShiftUtil.java
@@ -1,0 +1,62 @@
+package tools.jackson.dataformat.cbor;
+
+/**
+ * Byte-shifting fallback for reading and writing multi-byte primitives on byte
+ * arrays, used on runtimes where {@link CBORVarHandleUtil} is unusable.
+ *<p>
+ * IMPORTANT: this class must NOT reference {@code java.lang.invoke.VarHandle},
+ * directly or indirectly: it is the fallback for runtimes that lack that type,
+ * and naming it here would make this class fail to link on exactly those
+ * runtimes. Keeping the two implementations in separate classes is what makes
+ * the fallback path safe; see {@link CBORVarHandleUtil} for the full pattern.
+ *
+ * @since 3.3
+ */
+final class CBORByteShiftUtil
+{
+    private CBORByteShiftUtil() { }
+
+    /**
+     * Reads 4 bytes starting at given offset as a big-endian {@code int}.
+     * Caller MUST have verified that {@code offset+4} is within bounds of
+     * given array.
+     */
+    static int getIntBE(byte[] buffer, int offset) {
+        return ((buffer[offset] & 0xFF) << 24)
+                | ((buffer[offset+1] & 0xFF) << 16)
+                | ((buffer[offset+2] & 0xFF) << 8)
+                | (buffer[offset+3] & 0xFF);
+    }
+
+    /**
+     * Reads 8 bytes starting at given offset as a big-endian {@code long}.
+     * Caller MUST have verified that {@code offset+8} is within bounds of
+     * given array.
+     */
+    static long getLongBE(byte[] buffer, int offset) {
+        // the two 32-bit halves combine to exactly a big-endian 8-byte read
+        final int i1 = getIntBE(buffer, offset);
+        final int i2 = getIntBE(buffer, offset+4);
+        return (((long) i1) << 32) | (((long) i2) & 0xFFFFFFFFL);
+    }
+
+    /**
+     * Writes given {@code int} as 4 big-endian bytes at given offset; caller
+     * MUST have verified that {@code offset+4} is within bounds of given array.
+     */
+    static void setIntBE(byte[] buffer, int offset, int value) {
+        buffer[offset] = (byte) (value >> 24);
+        buffer[offset+1] = (byte) (value >> 16);
+        buffer[offset+2] = (byte) (value >> 8);
+        buffer[offset+3] = (byte) value;
+    }
+
+    /**
+     * Writes given {@code long} as 8 big-endian bytes at given offset; caller
+     * MUST have verified that {@code offset+8} is within bounds of given array.
+     */
+    static void setLongBE(byte[] buffer, int offset, long value) {
+        setIntBE(buffer, offset, (int) (value >> 32));
+        setIntBE(buffer, offset+4, (int) value);
+    }
+}

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORGenerator.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORGenerator.java
@@ -1669,7 +1669,7 @@ surr1, surr2));
 
     private final void _writeInt32(int i) {
         if (_VARHANDLE_AVAILABLE) {
-            CBORVarHandleUtil.setInt(_outputBuffer, _outputTail, i);
+            CBORVarHandleUtil.setIntBE(_outputBuffer, _outputTail, i);
             _outputTail += 4;
         } else {
             _writeInt32Bytes(i);
@@ -1678,7 +1678,7 @@ surr1, surr2));
 
     private final void _writeInt64(long l) {
         if (_VARHANDLE_AVAILABLE) {
-            CBORVarHandleUtil.setLong(_outputBuffer, _outputTail, l);
+            CBORVarHandleUtil.setLongBE(_outputBuffer, _outputTail, l);
             _outputTail += 8;
         } else {
             _writeInt32Bytes((int) (l >> 32));

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORGenerator.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORGenerator.java
@@ -1670,27 +1670,19 @@ surr1, surr2));
     private final void _writeInt32(int i) {
         if (_VARHANDLE_AVAILABLE) {
             CBORVarHandleUtil.setIntBE(_outputBuffer, _outputTail, i);
-            _outputTail += 4;
         } else {
-            _writeInt32Bytes(i);
+            CBORByteShiftUtil.setIntBE(_outputBuffer, _outputTail, i);
         }
+        _outputTail += 4;
     }
 
     private final void _writeInt64(long l) {
         if (_VARHANDLE_AVAILABLE) {
             CBORVarHandleUtil.setLongBE(_outputBuffer, _outputTail, l);
-            _outputTail += 8;
         } else {
-            _writeInt32Bytes((int) (l >> 32));
-            _writeInt32Bytes((int) l);
+            CBORByteShiftUtil.setLongBE(_outputBuffer, _outputTail, l);
         }
-    }
-
-    private final void _writeInt32Bytes(int i) {
-        _outputBuffer[_outputTail++] = (byte) (i >> 24);
-        _outputBuffer[_outputTail++] = (byte) (i >> 16);
-        _outputBuffer[_outputTail++] = (byte) (i >> 8);
-        _outputBuffer[_outputTail++] = (byte) i;
+        _outputTail += 8;
     }
 
     private final void _writeLengthMarker(int majorType, int i)

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORParser.java
@@ -3504,10 +3504,7 @@ CBORConstants.MAJOR_TYPE_BYTES, type);
         if (_VARHANDLE_AVAILABLE) {
             return CBORVarHandleUtil.getIntBE(buffer, offset);
         }
-        return ((buffer[offset] & 0xFF) << 24)
-                | ((buffer[offset+1] & 0xFF) << 16)
-                | ((buffer[offset+2] & 0xFF) << 8)
-                | (buffer[offset+3] & 0xFF);
+        return CBORByteShiftUtil.getIntBE(buffer, offset);
     }
 
     /*
@@ -3805,12 +3802,10 @@ expType, type, ch));
         final int v;
         if (_VARHANDLE_AVAILABLE) {
             v = CBORVarHandleUtil.getIntBE(b, ptr);
-            ptr += 4;
         } else {
-            v = (b[ptr++] << 24) + ((b[ptr++] & 0xFF) << 16)
-                    + ((b[ptr++] & 0xFF) << 8) + (b[ptr++] & 0xFF);
+            v = CBORByteShiftUtil.getIntBE(b, ptr);
         }
-        _inputPtr = ptr;
+        _inputPtr = ptr + 4;
         return v;
     }
 
@@ -3839,19 +3834,14 @@ expType, type, ch));
             return _slow64();
         }
         final byte[] b = _inputBuffer;
+        final long l;
         if (_VARHANDLE_AVAILABLE) {
-            // NOTE: identical to `_long()` of the two 32-bit halves below, since
-            // that is just a big-endian 8-byte read spelled out
-            final long l = CBORVarHandleUtil.getLongBE(b, ptr);
-            _inputPtr = ptr + 8;
-            return l;
+            l = CBORVarHandleUtil.getLongBE(b, ptr);
+        } else {
+            l = CBORByteShiftUtil.getLongBE(b, ptr);
         }
-        int i1 = (b[ptr++] << 24) + ((b[ptr++] & 0xFF) << 16)
-                + ((b[ptr++] & 0xFF) << 8) + (b[ptr++] & 0xFF);
-        int i2 = (b[ptr++] << 24) + ((b[ptr++] & 0xFF) << 16)
-                + ((b[ptr++] & 0xFF) << 8) + (b[ptr++] & 0xFF);
-        _inputPtr = ptr;
-        return _long(i1, i2);
+        _inputPtr = ptr + 8;
+        return l;
     }
 
     private final long _slow64() throws JacksonException {

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORParser.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORParser.java
@@ -3502,7 +3502,7 @@ CBORConstants.MAJOR_TYPE_BYTES, type);
      */
     private final static int _decodeQuad(byte[] buffer, int offset) {
         if (_VARHANDLE_AVAILABLE) {
-            return CBORVarHandleUtil.getInt(buffer, offset);
+            return CBORVarHandleUtil.getIntBE(buffer, offset);
         }
         return ((buffer[offset] & 0xFF) << 24)
                 | ((buffer[offset+1] & 0xFF) << 16)
@@ -3804,7 +3804,7 @@ expType, type, ch));
         final byte[] b = _inputBuffer;
         final int v;
         if (_VARHANDLE_AVAILABLE) {
-            v = CBORVarHandleUtil.getInt(b, ptr);
+            v = CBORVarHandleUtil.getIntBE(b, ptr);
             ptr += 4;
         } else {
             v = (b[ptr++] << 24) + ((b[ptr++] & 0xFF) << 16)
@@ -3842,7 +3842,7 @@ expType, type, ch));
         if (_VARHANDLE_AVAILABLE) {
             // NOTE: identical to `_long()` of the two 32-bit halves below, since
             // that is just a big-endian 8-byte read spelled out
-            final long l = CBORVarHandleUtil.getLong(b, ptr);
+            final long l = CBORVarHandleUtil.getLongBE(b, ptr);
             _inputPtr = ptr + 8;
             return l;
         }

--- a/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORVarHandleUtil.java
+++ b/cbor/src/main/java/tools/jackson/dataformat/cbor/CBORVarHandleUtil.java
@@ -55,11 +55,11 @@ final class CBORVarHandleUtil
     // fields. Only called when the corresponding field is non-null, which implies
     // VarHandle is available on this runtime.
 
-    static void setInt(byte[] array, int offset, int value) {
+    static void setIntBE(byte[] array, int offset, int value) {
         INT_BE.set(array, offset, value);
     }
 
-    static void setLong(byte[] array, int offset, long value) {
+    static void setLongBE(byte[] array, int offset, long value) {
         LONG_BE.set(array, offset, value);
     }
 
@@ -69,7 +69,7 @@ final class CBORVarHandleUtil
      *
      * @since 3.3
      */
-    static int getInt(byte[] array, int offset) {
+    static int getIntBE(byte[] array, int offset) {
         return (int) INT_BE.get(array, offset);
     }
 
@@ -79,7 +79,7 @@ final class CBORVarHandleUtil
      *
      * @since 3.3
      */
-    static long getLong(byte[] array, int offset) {
+    static long getLongBE(byte[] array, int offset) {
         return (long) LONG_BE.get(array, offset);
     }
 }

--- a/cbor/src/test/java/tools/jackson/dataformat/cbor/VarHandleFallbackTest.java
+++ b/cbor/src/test/java/tools/jackson/dataformat/cbor/VarHandleFallbackTest.java
@@ -1,0 +1,134 @@
+package tools.jackson.dataformat.cbor;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link CBORByteShiftUtil}, the byte-shifting fallback used on
+ * runtimes where {@link CBORVarHandleUtil} is unusable.
+ *<p>
+ * Needed because {@code CBORParser._VARHANDLE_AVAILABLE} is {@code static final}
+ * and true on every JDK we test on: the fallback branches are constant-folded
+ * away, so parsing and generation tests alone never execute them. Here the
+ * fallback is called directly and checked against {@link ByteBuffer} as an
+ * independent oracle, plus against the VarHandle implementation it stands in for.
+ */
+public class VarHandleFallbackTest extends CBORTestBase
+{
+    private final static int OFFSET = 3; // deliberately unaligned
+
+    @Test
+    public void testGetIntBE() throws Exception
+    {
+        for (byte[] input : _inputs(4)) {
+            final int exp = ByteBuffer.wrap(input, OFFSET, 4)
+                    .order(ByteOrder.BIG_ENDIAN).getInt();
+            assertEquals(exp, CBORByteShiftUtil.getIntBE(input, OFFSET));
+            if (CBORVarHandleUtil.isAvailable()) {
+                assertEquals(exp, CBORVarHandleUtil.getIntBE(input, OFFSET));
+            }
+        }
+    }
+
+    @Test
+    public void testGetLongBE() throws Exception
+    {
+        for (byte[] input : _inputs(8)) {
+            final long exp = ByteBuffer.wrap(input, OFFSET, 8)
+                    .order(ByteOrder.BIG_ENDIAN).getLong();
+            assertEquals(exp, CBORByteShiftUtil.getLongBE(input, OFFSET));
+            if (CBORVarHandleUtil.isAvailable()) {
+                assertEquals(exp, CBORVarHandleUtil.getLongBE(input, OFFSET));
+            }
+        }
+    }
+
+    @Test
+    public void testSetIntBE() throws Exception
+    {
+        for (int value : _intValues()) {
+            byte[] exp = new byte[OFFSET+4];
+            ByteBuffer.wrap(exp, OFFSET, 4).order(ByteOrder.BIG_ENDIAN).putInt(value);
+
+            byte[] act = new byte[OFFSET+4];
+            CBORByteShiftUtil.setIntBE(act, OFFSET, value);
+            assertArrayEquals(exp, act, "for value "+value);
+
+            if (CBORVarHandleUtil.isAvailable()) {
+                byte[] viaHandle = new byte[OFFSET+4];
+                CBORVarHandleUtil.setIntBE(viaHandle, OFFSET, value);
+                assertArrayEquals(exp, viaHandle, "for value "+value);
+            }
+        }
+    }
+
+    @Test
+    public void testSetLongBE() throws Exception
+    {
+        for (long value : _longValues()) {
+            byte[] exp = new byte[OFFSET+8];
+            ByteBuffer.wrap(exp, OFFSET, 8).order(ByteOrder.BIG_ENDIAN).putLong(value);
+
+            byte[] act = new byte[OFFSET+8];
+            CBORByteShiftUtil.setLongBE(act, OFFSET, value);
+            assertArrayEquals(exp, act, "for value "+value);
+
+            if (CBORVarHandleUtil.isAvailable()) {
+                byte[] viaHandle = new byte[OFFSET+8];
+                CBORVarHandleUtil.setLongBE(viaHandle, OFFSET, value);
+                assertArrayEquals(exp, viaHandle, "for value "+value);
+            }
+        }
+    }
+
+    // // // Helper methods for building inputs: sign-bit and all-bits-set cases
+    // // // first, then pseudo-random ones (fixed seed, for reproducibility)
+
+    private byte[][] _inputs(int length) {
+        final int size = OFFSET + length;
+        byte[][] result = new byte[3+100][];
+        result[0] = new byte[size];
+        result[1] = new byte[size];
+        java.util.Arrays.fill(result[1], (byte) 0xFF);
+        result[2] = new byte[size];
+        result[2][OFFSET] = (byte) 0x80; // high bit of first byte only
+        Random rnd = new Random(1234);
+        for (int i = 3; i < result.length; ++i) {
+            byte[] b = new byte[size];
+            rnd.nextBytes(b);
+            result[i] = b;
+        }
+        return result;
+    }
+
+    private int[] _intValues() {
+        int[] result = new int[4+100];
+        result[0] = 0;
+        result[1] = -1;
+        result[2] = Integer.MIN_VALUE;
+        result[3] = Integer.MAX_VALUE;
+        Random rnd = new Random(5678);
+        for (int i = 4; i < result.length; ++i) {
+            result[i] = rnd.nextInt();
+        }
+        return result;
+    }
+
+    private long[] _longValues() {
+        long[] result = new long[4+100];
+        result[0] = 0L;
+        result[1] = -1L;
+        result[2] = Long.MIN_VALUE;
+        result[3] = Long.MAX_VALUE;
+        Random rnd = new Random(9012);
+        for (int i = 4; i < result.length; ++i) {
+            result[i] = rnd.nextLong();
+        }
+        return result;
+    }
+}

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -70,3 +70,6 @@ PJ Fanning (@pjfanning)
 * Contributed #758: (cbor) Use `VarHandle` for multi-byte primitive reads in
   `CBORParser`
  (3.3.0)
+* Contributed #762: (avro) Use `VarHandle` for `float`/`double` reads in Avro
+  parser
+ (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -30,6 +30,8 @@ implementations)
 #759: (smile) Use more efficient `String` construction wrt "Compact Strings"
   for "long" text values
  (fix by @cowtowncoder, w/ Claude code)
+#762: (avro) Use `VarHandle` for `float`/`double` reads in Avro parser
+ (contributed by @pjfanning)
 
 3.2.3 (not yet released)
 

--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileByteShiftUtil.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileByteShiftUtil.java
@@ -1,0 +1,30 @@
+package tools.jackson.dataformat.smile;
+
+/**
+ * Byte-shifting fallback for reading multi-byte primitives out of byte arrays,
+ * used on runtimes where {@link SmileVarHandleUtil} is unusable.
+ *<p>
+ * IMPORTANT: this class must NOT reference {@code java.lang.invoke.VarHandle},
+ * directly or indirectly: it is the fallback for runtimes that lack that type,
+ * and naming it here would make this class fail to link on exactly those
+ * runtimes. Keeping the two implementations in separate classes is what makes
+ * the fallback path safe; see {@link SmileVarHandleUtil} for the full pattern.
+ *
+ * @since 3.3
+ */
+final class SmileByteShiftUtil
+{
+    private SmileByteShiftUtil() { }
+
+    /**
+     * Reads 4 bytes starting at given offset as a big-endian {@code int}.
+     * Caller MUST have verified that {@code offset+4} is within bounds of
+     * given array.
+     */
+    static int getIntBE(byte[] buffer, int offset) {
+        return ((buffer[offset] & 0xFF) << 24)
+                | ((buffer[offset+1] & 0xFF) << 16)
+                | ((buffer[offset+2] & 0xFF) << 8)
+                | (buffer[offset+3] & 0xFF);
+    }
+}

--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileParserBase.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileParserBase.java
@@ -761,10 +761,7 @@ public abstract class SmileParserBase extends ParserMinimalBase
         if (_VARHANDLE_AVAILABLE) {
             return SmileVarHandleUtil.getIntBE(buffer, offset);
         }
-        return ((buffer[offset] & 0xFF) << 24)
-                | ((buffer[offset+1] & 0xFF) << 16)
-                | ((buffer[offset+2] & 0xFF) << 8)
-                | (buffer[offset+3] & 0xFF);
+        return SmileByteShiftUtil.getIntBE(buffer, offset);
     }
 
     /**

--- a/smile/src/test/java/tools/jackson/dataformat/smile/VarHandleFallbackTest.java
+++ b/smile/src/test/java/tools/jackson/dataformat/smile/VarHandleFallbackTest.java
@@ -1,0 +1,57 @@
+package tools.jackson.dataformat.smile;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link SmileByteShiftUtil}, the byte-shifting fallback used on
+ * runtimes where {@link SmileVarHandleUtil} is unusable.
+ *<p>
+ * Needed because {@code SmileParserBase._VARHANDLE_AVAILABLE} is
+ * {@code static final} and true on every JDK we test on: the fallback branch is
+ * constant-folded away, so parsing tests alone never execute it. Here the
+ * fallback is called directly and checked against {@link ByteBuffer} as an
+ * independent oracle, plus against the VarHandle implementation it stands in for.
+ */
+public class VarHandleFallbackTest extends BaseTestForSmile
+{
+    private final static int OFFSET = 3; // deliberately unaligned
+
+    @Test
+    public void testGetIntBE() throws Exception
+    {
+        for (byte[] input : _inputs()) {
+            final int exp = ByteBuffer.wrap(input, OFFSET, 4)
+                    .order(ByteOrder.BIG_ENDIAN).getInt();
+            assertEquals(exp, SmileByteShiftUtil.getIntBE(input, OFFSET));
+            if (SmileVarHandleUtil.isAvailable()) {
+                assertEquals(exp, SmileVarHandleUtil.getIntBE(input, OFFSET));
+            }
+        }
+    }
+
+    // Sign-bit and all-bits-set cases first, then pseudo-random ones
+    // (fixed seed, for reproducibility)
+    private byte[][] _inputs() {
+        final int size = OFFSET + 4;
+        byte[][] result = new byte[3+100][];
+        result[0] = new byte[size];
+        result[1] = new byte[size];
+        Arrays.fill(result[1], (byte) 0xFF);
+        result[2] = new byte[size];
+        result[2][OFFSET] = (byte) 0x80; // high bit of first byte only
+        Random rnd = new Random(1234);
+        for (int i = 3; i < result.length; ++i) {
+            byte[] b = new byte[size];
+            rnd.nextBytes(b);
+            result[i] = b;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
I added a benchmark to https://github.com/pjfanning/jackson-bench

Java 17.0.19
```
Benchmark                                                  Mode  Cnt    Score     Error  Units
AvroDoubleArrayBench.benchParseFromByteArray              thrpt    5  470.442 ±  55.852  ops/s
AvroDoubleArrayBench.benchParseFromByteArraySwar          thrpt    5  570.629 ±  46.614  ops/s
```