### PR TITLE
Use configured `StreamReadConstraints` in `SmileGenerator.writeNumber(String)`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -76,3 +76,6 @@ PJ Fanning (@pjfanning)
 * Contributed #763: (protobuf) Use `VarHandle` for multi-byte primitive reads
   and writes in `ProtobufParser` / `ProtobufGenerator`
  (3.3.0)
+* Contributed #781: (smile) `SmileGenerator.writeNumber(String)` should validate
+  number length against configured `StreamReadConstraints`, not global defaults
+ (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -38,6 +38,9 @@ implementations)
 #767: (smile) Use more efficient `String` construction wrt "Compact Strings"
   for "short" ASCII text values of async parser
  (fix by @cowtowncoder, w/ Claude code)
+#781: (smile) `SmileGenerator.writeNumber(String)` should validate number length
+  against configured `StreamReadConstraints`, not global defaults
+ (contributed by @pjfanning)
 
 3.2.3 (not yet released)
 

--- a/smile/src/main/java/tools/jackson/dataformat/smile/SmileGenerator.java
+++ b/smile/src/main/java/tools/jackson/dataformat/smile/SmileGenerator.java
@@ -2761,12 +2761,10 @@ surr1, surr2));
 
     /**
      * We need access to some reader-side constraints for safety-check within
-     * number decoding for {@linl #writeNumber(String)}: for now we need to
-     * rely on global defaults; should be ok for basic safeguarding.
-     *
-     * @since 2.17
+     * number decoding for {@link #writeNumber(String)}: these are the ones
+     * configured for the underlying factory, accessed via {@link IOContext}.
      */
     protected StreamReadConstraints _streamReadConstraints() {
-        return StreamReadConstraints.defaults();
+        return _ioContext.streamReadConstraints();
     }
 }

--- a/smile/src/test/java/tools/jackson/dataformat/smile/gen/SmileGeneratorNumbersTest.java
+++ b/smile/src/test/java/tools/jackson/dataformat/smile/gen/SmileGeneratorNumbersTest.java
@@ -1,14 +1,21 @@
 package tools.jackson.dataformat.smile.gen;
 
 import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
 
 import tools.jackson.dataformat.smile.*;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SmileGeneratorNumbersTest
     extends BaseTestForSmile
@@ -201,6 +208,42 @@ public class SmileGeneratorNumbersTest
         gen.writeNumber("-50.00000000125");
         gen.close();
         assertEquals(10, out.toByteArray().length);
+    }
+
+    // [dataformats-binary#781]: `writeNumber(String)` should use the factory's
+    // `StreamReadConstraints` for its number-length guard, not global defaults
+    @Test
+    public void testNumbersAsStringLengthLimit() throws Exception
+    {
+        final int maxLen = 20;
+        SmileFactory f = smileFactoryBuilder(false, false, false)
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNumberLength(maxLen).build())
+                .build();
+        final String tooLongInt = "1".repeat(maxLen + 1);
+        final String tooLongDec = "1." + "1".repeat(maxLen - 1);
+
+        for (String num : new String[] { tooLongInt, tooLongDec }) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (SmileGenerator gen = (SmileGenerator) f.createGenerator(out)) {
+                gen.writeNumber(num);
+                fail("Should not pass for: "+num);
+            } catch (StreamConstraintsException e) {
+                verifyException(e, "Number value length (" + (maxLen + 1)
+                        + ") exceeds the maximum allowed (" + maxLen + ",");
+            }
+        }
+
+        // And conversely, one at the limit is fine
+        final String atLimit = "1".repeat(maxLen);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (SmileGenerator gen = (SmileGenerator) f.createGenerator(out)) {
+            gen.writeNumber(atLimit);
+        }
+        try (JsonParser p = f.createParser(out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(new BigInteger(atLimit), p.getBigIntegerValue());
+        }
     }
 
     // [dataformats-binary#608]


### PR DESCRIPTION
Fixes #781.

`SmileGenerator._streamReadConstraints()` — used by `_writeIntegralNumber()` / `_writeDecimalNumber()` to guard `writeNumber(String)` against over-long number Strings — returned `StreamReadConstraints.defaults()`, so a `maxNumberLength` configured on the `SmileFactory` was ignored on the write path (lower limits not enforced, higher limits spuriously rejected).

Now returns `_ioContext.streamReadConstraints()`, i.e. the factory's configured instance.

Adds `SmileGeneratorNumbersTest.testNumbersAsStringLengthLimit` covering both the integral and decimal paths, plus a round-trip at the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)