### PR TITLE
Fix #777: properties following an `@AvroEncode`d value are silently dropped

### DIFF
--- a/avro/src/main/java/tools/jackson/dataformat/avro/apacheimpl/CustomEncodingDeserializer.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/apacheimpl/CustomEncodingDeserializer.java
@@ -6,6 +6,7 @@ import org.apache.avro.reflect.CustomEncoding;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
 import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
@@ -27,23 +28,41 @@ public class CustomEncodingDeserializer<T> extends ValueDeserializer<T> {
 
     @Override
     public T deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
-        AvroParserImpl avroParser = (AvroParserImpl) p;
-        DecoderOverAvroParser decoder = new DecoderOverAvroParser(avroParser);
-        try {
-            return encoding.read(null, decoder);
-        } catch (IOException e) {
-            throw JacksonIOException.construct(e);
-        }
+        return _read(p, null);
     }
 
     @Override
     public T deserialize(JsonParser p, DeserializationContext ctxt, T intoValue) throws JacksonException {
-        AvroParserImpl avroParser = (AvroParserImpl) p;
-        DecoderOverAvroParser decoder = new DecoderOverAvroParser(avroParser);
+        return _read(p, intoValue);
+    }
+
+    private T _read(JsonParser p, T reuse) throws JacksonException
+    {
+        final AvroParserImpl avroParser = (AvroParserImpl) p;
+        // `CustomEncoding` reads scalar leaves straight off the `Decoder`, and
+        // `DecoderOverAvroParser` swallows the structural tokens it steps over on the
+        // way. For a structured value that leaves the stream parked *inside* the value
+        // once the last leaf is read, with its closing token(s) still pending; the
+        // enclosing deserializer would then read our END_OBJECT as its own and stop
+        // early, silently dropping every property after this one. So remember how deep
+        // we started, and unwind back to the matching close token afterwards.
+        final JsonToken start = p.currentToken();
+        final boolean structured = (start == JsonToken.START_OBJECT) || (start == JsonToken.START_ARRAY);
+        final int startDepth = structured ? avroParser.getAvroContextDepth() : 0;
+
+        final T value;
         try {
-            return encoding.read(intoValue, decoder);
+            value = encoding.read(reuse, new DecoderOverAvroParser(avroParser));
         } catch (IOException e) {
             throw JacksonIOException.construct(e);
         }
+        if (structured) {
+            while (avroParser.getAvroContextDepth() >= startDepth) {
+                if (p.nextToken() == null) { // truncated content; let caller report it
+                    break;
+                }
+            }
+        }
+        return value;
     }
 }

--- a/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
+++ b/avro/src/main/java/tools/jackson/dataformat/avro/deser/AvroParserImpl.java
@@ -680,6 +680,16 @@ public abstract class AvroParserImpl
         return _avroContext instanceof RecordReader;
     }
 
+    /**
+     * Accessor for the nesting depth of the currently active Avro read context;
+     * needed by callers that hand the parser off to Avro's own {@code Decoder}
+     * API (see {@code CustomEncodingDeserializer}) and afterwards have to tell
+     * how far back up the structure the stream must be unwound.
+     */
+    public final int getAvroContextDepth() {
+        return _avroContext.getNestingDepth();
+    }
+
     public final void setAvroContext(AvroReadContext ctxt) {
         _avroContext = ctxt;
     }

