### PR TITLE
Optimize async short ASCII string decoding

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -32,6 +32,10 @@ implementations)
  (fix by @cowtowncoder, w/ Claude code)
 #762: (avro) Use `VarHandle` for `float`/`double` reads in Avro parser
  (contributed by @pjfanning)
+#767: (smile) Use more efficient `String` construction wrt "Compact Strings"
+  for "short" ASCII text values of async parser; also fixes decoding of such
+  values that are split across input feeds
+ (fix by @cowtowncoder, w/ Claude code)
 
 3.2.3 (not yet released)
 

--- a/smile/src/main/java/tools/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
@@ -294,7 +294,7 @@ public class NonBlockingByteArrayParser
                 if (avail >= needed) { // got it all
                     System.arraycopy(_inputBuffer, _inputPtr, _inputCopy, _inputCopyLen, needed);
                     _inputPtr += needed;
-                    String text = (_minorState == MINOR_PROPERTY_NAME_SHORT_ASCII)
+                    String text = (_minorState == MINOR_VALUE_STRING_SHORT_ASCII)
                             ? _decodeASCIIText(_inputCopy, 0, fullLen)
                             : _decodeShortUnicodeText(_inputCopy, 0, fullLen);
                     if (_seenStringValueCount >= 0) { // shared String values enabled

--- a/smile/src/main/java/tools/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import tools.jackson.core.JacksonException;
@@ -1583,28 +1584,9 @@ public class NonBlockingByteArrayParser
     private final String _decodeASCIIText(byte[] inBuf, int inPtr, int len) throws JacksonException
     {
         // note: caller ensures we have enough bytes available
-        char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
-        int outPtr = 0;
-
-        // loop unrolling seems to help here:
-        for (int inEnd = inPtr + len - 3; inPtr < inEnd; ) {
-            outBuf[outPtr++] = (char) inBuf[inPtr++];
-            outBuf[outPtr++] = (char) inBuf[inPtr++];
-            outBuf[outPtr++] = (char) inBuf[inPtr++];
-            outBuf[outPtr++] = (char) inBuf[inPtr++];
-        }
-        int left = (len & 3);
-        if (left > 0) {
-            outBuf[outPtr++] = (char) inBuf[inPtr++];
-            if (left > 1) {
-                outBuf[outPtr++] = (char) inBuf[inPtr++];
-                if (left > 2) {
-                    outBuf[outPtr++] = (char) inBuf[inPtr++];
-                }
-            }
-        }
-        _textBuffer.setCurrentLength(len);
-        return _textBuffer.contentsAsString();
+        String str = new String(inBuf, inPtr, len, StandardCharsets.US_ASCII);
+        _textBuffer.resetWithString(str);
+        return str;
     }
 
     /**

--- a/smile/src/test/java/tools/jackson/dataformat/smile/async/SimpleStringArrayTest.java
+++ b/smile/src/test/java/tools/jackson/dataformat/smile/async/SimpleStringArrayTest.java
@@ -58,7 +58,7 @@ public class SimpleStringArrayTest extends AsyncTestBase
     }
 
     @Test
-    public void testShortAsciiStringAccessorsWithContiguousInput() throws IOException
+    public void testShortAsciiStringAccessors() throws IOException
     {
         final int[] lengths = { 1, 2, 3, 4, 31, 32, 33, 63, 64 };
         final String[] input = new String[lengths.length];
@@ -67,7 +67,16 @@ public class SimpleStringArrayTest extends AsyncTestBase
         }
         byte[] data = _stringDoc(_smileWriter(true), input);
 
-        AsyncReaderWrapper r = asyncForBytes(_smileReader(true), data.length + 1, data, 0);
+        // Contiguous input, but also chunked, to cover split-across-feeds decoding
+        _testShortAsciiStringAccessors(input, data, data.length + 1);
+        _testShortAsciiStringAccessors(input, data, 3);
+        _testShortAsciiStringAccessors(input, data, 1);
+    }
+
+    private void _testShortAsciiStringAccessors(String[] input, byte[] data, int readSize)
+        throws IOException
+    {
+        AsyncReaderWrapper r = asyncForBytes(_smileReader(true), readSize, data, 0);
         assertNull(r.currentToken());
         assertToken(JsonToken.START_ARRAY, r.nextToken());
         for (String value : input) {
@@ -84,6 +93,43 @@ public class SimpleStringArrayTest extends AsyncTestBase
         assertToken(JsonToken.END_ARRAY, r.nextToken());
         assertNull(r.nextToken());
         assertTrue(r.isClosed());
+    }
+
+    // [dataformats-binary#767]: short ASCII value split across feeds must decode
+    // the same as one fed contiguously (it used to take the Unicode path instead)
+    @Test
+    public void testShortAsciiValueChunkIndependence() throws IOException
+    {
+        byte[] data = _stringDoc(_smileWriter(true), new String[] { "abcd" });
+        // Corrupt one content byte so ASCII and Unicode decoding disagree
+        int ix = _lastIndexOf(data, (byte) 'b');
+        assertTrue(ix > 0, "Should find content byte to corrupt");
+        data[ix] = (byte) 0xC5;
+
+        String contiguous = _readSingleString(data, data.length + 1);
+        assertEquals(contiguous, _readSingleString(data, 3));
+        assertEquals(contiguous, _readSingleString(data, 1));
+    }
+
+    private String _readSingleString(byte[] data, int readSize) throws IOException
+    {
+        AsyncReaderWrapper r = asyncForBytes(_smileReader(true), readSize, data, 0);
+        assertToken(JsonToken.START_ARRAY, r.nextToken());
+        assertToken(JsonToken.VALUE_STRING, r.nextToken());
+        String text = r.currentText();
+        assertToken(JsonToken.END_ARRAY, r.nextToken());
+        r.close();
+        return text;
+    }
+
+    private int _lastIndexOf(byte[] data, byte b)
+    {
+        for (int i = data.length; --i >= 0; ) {
+            if (data[i] == b) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     @Test

--- a/smile/src/test/java/tools/jackson/dataformat/smile/async/SimpleStringArrayTest.java
+++ b/smile/src/test/java/tools/jackson/dataformat/smile/async/SimpleStringArrayTest.java
@@ -58,6 +58,35 @@ public class SimpleStringArrayTest extends AsyncTestBase
     }
 
     @Test
+    public void testShortAsciiStringAccessorsWithContiguousInput() throws IOException
+    {
+        final int[] lengths = { 1, 2, 3, 4, 31, 32, 33, 63, 64 };
+        final String[] input = new String[lengths.length];
+        for (int i = 0; i < lengths.length; ++i) {
+            input[i] = _ascii(lengths[i]);
+        }
+        byte[] data = _stringDoc(_smileWriter(true), input);
+
+        AsyncReaderWrapper r = asyncForBytes(_smileReader(true), data.length + 1, data, 0);
+        assertNull(r.currentToken());
+        assertToken(JsonToken.START_ARRAY, r.nextToken());
+        for (String value : input) {
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+
+            assertEquals(value, r.currentText());
+            assertEquals(value.length(), r.parser().getStringLength());
+
+            final char[] ch = r.parser().getStringCharacters();
+            final int offset = r.parser().getStringOffset();
+            final int len = r.parser().getStringLength();
+            assertEquals(value, new String(ch, offset, len));
+        }
+        assertToken(JsonToken.END_ARRAY, r.nextToken());
+        assertNull(r.nextToken());
+        assertTrue(r.isClosed());
+    }
+
+    @Test
     public void testShortUnicodeStrings() throws IOException
     {
         final String repeat = "Test: "+UNICODE_2BYTES;
@@ -202,5 +231,14 @@ public class SimpleStringArrayTest extends AsyncTestBase
         g.writeEndArray();
         g.close();
         return bytes.toByteArray();
+    }
+
+    private String _ascii(int len)
+    {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            sb.append((char) ('a' + (i % 26)));
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
## Summary

This PR optimizes contiguous short-ASCII `VALUE_STRING` decoding in the Smile async parser.

`NonBlockingByteArrayParser` previously decoded these values by copying bytes into `TextBuffer`'s char buffer and then materializing a `String`. When the complete short ASCII value is already available in the input buffer, this PR constructs the `String` directly from the input bytes using `StandardCharsets.US_ASCII` and resets the `TextBuffer` with that string.

This mirrors the approach already used by the synchronous Smile parser for the equivalent contiguous short-ASCII path.

## Changes

- Use direct `byte[]` to `String` decoding for contiguous short ASCII values in `NonBlockingByteArrayParser`
- Preserve `TextBuffer` state with `resetWithString(str)`
- Add async parser coverage for short ASCII string accessors with contiguous input

## Benchmark

The benchmark exercises the actual async `NonBlockingByteArrayParser` path on JDK 21.0.7 using JMH 1.37.

Setup:

- 5 forks
- 5 × 1 s warmup
- 8 × 1 s measurement
- 4096 unique ASCII values per invocation
- Complete Smile input supplied in one `ByteArrayFeeder.feedInput()` call
- `CHECK_SHARED_STRING_VALUES` disabled
- Lengths: 8, 32, and 64 (`SmileConstants.MAX_SHORT_VALUE_STRING_BYTES`)
- GC profiler enabled

### `JsonParser.getString()`

| Length | Base ns/value | Candidate ns/value | Reduction | Base B/op | Candidate B/op |
| -----: | ------------: | -----------------: | --------: | --------: | -------------: |
| 8 | 13.661 ± 0.326 | 12.854 ± 0.278 | 5.9% | 48.156 | 48.156 |
| 32 | 17.785 ± 0.580 | 12.630 ± 0.211 | 29.0% | 72.156 | 72.156 |
| 64 | 23.674 ± 0.411 | 13.845 ± 0.374 | 41.5% | 104.156 | 104.156 |

### `JsonParser.getStringCharacters()`

| Length | Base ns/value | Candidate ns/value | Reduction | Base B/op | Candidate B/op |
| -----: | ------------: | -----------------: | --------: | --------: | -------------: |
| 8 | 16.890 ± 0.727 | 14.379 ± 0.153 | 14.9% | 80.156 | 80.156 |
| 32 | 21.764 ± 0.574 | 16.010 ± 0.136 | 26.4% | 152.156 | 152.156 |
| 64 | 29.892 ± 1.058 | 19.436 ± 0.134 | 35.0% | 248.156 | 248.156 |

Normalized allocation was effectively unchanged. The measured improvement therefore appears to come primarily from avoiding the intermediate byte-to-char decoding/copying step rather than from reducing allocation.

## Testing

```bash
./mvnw -pl smile -Dtest=SimpleStringArrayTest -Dsurefire.useModulePath=false test
```