### PR TITLE
Fix swapped shared-buffer constants in Smile async parser

### DIFF
--- a/smile/src/main/java/tools/jackson/dataformat/smile/async/NonBlockingParserBase.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/async/NonBlockingParserBase.java
@@ -518,7 +518,7 @@ public abstract class NonBlockingParserBase
       	   newShared = oldShared;
       	   _seenNameCount = 0; // could also clear, but let's not yet bother
         } else {
-            int newSize = (len == DEFAULT_STRING_VALUE_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_NAMES;
+            int newSize = (len == DEFAULT_NAME_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_NAMES;
             newShared = new String[newSize];
             System.arraycopy(oldShared, 0, newShared, 0, oldShared.length);
         }
@@ -589,7 +589,7 @@ public abstract class NonBlockingParserBase
            newShared = oldShared;
            _seenStringValueCount = 0; // could also clear, but let's not yet bother
         } else {
-            int newSize = (len == DEFAULT_NAME_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_STRING_VALUES;
+            int newSize = (len == DEFAULT_STRING_VALUE_BUFFER_LENGTH) ? 256 : SmileConstants.MAX_SHARED_STRING_VALUES;
             newShared = new String[newSize];
             System.arraycopy(oldShared, 0, newShared, 0, oldShared.length);
         }


### PR DESCRIPTION
In `NonBlockingParserBase`, the two shared-table growth methods use each other's constant:

- `_expandSeenNames()` compares the current length against `DEFAULT_STRING_VALUE_BUFFER_LENGTH`
- `_expandSeenStringValues()` compares against `DEFAULT_NAME_BUFFER_LENGTH`

Both constants are `64` today, so the growth sequence comes out the same either way and there is **no behavioural change** — this is a latent bug only. But the pairing is wrong, and retuning either constant on its own would silently break the growth steps of the other table.

Same fix as was already applied to the blocking `SmileParser` - #746

Smile module tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)