### PR TITLE
Fix async parser decoding of short ASCII values split across input feeds

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Active maintainers:
 
 #761: (smile) Async parser misses #312 NUL-padding: short property name
   collides with NUL-prefixed longer one
+#770: (smile) Async parser decodes short ASCII values split across input feeds
+  as short Unicode
 
 2.21.6 (14-Aug-2026)
 

--- a/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
+++ b/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/async/NonBlockingByteArrayParser.java
@@ -285,7 +285,7 @@ public class NonBlockingByteArrayParser
                 if (avail >= needed) { // got it all
                     System.arraycopy(_inputBuffer, _inputPtr, _inputCopy, _inputCopyLen, needed);
                     _inputPtr += needed;
-                    String text = (_minorState == MINOR_FIELD_NAME_SHORT_ASCII)
+                    String text = (_minorState == MINOR_VALUE_STRING_SHORT_ASCII)
                             ? _decodeASCIIText(_inputCopy, 0, fullLen)
                             : _decodeShortUnicodeText(_inputCopy, 0, fullLen);
                     if (_seenStringValueCount >= 0) { // shared text values enabled

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/async/SimpleStringArrayTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/async/SimpleStringArrayTest.java
@@ -61,6 +61,45 @@ public class SimpleStringArrayTest extends AsyncTestBase
         _testStrings(f, input, data, 1, 1);
     }
 
+    // Short ASCII value split across input feeds must
+    // decode the same as one fed contiguously (used to take the Unicode path instead)
+    @Test
+    public void testShortAsciiValueChunkIndependence() throws IOException
+    {
+        SmileFactory f = new SmileFactory();
+        f.enable(SmileParser.Feature.REQUIRE_HEADER);
+        byte[] data = _stringDoc(f, new String[] { "abcd" });
+        // Corrupt one content byte so that ASCII and Unicode decoding disagree
+        int ix = _lastIndexOf(data, (byte) 'b');
+        assertTrue(ix > 0, "Should find content byte to corrupt");
+        data[ix] = (byte) 0xC5;
+
+        String contiguous = _readSingleString(f, data, data.length + 1);
+        assertEquals(contiguous, _readSingleString(f, data, 3));
+        assertEquals(contiguous, _readSingleString(f, data, 1));
+    }
+
+    private String _readSingleString(SmileFactory f, byte[] data, int readSize) throws IOException
+    {
+        AsyncReaderWrapper r = asyncForBytes(f, readSize, data, 0);
+        assertToken(JsonToken.START_ARRAY, r.nextToken());
+        assertToken(JsonToken.VALUE_STRING, r.nextToken());
+        String text = r.currentText();
+        assertToken(JsonToken.END_ARRAY, r.nextToken());
+        r.close();
+        return text;
+    }
+
+    private int _lastIndexOf(byte[] data, byte b)
+    {
+        for (int i = data.length; --i >= 0; ) {
+            if (data[i] == b) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     @Test
     public void testShortUnicodeStrings() throws IOException
     {

--- a/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/async/SimpleStringArrayTest.java
+++ b/smile/src/test/java/com/fasterxml/jackson/dataformat/smile/async/SimpleStringArrayTest.java
@@ -61,7 +61,7 @@ public class SimpleStringArrayTest extends AsyncTestBase
         _testStrings(f, input, data, 1, 1);
     }
 
-    // Short ASCII value split across input feeds must
+    // [dataformats-binary#770]: short ASCII value split across input feeds must
     // decode the same as one fed contiguously (used to take the Unicode path instead)
     @Test
     public void testShortAsciiValueChunkIndependence() throws IOException


### PR DESCRIPTION
## Problem

In `NonBlockingByteArrayParser._finishToken()`, the `MINOR_VALUE_STRING_SHORT_ASCII` /
`MINOR_VALUE_STRING_SHORT_UNICODE` case picks its decoder with:

```java
String text = (_minorState == MINOR_FIELD_NAME_SHORT_ASCII)
        ? _decodeASCIIText(_inputCopy, 0, fullLen)
        : _decodeShortUnicodeText(_inputCopy, 0, fullLen);
```

`MINOR_FIELD_NAME_SHORT_ASCII` is `5`; the two case labels are `16` and `17`. The
condition can therefore never be true, and short ASCII **values** that span a feed
boundary are always decoded as short Unicode.

For well-formed ASCII content both decoders agree, so this is invisible in normal use.
For content that is not valid ASCII, the same document decodes to different Strings
depending on how the caller chunks the input — a `0xC5` byte inside a short-ASCII token
yields `a�cd` when fed contiguously but `aţd` when fed one byte at a time.

The equivalent check for property names (line 233) tests the right constant and is
left unchanged. These are the only two such comparisons in the async parser; the third
(`MINOR_HEADER_INLINE`, line 396) is reachable and correct. CBOR has no async parser on
2.x, so Smile is the only affected backend.

## Fix

Compare against `MINOR_VALUE_STRING_SHORT_ASCII`.

## Test

`SimpleStringArrayTest.testShortAsciiValueChunkIndependence` writes a short ASCII value,
corrupts one content byte so the two decoders disagree, then asserts that feed sizes of
`length+1`, 3 and 1 all produce the same String. It fails on the unfixed code with
`expected: <a�cd> but was: <aţd>`.

Full smile module suite: 270 tests, 0 failures. CI green on JDK 8/17/21.

## Note for merge-forward

3.x already carries this same one-token fix via #767, so the merge-forward will conflict
on that line at 3.x (either side is fine to take). 3.1 and 3.2 still have the bug and do
need it. The test will also need the 3.x API names (`SmileReadFeature`, no `IOException`)
when it reaches the 3.x side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbhNqemoB4csempvUS9n5z