--- a/avro/src/test/java/tools/jackson/dataformat/avro/CustomEncodingTrailingPropertyTest.java
+++ b/avro/src/test/java/tools/jackson/dataformat/avro/CustomEncodingTrailingPropertyTest.java
@@ -1,0 +1,282 @@
+package tools.jackson.dataformat.avro;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.reflect.AvroEncode;
+import org.apache.avro.reflect.CustomEncoding;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test for [dataformats-binary#777]: properties following an {@code @AvroEncode}d
+ * value (record, array or map) were silently dropped, because the custom decoding left
+ * the parser positioned inside the encoded value instead of on its closing token.
+ */
+public class CustomEncodingTrailingPropertyTest extends AvroTestBase
+{
+    static class Component {
+        public int first;
+        public int second;
+
+        protected Component() { }
+        public Component(int f, int s) { first = f; second = s; }
+    }
+
+    static class NestingComponent {
+        public int outerValue;
+        public Component inner;
+
+        protected NestingComponent() { }
+        public NestingComponent(int o, Component i) { outerValue = o; inner = i; }
+    }
+
+    // NOTE: encodings deliberately read/write via the raw `Encoder` / `Decoder` API
+    // rather than `ReflectData`, so the test does not depend on Avro's class allow-list.
+    static final Schema COMPONENT_SCHEMA = SchemaBuilder.record("Component")
+            .fields()
+            .requiredInt("first")
+            .requiredInt("second")
+            .endRecord();
+
+    static final Schema NESTING_SCHEMA = SchemaBuilder.record("NestingComponent")
+            .fields()
+            .requiredInt("outerValue")
+            .name("inner").type(COMPONENT_SCHEMA).noDefault()
+            .endRecord();
+
+    public static class ComponentEncoding extends CustomEncoding<Component> {
+        public ComponentEncoding() {
+            schema = COMPONENT_SCHEMA;
+        }
+
+        @Override
+        protected void write(Object datum, Encoder out) throws IOException {
+            Component c = (Component) datum;
+            out.writeInt(c.first);
+            out.writeInt(c.second);
+        }
+
+        @Override
+        protected Component read(Object reuse, Decoder in) throws IOException {
+            return new Component(in.readInt(), in.readInt());
+        }
+    }
+
+    public static class NestingEncoding extends CustomEncoding<NestingComponent> {
+        public NestingEncoding() {
+            schema = NESTING_SCHEMA;
+        }
+
+        @Override
+        protected void write(Object datum, Encoder out) throws IOException {
+            NestingComponent c = (NestingComponent) datum;
+            out.writeInt(c.outerValue);
+            out.writeInt(c.inner.first);
+            out.writeInt(c.inner.second);
+        }
+
+        @Override
+        protected NestingComponent read(Object reuse, Decoder in) throws IOException {
+            return new NestingComponent(in.readInt(),
+                    new Component(in.readInt(), in.readInt()));
+        }
+    }
+
+    static final Schema INT_ARRAY_SCHEMA = SchemaBuilder.array().items().intType();
+
+    static final Schema INT_MAP_SCHEMA = SchemaBuilder.map().values().intType();
+
+    public static class IntListEncoding extends CustomEncoding<List<Integer>> {
+        public IntListEncoding() {
+            schema = INT_ARRAY_SCHEMA;
+        }
+
+        @Override
+        protected void write(Object datum, Encoder out) throws IOException {
+            @SuppressWarnings("unchecked")
+            List<Integer> list = (List<Integer>) datum;
+            out.writeArrayStart();
+            out.setItemCount(list.size());
+            for (Integer value : list) {
+                out.startItem();
+                out.writeInt(value);
+            }
+            out.writeArrayEnd();
+        }
+
+        @Override
+        protected List<Integer> read(Object reuse, Decoder in) throws IOException {
+            List<Integer> list = new ArrayList<>();
+            for (long n = in.readArrayStart(); n > 0; n = in.arrayNext()) {
+                for (long i = 0; i < n; ++i) {
+                    list.add(in.readInt());
+                }
+            }
+            return list;
+        }
+    }
+
+    public static class IntMapEncoding extends CustomEncoding<Map<String, Integer>> {
+        public IntMapEncoding() {
+            schema = INT_MAP_SCHEMA;
+        }
+
+        @Override
+        protected void write(Object datum, Encoder out) throws IOException {
+            @SuppressWarnings("unchecked")
+            Map<String, Integer> map = (Map<String, Integer>) datum;
+            out.writeMapStart();
+            out.setItemCount(map.size());
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                out.startItem();
+                out.writeString(entry.getKey());
+                out.writeInt(entry.getValue());
+            }
+            out.writeMapEnd();
+        }
+
+        @Override
+        protected Map<String, Integer> read(Object reuse, Decoder in) throws IOException {
+            Map<String, Integer> map = new LinkedHashMap<>();
+            for (long n = in.readMapStart(); n > 0; n = in.mapNext()) {
+                for (long i = 0; i < n; ++i) {
+                    map.put(in.readString(), in.readInt());
+                }
+            }
+            return map;
+        }
+    }
+
+    // NOTE: property names chosen so that the encoded one sorts FIRST; trailing
+    // properties are the ones that used to get dropped.
+    static class Wrapper {
+        @AvroEncode(using = ComponentEncoding.class)
+        public Component component;
+
+        public int trailingInt;
+        public String trailingText;
+
+        protected Wrapper() { }
+        public Wrapper(Component c, int i, String t) {
+            component = c;
+            trailingInt = i;
+            trailingText = t;
+        }
+    }
+
+    static class NestingWrapper {
+        @AvroEncode(using = NestingEncoding.class)
+        public NestingComponent component;
+
+        public int trailingInt;
+
+        protected NestingWrapper() { }
+        public NestingWrapper(NestingComponent c, int i) {
+            component = c;
+            trailingInt = i;
+        }
+    }
+
+    static class ArrayWrapper {
+        @AvroEncode(using = IntListEncoding.class)
+        public List<Integer> values;
+
+        public int trailingInt;
+        public String trailingText;
+
+        protected ArrayWrapper() { }
+        public ArrayWrapper(List<Integer> v, int i, String t) {
+            values = v;
+            trailingInt = i;
+            trailingText = t;
+        }
+    }
+
+    static class MapWrapper {
+        @AvroEncode(using = IntMapEncoding.class)
+        public Map<String, Integer> values;
+
+        public int trailingInt;
+
+        protected MapWrapper() { }
+        public MapWrapper(Map<String, Integer> v, int i) {
+            values = v;
+            trailingInt = i;
+        }
+    }
+
+    private final AvroMapper MAPPER = newMapper();
+
+    @Test
+    public void testPropertiesAfterCustomEncodedRecord() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFor(Wrapper.class);
+        Wrapper input = new Wrapper(new Component(13, 42), 3456, "trailing!");
+
+        byte[] encoded = MAPPER.writer(schema).writeValueAsBytes(input);
+        Wrapper result = MAPPER.readerFor(Wrapper.class).with(schema).readValue(encoded);
+
+        assertNotNull(result.component);
+        assertEquals(13, result.component.first);
+        assertEquals(42, result.component.second);
+        // these two used to come back as 0 / null
+        assertEquals(3456, result.trailingInt);
+        assertEquals("trailing!", result.trailingText);
+    }
+
+    @Test
+    public void testPropertiesAfterNestedCustomEncodedRecord() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFor(NestingWrapper.class);
+        NestingWrapper input = new NestingWrapper(
+                new NestingComponent(7, new Component(13, 42)), 3456);
+
+        byte[] encoded = MAPPER.writer(schema).writeValueAsBytes(input);
+        NestingWrapper result = MAPPER.readerFor(NestingWrapper.class).with(schema).readValue(encoded);
+
+        assertNotNull(result.component);
+        assertEquals(7, result.component.outerValue);
+        assertNotNull(result.component.inner);
+        assertEquals(13, result.component.inner.first);
+        assertEquals(42, result.component.inner.second);
+        // unwinding has to pop TWO record levels here
+        assertEquals(3456, result.trailingInt);
+    }
+
+    @Test
+    public void testPropertiesAfterCustomEncodedArray() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFor(ArrayWrapper.class);
+        ArrayWrapper input = new ArrayWrapper(Arrays.asList(1, 2, 3), 3456, "trailing!");
+
+        byte[] encoded = MAPPER.writer(schema).writeValueAsBytes(input);
+        ArrayWrapper result = MAPPER.readerFor(ArrayWrapper.class).with(schema).readValue(encoded);
+
+        assertEquals(Arrays.asList(1, 2, 3), result.values);
+        assertEquals(3456, result.trailingInt);
+        assertEquals("trailing!", result.trailingText);
+    }
+
+    @Test
+    public void testPropertiesAfterCustomEncodedMap() throws Exception
+    {
+        AvroSchema schema = MAPPER.schemaFor(MapWrapper.class);
+        Map<String, Integer> values = new LinkedHashMap<>();
+        values.put("a", 1);
+        values.put("b", 2);
+
+        byte[] encoded = MAPPER.writer(schema).writeValueAsBytes(new MapWrapper(values, 3456));
+        MapWrapper result = MAPPER.readerFor(MapWrapper.class).with(schema).readValue(encoded);
+
+        assertEquals(values, result.values);
+        assertEquals(3456, result.trailingInt);
+    }
+}

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -38,6 +38,8 @@ implementations)
 #767: (smile) Use more efficient `String` construction wrt "Compact Strings"
   for "short" ASCII text values of async parser
  (fix by @cowtowncoder, w/ Claude code)
