### PR TITLE
Fix `EnumLookup` hash-area sizing

### DIFF
--- a/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/EnumLookup.java
+++ b/protobuf/src/main/java/tools/jackson/dataformat/protobuf/schema/EnumLookup.java
@@ -293,7 +293,8 @@ public abstract class EnumLookup
             LinkedHashMap<Integer,String> byId = new LinkedHashMap<Integer,String>();
 
             // First: calculate size of primary hash area
-            final int size = findSize(byId.size());
+            // NOTE: must size from `entries`; `byId` is still empty at this point
+            final int size = findSize(entries.size());
             final int mask = size-1;
             // and allocate enough to contain primary/secondary, expand for spillovers as need be
             int alloc = size + (size>>1);
@@ -328,6 +329,10 @@ public abstract class EnumLookup
             }
             return new Big(byId, mask, spills, keys, indices);
         }
+
+        // Accessors for testing of hash area sizing
+        int hashArea() { return _hashMask+1; }
+        int spillCount() { return _spillCount; }
 
         @Override
         public String findEnumByIndex(int index) {

--- a/protobuf/src/test/java/tools/jackson/dataformat/protobuf/schema/EnumLookupTest.java
+++ b/protobuf/src/test/java/tools/jackson/dataformat/protobuf/schema/EnumLookupTest.java
@@ -1,0 +1,54 @@
+package tools.jackson.dataformat.protobuf.schema;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Tests for {@link EnumLookup}, in particular that the "big" variant sizes its
+ * hash area from the actual entry count (it used to always size for 0 entries,
+ * pushing nearly everything into the linear-scan spill area).
+ */
+public class EnumLookupTest
+{
+    @Test
+    public void testBigLookupResolvesAllEntries()
+    {
+        final int count = 100;
+        EnumLookup lookup = EnumLookup.construct(_enumDef(count));
+        for (int i = 0; i < count; ++i) {
+            String name = "VALUE_"+i;
+            assertEquals(i, lookup.findEnumIndex(name), name);
+            assertEquals(name, lookup.findEnumByIndex(i));
+        }
+        assertEquals(-1, lookup.findEnumIndex("NO_SUCH_VALUE"));
+        assertEquals(count, lookup.getEnumValues().size());
+    }
+
+    @Test
+    public void testBigLookupHashAreaSizedFromEntryCount()
+    {
+        final int count = 100;
+        EnumLookup.Big lookup = assertInstanceOf(EnumLookup.Big.class,
+                EnumLookup.construct(_enumDef(count)));
+        // With correct sizing the primary hash area holds 128 slots; the old code
+        // sized for 0 entries (8 primary + 4 secondary slots), so nearly every
+        // entry ended up in the linearly-scanned overflow area.
+        assertEquals(128, lookup.hashArea());
+        if (lookup.spillCount() >= (count / 2)) {
+            throw new AssertionError("Too many spill-over entries: "+lookup.spillCount());
+        }
+    }
+
+    private ProtobufEnum _enumDef(int count) {
+        Map<String,Integer> values = new LinkedHashMap<>();
+        for (int i = 0; i < count; ++i) {
+            values.put("VALUE_"+i, i);
+        }
+        return new ProtobufEnum("BigEnum", values, true);
+    }
+}


### PR DESCRIPTION
Split out of #772.

```java
LinkedHashMap<Integer,String> byId = new LinkedHashMap<Integer,String>();

// First: calculate size of primary hash area
final int size = findSize(byId.size());
```

`byId` is created on the line above and populated in the loop *below*, so this is always `findSize(0)` == 8. Every protobuf enum, regardless of size, got an 8-slot primary + 4-slot secondary hash area. A 100-value enum pushed ~88 entries into the linearly-scanned spill area, and grew the backing arrays 4 slots at a time while building it.

Sizing from `entries` instead gives 128 primary slots and 19 spills for the same enum.

Correctness was never affected — the spill scan finds everything — so this is purely lookup and construction cost, paid on every enum-valued field write.

Pre-dates the 2.x -> 3.x rename and is present on `2.21` too; targeting `3.x` for now, happy to redo against `2.21` and merge forward if you prefer.

### Test

`EnumLookupTest` — a 100-value enum resolves every entry by name and by index, and the primary hash area is 128 slots rather than 8. Needed two package-private accessors (`hashArea()`, `spillCount()`) on `EnumLookup.Big`.

Full `protobuf` module test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