+#777: (avro) Properties following an `@AvroEncode`d value are silently dropped
+ (fix by @cowtowncoder, w/ Claude code)
 
 3.2.3 (not yet released)
 


### PR DESCRIPTION
Fixes #777.

## Problem

`AvroAnnotationIntrospector` installs a `CustomEncodingDeserializer` for `@AvroEncode`d accessors, which hands the parser to Avro's `CustomEncoding.read(...)` through `DecoderOverAvroParser`. That decoder swallows the virtual structural tokens it steps over while hunting for scalar leaves, so once the last leaf is read the stream is parked *inside* the encoded value with its closing token(s) still pending.

The enclosing deserializer then calls `nextToken()`, gets the encoded value's `END_OBJECT`, and reads it as its own end — stopping early and leaving every following property at its default.

Because `FAIL_ON_TRAILING_TOKENS` is enabled by default in Jackson 3 this now surfaces as a `MismatchedInputException`. With the feature off (and on the 2.x line) the read "succeeds" and quietly returns truncated objects, which is the more dangerous shape.

## Fix

Record the Avro read-context depth on entry and unwind to the matching close token after the custom encoding is done:

```java
final boolean structured = (start == JsonToken.START_OBJECT) || (start == JsonToken.START_ARRAY);
final int startDepth = structured ? avroParser.getAvroContextDepth() : 0;
...
if (structured) {
    while (avroParser.getAvroContextDepth() >= startDepth) {
        if (p.nextToken() == null) { break; }   // truncated content; let caller report it
    }
}
```

The depth check comes *before* `nextToken()`, so an encoding that already consumed its own close token causes no over-consumption. Scalar encodings (e.g. UUID-as-bytes over a `["null","bytes"]` union) take the `structured == false` path and are untouched — they were already positioned correctly.

Also adds `AvroParserImpl.getAvroContextDepth()`. This is needed because `JsonParser.streamReadContext()` on the Avro parser returns a flat `SimpleStreamReadContext` reporting depth 0 for every token; only the internal `AvroReadContext` chain tracks real nesting. It sits beside the existing public `isRecord()` / `setAvroContext()`.

## Tests

`CustomEncodingTrailingPropertyTest` covers all three structured shapes plus a nested level. All four fail on `3.x` without the fix:

| Case | Without fix |
|---|---|
| record, 1 level | trailing `PROPERTY_NAME` |
| nested record, 2 levels | trailing `END_OBJECT` |
| array | `Cannot deserialize ArrayWrapper from Array value (token START_ARRAY)` |
| map | trailing `END_OBJECT` |

The encodings deliberately use the raw `Encoder`/`Decoder` API rather than `ReflectData`, so the test does not depend on Avro's class allow-list.

## Performance

No code here is reached unless `@AvroEncode` is used. For scalar encodings the addition is one `currentToken()` read and two comparisons (the ternary short-circuits the depth call). For structured ones the unwind is bounded by schema nesting depth, not data size — measured 1 iteration for a flat record/array/map, and 1 for every one of the 32 reads in the existing `AvroEncodeTest`, whose `CustomComponent` has 9 fields including a nested record and a map of arrays. The loop decodes no payload bytes; it only pops contexts.

## Verification

Full `avro` module on this branch: `Tests run: 1498, Failures: 0, Errors: 116` — the 4 new tests pass and the error count is unchanged from unmodified `3.x` (1494/116).

Note those 116 pre-existing errors are the Avro 1.12.1 `ReflectData` recursion regression (`StackOverflowError`) plus older interop gaps; they're unrelated to this change and are addressed separately by the Avro 1.12.2 upgrade. On that branch, with both changes in place, `AvroEncodeTest` goes fully green (64/64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFZddVuRUhTeamPoKE7TUU
